### PR TITLE
add sme generation prompt

### DIFF
--- a/tools/prediction_request.py
+++ b/tools/prediction_request.py
@@ -22,6 +22,7 @@
 import json
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Dict, Generator, List, Optional, Tuple
+from dataclasses import dataclass
 
 import openai
 import requests
@@ -111,6 +112,10 @@ OUTPUT_FORMAT
 * Output only the JSON object. Do not include any other contents in your response.
 """
 
+@dataclass
+class SMERolePrompt:
+    sme: str
+    sme_introduction: str
 
 def search_google(query: str, api_key: str, engine: str, num: int = 3) -> List[str]:
     service = build("customsearch", "v1", developerKey=api_key)
@@ -233,6 +238,9 @@ def run(**kwargs) -> Tuple[str, Optional[Dict[str, Any]]]:
     """Run the task"""
     tool = kwargs["tool"]
     prompt = kwargs["prompt"]
+    # this is optional
+    if kwargs.get("sme_role_system_prompt"):
+        sme_role_system_prompt: SMERolePrompt = SMERolePrompt(**kwargs["sme_role_system_prompt"])
     max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
     temperature = kwargs.get("temperature", DEFAULT_OPENAI_SETTINGS["temperature"])
 
@@ -259,10 +267,17 @@ def run(**kwargs) -> Tuple[str, Optional[Dict[str, Any]]]:
     moderation_result = openai.Moderation.create(prediction_prompt)
     if moderation_result["results"][0]["flagged"]:
         return "Moderation flagged the prompt as in violation of terms.", None
-    messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": prediction_prompt},
-    ]
+    if sme_role_system_prompt:
+        print(f"You are using SME: {sme_role_system_prompt.sme}")
+        messages = [
+            {"role": "system", "content": sme_role_system_prompt.sme_introduction},
+            {"role": "user", "content": prediction_prompt},
+        ]
+    else:
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prediction_prompt},
+        ]
     response = openai.ChatCompletion.create(
         model=engine,
         messages=messages,

--- a/tools/sme_generation_request.py
+++ b/tools/sme_generation_request.py
@@ -1,0 +1,105 @@
+"""This module implements a Mech tool to generate Subject Matter Expert (SME) roles for a given market question"""
+import json
+from typing import Any, Dict, Generator, List, Optional, Tuple
+
+import openai
+
+DEFAULT_OPENAI_SETTINGS = {
+    "max_tokens": 500,
+    "temperature": 0,
+}
+
+ALLOWED_TOOLS = [
+    "strong-sme-generator",
+    "normal-sme-generator",
+]
+
+TOOL_TO_ENGINE = {
+    "strong-sme-generator": "gpt-4",
+    "normal-sme-generator": "gpt-3.5-turbo",
+}
+
+SME_GENERATION_SYSTEM_PROMPT = """
+This task requires answering Yes or No to a specific question related to certain knowledge domains. The final opinion to the question should be determined by one or more subject matter experts (SME) of the related domains. You need to generate one or more SME roles and their role introduction that you believe to be helpful in forming a correct answer to question in the task.
+
+Examples:
+task question: "Will Apple release iphone 15 by 1 October 2023?"
+[
+        {
+            "sme": "Technology Analyst",
+            "sme_introduction": "You are a seasoned technology analyst AI assistant. Your goal is to do comprehensive research on the news on the tech companies and answer investor's interested questions in a trustful and accurate way."
+        }
+]
+---
+task question: "Will the newly elected ceremonial president of Singapore face any political scandals by 13 September 2023?"
+[
+        { 
+            "sme":  "Political Commentator",
+            "sme_introduction": "You are an experienced political commentator in Asia. Your main objective is to produce comprehensive, insightful and impartial analysis based on the relevant political news and your politic expertise to form an answer to the question releted to a political event or politician."
+        }
+]
+---
+task question: "Will the air strike conflict in Sudan be resolved by 13 September 2023?"
+[
+       {
+            "sme:  "Military Expert",
+            "sme_introduction": "You are an experienced expert in military operation and industry. Your main goal is to faithfully and accurately answer a military related question based on the provided intelligence and your professional experience"
+        },
+       {
+            "sme:  "Diplomat",
+            "sme_introduction": "You are an senior deplomat who engages in diplomacy to foster peaceful relations, negotiate agreements, and navigate complex political, economic, and social landscapes. You need to form an opinion on a question related to international conflicts based on the related information and your understading in geopolitics."
+        },
+]
+"""
+
+SME_GENERATION_MARKET_PROMPT = """
+task question: "{question}"
+"""
+
+def run(**kwargs) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Generate SME roles for a given market question
+
+    Raises:
+        ValueError: _description_
+
+    Returns:
+        Tuple[str, Optional[Dict[str, Any]]]: str is the generated SME roles, it can be loaded with `json.loads` 
+        to get a list of dict. The dict has two keys: "sme" and "sme_introduction". 
+        The value of "sme" is the SME role name, and the value of "sme_introduction" is the introduction of the SME role.
+    """
+    tool = kwargs["tool"]
+    # prompt is the actual question
+    prompt = kwargs["prompt"]
+    max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
+    temperature = kwargs.get("temperature", DEFAULT_OPENAI_SETTINGS["temperature"])
+
+    if tool not in ALLOWED_TOOLS:
+        raise ValueError(f"tool must be one of {ALLOWED_TOOLS}")
+    
+    engine = TOOL_TO_ENGINE[tool]
+
+    market_question = SME_GENERATION_MARKET_PROMPT.format(question=prompt)
+    system_prompt = SME_GENERATION_SYSTEM_PROMPT
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": market_question},
+    ]
+    response = openai.ChatCompletion.create(
+        model=engine,
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        n=1,
+        timeout=150,
+        request_timeout=150,
+        stop=None,
+    )
+
+    generated_sme_roles = response.choices[0].message.content
+    # check whether the generated_sme_roles is valid json
+    try:
+        generated_sme_roles = json.loads(generated_sme_roles)
+    except json.decoder.JSONDecodeError as e:
+        return f"Failed to generate SME roles due to {e}", None
+    return response.choices[0].message.content, None


### PR DESCRIPTION
# Pull Request
## Description
This pull request introduces a Mech tool to establish Subject Matter Expert (SME) roles for specific market-related questions. The resulting SME introduction can serve as a system prompt to guide downstream language models (LLMs) in answering those questions.

Currently, AI Mech works primarily with proprietary LLMs like GPT-3.5 and GPT-4 due to their strong generalization abilities. However, this tool has the potential to integrate other specialized domain LLMs for decision-making in specific areas. For instance, we can fine-tune an open-source LLM with content related to blockchain and quantitative finance to enhance its expertise in blockchain investment and probability estimation. This enables us to address questions like, "Will Tether cause a crypto market collapse by the end of 2024?" We can also manage risk preferences for these fine-tuned roles in line with our investment strategy.

Furthermore, the trading community can collaborate to develop a set of domain-specific LLMs to address a wide array of questions and contribute additional tools that can leverage the capabilities of these domain-specific LLMs within the Mech ecosystem.

## Flow Diagram
![flow_flock](https://github.com/valory-xyz/mech/assets/52875892/9fe59998-3034-4c03-b508-0365b5dcb457)

## Changes
- [x] Add a new tool to create SME roles for a given market conditional question
- [x] Allow user to specify the `sme_role_system_prompt` in the `mech/tools/prediction_request.py`

## Additional Notes
* Author: Yizhe Wen (yizhe@flock.io)
* Contributed by [FLock.io](https://flock.io/). We bring large model fine-tuning to Web 3.