### PR TITLE
fix: don't add markdown to url prompts

### DIFF
--- a/tools/optimization_by_prompting/optimization_by_prompting.py
+++ b/tools/optimization_by_prompting/optimization_by_prompting.py
@@ -154,7 +154,10 @@ OUTPUT_FORMAT
    - "queries": An array of strings of size between 1 and 5. Each string must be a search engine query that can help obtain relevant information to estimate
      the probability that the event in "USER_PROMPT" occurs. You must provide original information in each query, and they should not overlap
      or lead to obtain the same set of results.
-* Output only the JSON object. Do not include any other contents in your response.
+* Output only the JSON object. Do not include any other contents in your response
+* This is incorrect: "```json{{"queries": []}}```"
+* This is incorrect: "```json"{{"queries": []}}"```"
+* This is correct: "{{"queries": []}}".
 """
 
 TEMPLATE_INSTRUCTOR = """You are an advanced reasoning agent that suggest to a bot ways to predict world events very accurately.

--- a/tools/prediction_request/prediction_request.py
+++ b/tools/prediction_request/prediction_request.py
@@ -129,6 +129,9 @@ OUTPUT_FORMAT
      0 indicates lowest utility; 1 maximum utility.
 * The sum of "p_yes" and "p_no" must equal 1.
 * Output only the JSON object. Do not include any other contents in your response.
+* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
+* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
+* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
 """
 
 URL_QUERY_PROMPT = """
@@ -157,9 +160,9 @@ OUTPUT_FORMAT
      or lead to obtain the same set of results.
 * Output only the JSON object. Do not include any other contents in your response.
 * Never use Markdown syntax highlighting, such as ```json``` to surround the output. Only output the raw json string.
-* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
-* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
-* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+* This is incorrect: "```json{{"queries": []}}```"
+* This is incorrect: "```json"{{"queries": []}}"```"
+* This is correct: "{{"queries": []}}"
 """
 
 

--- a/tools/prediction_request_embedding/prediction_sentence_embedding.py
+++ b/tools/prediction_request_embedding/prediction_sentence_embedding.py
@@ -174,6 +174,9 @@ OUTPUT_FORMAT:
 * The JSON must contain two fields: "queries", and "urls".
    - "queries": A 1-5 item array of the generated search engine queries.
 * Include only the JSON object in your output.
+* This is incorrect: "```json{{"queries": []}}```"
+* This is incorrect: "```json"{{"queries": []}}"```"
+* This is correct: "{{"queries": []}}"
 """
 
 # Global constants for possible attribute names for release and update dates

--- a/tools/prediction_request_sme/prediction_request_sme.py
+++ b/tools/prediction_request_sme/prediction_request_sme.py
@@ -144,6 +144,9 @@ OUTPUT_FORMAT
      the probability that the event in "USER_PROMPT" occurs. You must provide original information in each query, and they should not overlap
      or lead to obtain the same set of results.
 * Output only the JSON object. Do not include any other contents in your response.
+* This is incorrect: "```json{{"queries": []}}```"
+* This is incorrect: "```json"{{"queries": []}}"```"
+* This is correct: "{{"queries": []}}"
 """
 
 SME_GENERATION_MARKET_PROMPT = """

--- a/tools/prediction_sum_url_content/prediction_sum_url_content.py
+++ b/tools/prediction_sum_url_content/prediction_sum_url_content.py
@@ -162,6 +162,9 @@ OUTPUT_FORMAT:
 * The JSON must contain two fields: "queries", and "urls".
    - "queries": A 1-5 item array of the generated search engine queries.
 * Include only the JSON object in your output.
+* This is incorrect: "```json{{"queries": []}}```"
+* This is incorrect: "```json"{{"queries": []}}"```"
+* This is correct: "{{"queries": []}}"
 """
 
 # Global constants for possible attribute names for release and update dates


### PR DESCRIPTION
This PR adjusts the prompt to not include json markdown for url prompts.