### PR TITLE
Remove filter and use filterParams

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,20 +2,20 @@
     "dev": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",
         "protocol/valory/websocket_client/0.1.0": "bafybeifjk254sy65rna2k32kynzenutujwqndap2r222afvr3zezi27mx4",
-        "contract/valory/agent_mech/0.1.0": "bafybeigs3jle7n57sqwdnwi2egfia6ingt7wxhzykft7ssasjj26ig32xi",
+        "contract/valory/agent_mech/0.1.0": "bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm",
         "contract/valory/agent_registry/0.1.0": "bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq",
         "contract/valory/hash_checkpoint/0.1.0": "bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da",
-        "contract/valory/mech_marketplace/0.1.0": "bafybeic7xtjx7a6i2h6apxjaupezqsxlhidsnvnasv6ms3rlekn7vorkgi",
+        "contract/valory/mech_marketplace/0.1.0": "bafybeicsfg2kc2m4ffhrjkxxylq5pstl2tdevxzgwp45u6n7465tennet4",
         "contract/valory/balance_tracker/0.1.0": "bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4",
         "connection/valory/websocket_client/0.1.0": "bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli",
         "skill/valory/contract_subscription/0.1.0": "bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy",
-        "skill/valory/mech_abci/0.1.0": "bafybeid5aimttywh3dycslgzjgn5sf3q4wxhw4ygejl53gocjc5ufnfhlu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifwqqfhlpnrzyu4u4jzdnaecdnkphshv7zqz6mtua77frj6clrmbq",
-        "skill/valory/task_execution/0.1.0": "bafybeiegmmap2vsoqwcjic746gxfypwah533tk6wjd6lpyt4bo2uxyu3hm",
+        "skill/valory/mech_abci/0.1.0": "bafybeihcyo7w7dq2kgftrqxuaaadntr6mpsi6tddgmxuc34zhppfeggmee",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibxfn6yqdpc36jxv7ht45tpu26rtzq72nywej2o3ybivx7lx7fprq",
+        "skill/valory/task_execution/0.1.0": "bafybeicknvidmx5v3rhc5yee6dptzrskvxlhyhqyne6r5gqv4nclwanltq",
         "skill/valory/websocket_client/0.1.0": "bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifa2gmumovmta3tkjcgref6347ubml54o3g64vymeolodcjuh2zoq",
-        "agent/valory/mech/0.1.0": "bafybeib3gh6mpkrj4hajasevz3fksqfx2tgmfdbupehcgc3pq26oouxof4",
-        "service/valory/mech/0.1.0": "bafybeieu6husr3ofe5cwnby53fy7imznlwlcbogqumylhkxihkxwwayuey"
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifs6pjhm6474dpdkfoyqnbjx3npdganwk5unsg4vgjiohcjp57mhi",
+        "agent/valory/mech/0.1.0": "bafybeiftjhemjjnxmvppzmm5tnpmal5hg6rpczbs27ny6hw3z6ersa7bja",
+        "service/valory/mech/0.1.0": "bafybeiala4qtx76puzhajxbf2ralp27ovngog6ytzd5bfesgymyo5an6fu"
     },
     "third_party": {
         "protocol/valory/default/1.0.0": "bafybeifqcqy5hfbnd7fjv4mqdjrtujh2vx3p2xhe33y67zoxa6ph7wdpaq",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,20 +2,20 @@
     "dev": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",
         "protocol/valory/websocket_client/0.1.0": "bafybeifjk254sy65rna2k32kynzenutujwqndap2r222afvr3zezi27mx4",
-        "contract/valory/agent_mech/0.1.0": "bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u",
+        "contract/valory/agent_mech/0.1.0": "bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34",
         "contract/valory/agent_registry/0.1.0": "bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq",
         "contract/valory/hash_checkpoint/0.1.0": "bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da",
-        "contract/valory/mech_marketplace/0.1.0": "bafybeidisebfdbrjxjscpskuw6uq4r6fdzxsgr5fhnxa5xvxhflfge653u",
+        "contract/valory/mech_marketplace/0.1.0": "bafybeifjforrarhg4mksmesr6pkbcotbqfsxtbuidqjypensprshlwfpza",
         "contract/valory/balance_tracker/0.1.0": "bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4",
         "connection/valory/websocket_client/0.1.0": "bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli",
         "skill/valory/contract_subscription/0.1.0": "bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy",
-        "skill/valory/mech_abci/0.1.0": "bafybeiadaqbl6jtkspozviho7xuv372hbv7lt3txg5ngdyzg7237x2fwyu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeif6pjl2av5fhwt5o6wwdoduiokleu3tqtomjq5yog43m75m453kei",
-        "skill/valory/task_execution/0.1.0": "bafybeicmpxhzj3hj5ces5f34gibxin5vpvztufy74za4vsliwocj2b7mde",
+        "skill/valory/mech_abci/0.1.0": "bafybeicdmjeas7avybqf4kgock54z3g66676zsk7iaiqgwwlerjxhczbza",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidnkudjprawobejyyc72eiqluoih5hxqstnu6hyautackmcqmavhe",
+        "skill/valory/task_execution/0.1.0": "bafybeiemosyhfcalxk5nlmgw5godpg2vcsdw22retk4b4ipw7t7agj5wxm",
         "skill/valory/websocket_client/0.1.0": "bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeihptz72mjmlunudw6slhoyfkl5lz3f4m4fjb4jvkf7husjclxmsp4",
-        "agent/valory/mech/0.1.0": "bafybeib6hj6zsvmggbsq5t3ca3cjmnv4hapkxazrpt72262qc6bobcb3za",
-        "service/valory/mech/0.1.0": "bafybeidzcjwolzyl74zm2enzf4u3jy3xa7mfuk4b2xjgkr2rgubizo7q2q"
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeiayuegt6f4vvbcc3x7anshe52byswvcohlot4ktnv7zrnvdsysxfe",
+        "agent/valory/mech/0.1.0": "bafybeie6lucimqu4k22hfth5fjnpuyhe7v7kor3ak2tfnrfwlg5jaioplm",
+        "service/valory/mech/0.1.0": "bafybeigwlyumza6q2ss77biptv3jpaxwxdrcrlrat2qzlg2gxeey6olgnm"
     },
     "third_party": {
         "protocol/valory/default/1.0.0": "bafybeifqcqy5hfbnd7fjv4mqdjrtujh2vx3p2xhe33y67zoxa6ph7wdpaq",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,20 +2,20 @@
     "dev": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",
         "protocol/valory/websocket_client/0.1.0": "bafybeifjk254sy65rna2k32kynzenutujwqndap2r222afvr3zezi27mx4",
-        "contract/valory/agent_mech/0.1.0": "bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm",
+        "contract/valory/agent_mech/0.1.0": "bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u",
         "contract/valory/agent_registry/0.1.0": "bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq",
         "contract/valory/hash_checkpoint/0.1.0": "bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da",
-        "contract/valory/mech_marketplace/0.1.0": "bafybeicsfg2kc2m4ffhrjkxxylq5pstl2tdevxzgwp45u6n7465tennet4",
+        "contract/valory/mech_marketplace/0.1.0": "bafybeidisebfdbrjxjscpskuw6uq4r6fdzxsgr5fhnxa5xvxhflfge653u",
         "contract/valory/balance_tracker/0.1.0": "bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4",
         "connection/valory/websocket_client/0.1.0": "bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli",
         "skill/valory/contract_subscription/0.1.0": "bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy",
-        "skill/valory/mech_abci/0.1.0": "bafybeihcyo7w7dq2kgftrqxuaaadntr6mpsi6tddgmxuc34zhppfeggmee",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibxfn6yqdpc36jxv7ht45tpu26rtzq72nywej2o3ybivx7lx7fprq",
-        "skill/valory/task_execution/0.1.0": "bafybeicknvidmx5v3rhc5yee6dptzrskvxlhyhqyne6r5gqv4nclwanltq",
+        "skill/valory/mech_abci/0.1.0": "bafybeiadaqbl6jtkspozviho7xuv372hbv7lt3txg5ngdyzg7237x2fwyu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeif6pjl2av5fhwt5o6wwdoduiokleu3tqtomjq5yog43m75m453kei",
+        "skill/valory/task_execution/0.1.0": "bafybeicmpxhzj3hj5ces5f34gibxin5vpvztufy74za4vsliwocj2b7mde",
         "skill/valory/websocket_client/0.1.0": "bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifs6pjhm6474dpdkfoyqnbjx3npdganwk5unsg4vgjiohcjp57mhi",
-        "agent/valory/mech/0.1.0": "bafybeiftjhemjjnxmvppzmm5tnpmal5hg6rpczbs27ny6hw3z6ersa7bja",
-        "service/valory/mech/0.1.0": "bafybeiala4qtx76puzhajxbf2ralp27ovngog6ytzd5bfesgymyo5an6fu"
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeihptz72mjmlunudw6slhoyfkl5lz3f4m4fjb4jvkf7husjclxmsp4",
+        "agent/valory/mech/0.1.0": "bafybeib6hj6zsvmggbsq5t3ca3cjmnv4hapkxazrpt72262qc6bobcb3za",
+        "service/valory/mech/0.1.0": "bafybeidzcjwolzyl74zm2enzf4u3jy3xa7mfuk4b2xjgkr2rgubizo7q2q"
     },
     "third_party": {
         "protocol/valory/default/1.0.0": "bafybeifqcqy5hfbnd7fjv4mqdjrtujh2vx3p2xhe33y67zoxa6ph7wdpaq",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,20 +2,20 @@
     "dev": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",
         "protocol/valory/websocket_client/0.1.0": "bafybeifjk254sy65rna2k32kynzenutujwqndap2r222afvr3zezi27mx4",
-        "contract/valory/agent_mech/0.1.0": "bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34",
+        "contract/valory/agent_mech/0.1.0": "bafybeibjlxgwwqodubwy3mhstnjqjsyat4ray32xgkkv5adysjwz5mzcau",
         "contract/valory/agent_registry/0.1.0": "bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq",
         "contract/valory/hash_checkpoint/0.1.0": "bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da",
-        "contract/valory/mech_marketplace/0.1.0": "bafybeifjforrarhg4mksmesr6pkbcotbqfsxtbuidqjypensprshlwfpza",
+        "contract/valory/mech_marketplace/0.1.0": "bafybeicx4aw7kbp4zxbdsafshkagzb53ji5m2ak537on2ryrzpnoxs2jkq",
         "contract/valory/balance_tracker/0.1.0": "bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4",
         "connection/valory/websocket_client/0.1.0": "bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli",
         "skill/valory/contract_subscription/0.1.0": "bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy",
-        "skill/valory/mech_abci/0.1.0": "bafybeicdmjeas7avybqf4kgock54z3g66676zsk7iaiqgwwlerjxhczbza",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidnkudjprawobejyyc72eiqluoih5hxqstnu6hyautackmcqmavhe",
-        "skill/valory/task_execution/0.1.0": "bafybeiemosyhfcalxk5nlmgw5godpg2vcsdw22retk4b4ipw7t7agj5wxm",
+        "skill/valory/mech_abci/0.1.0": "bafybeie2xstvcujzo7frn227a5thsbxv22prngc2nbzxbwms2hwkrhk5ty",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeib2v5zeeu4cwnxt37avxysdxgqh4gmotcvz6wthepqnvupafbpy7e",
+        "skill/valory/task_execution/0.1.0": "bafybeigbueebww7nbja5jo3x7o3524e26hhfnmvxrprpbmnvjffcxm7k54",
         "skill/valory/websocket_client/0.1.0": "bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeiayuegt6f4vvbcc3x7anshe52byswvcohlot4ktnv7zrnvdsysxfe",
-        "agent/valory/mech/0.1.0": "bafybeie6lucimqu4k22hfth5fjnpuyhe7v7kor3ak2tfnrfwlg5jaioplm",
-        "service/valory/mech/0.1.0": "bafybeigwlyumza6q2ss77biptv3jpaxwxdrcrlrat2qzlg2gxeey6olgnm"
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeiakedzpbl2v4ajpovpzrgpigwbzfqlwjyuucvexs2kckhlh7x3mce",
+        "agent/valory/mech/0.1.0": "bafybeiesbbt467twifwjvoa5kay54y7tiizevvuaybqhmhtgvtjswer2t4",
+        "service/valory/mech/0.1.0": "bafybeid5ub7tdchcpxpxl3mhf2ded5iwo4k7fo52gtcvu2sm5kdj2arqya"
     },
     "third_party": {
         "protocol/valory/default/1.0.0": "bafybeifqcqy5hfbnd7fjv4mqdjrtujh2vx3p2xhe33y67zoxa6ph7wdpaq",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -15,14 +15,14 @@ connections:
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 - valory/websocket_client:0.1.0:bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli
 contracts:
-- valory/agent_mech:0.1.0:bafybeigs3jle7n57sqwdnwi2egfia6ingt7wxhzykft7ssasjj26ig32xi
+- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeihx4j2k4gwst4qswkgqlcsr3zmplroc7zjwuqo3ttngjq3fwyumpu
 - valory/hash_checkpoint:0.1.0:bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 - valory/service_registry:0.1.0:bafybeibuq4p66jdpnrq7viz4zylydu3zneteukfy3gwdgp273vptnq3dvi
-- valory/mech_marketplace:0.1.0:bafybeic7xtjx7a6i2h6apxjaupezqsxlhidsnvnasv6ms3rlekn7vorkgi
+- valory/mech_marketplace:0.1.0:bafybeicsfg2kc2m4ffhrjkxxylq5pstl2tdevxzgwp45u6n7465tennet4
 - valory/balance_tracker:0.1.0:bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4
 protocols:
 - open_aea/signing:1.0.0:bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeifv2dynqo3o57nr6jntsvdkduytz3f6i52csv2bjwrr4qhi4mkm7i
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/contract_subscription:0.1.0:bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy
-- valory/mech_abci:0.1.0:bafybeid5aimttywh3dycslgzjgn5sf3q4wxhw4ygejl53gocjc5ufnfhlu
+- valory/mech_abci:0.1.0:bafybeihcyo7w7dq2kgftrqxuaaadntr6mpsi6tddgmxuc34zhppfeggmee
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/delivery_rate_abci:0.1.0:bafybeifa2gmumovmta3tkjcgref6347ubml54o3g64vymeolodcjuh2zoq
-- valory/task_execution:0.1.0:bafybeiegmmap2vsoqwcjic746gxfypwah533tk6wjd6lpyt4bo2uxyu3hm
-- valory/task_submission_abci:0.1.0:bafybeifwqqfhlpnrzyu4u4jzdnaecdnkphshv7zqz6mtua77frj6clrmbq
+- valory/delivery_rate_abci:0.1.0:bafybeifs6pjhm6474dpdkfoyqnbjx3npdganwk5unsg4vgjiohcjp57mhi
+- valory/task_execution:0.1.0:bafybeicknvidmx5v3rhc5yee6dptzrskvxlhyhqyne6r5gqv4nclwanltq
+- valory/task_submission_abci:0.1.0:bafybeibxfn6yqdpc36jxv7ht45tpu26rtzq72nywej2o3ybivx7lx7fprq
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
 - valory/websocket_client:0.1.0:bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -15,14 +15,14 @@ connections:
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 - valory/websocket_client:0.1.0:bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli
 contracts:
-- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
+- valory/agent_mech:0.1.0:bafybeibjlxgwwqodubwy3mhstnjqjsyat4ray32xgkkv5adysjwz5mzcau
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeihx4j2k4gwst4qswkgqlcsr3zmplroc7zjwuqo3ttngjq3fwyumpu
 - valory/hash_checkpoint:0.1.0:bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 - valory/service_registry:0.1.0:bafybeibuq4p66jdpnrq7viz4zylydu3zneteukfy3gwdgp273vptnq3dvi
-- valory/mech_marketplace:0.1.0:bafybeifjforrarhg4mksmesr6pkbcotbqfsxtbuidqjypensprshlwfpza
+- valory/mech_marketplace:0.1.0:bafybeicx4aw7kbp4zxbdsafshkagzb53ji5m2ak537on2ryrzpnoxs2jkq
 - valory/balance_tracker:0.1.0:bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4
 protocols:
 - open_aea/signing:1.0.0:bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeifv2dynqo3o57nr6jntsvdkduytz3f6i52csv2bjwrr4qhi4mkm7i
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/contract_subscription:0.1.0:bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy
-- valory/mech_abci:0.1.0:bafybeicdmjeas7avybqf4kgock54z3g66676zsk7iaiqgwwlerjxhczbza
+- valory/mech_abci:0.1.0:bafybeie2xstvcujzo7frn227a5thsbxv22prngc2nbzxbwms2hwkrhk5ty
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/delivery_rate_abci:0.1.0:bafybeiayuegt6f4vvbcc3x7anshe52byswvcohlot4ktnv7zrnvdsysxfe
-- valory/task_execution:0.1.0:bafybeiemosyhfcalxk5nlmgw5godpg2vcsdw22retk4b4ipw7t7agj5wxm
-- valory/task_submission_abci:0.1.0:bafybeidnkudjprawobejyyc72eiqluoih5hxqstnu6hyautackmcqmavhe
+- valory/delivery_rate_abci:0.1.0:bafybeiakedzpbl2v4ajpovpzrgpigwbzfqlwjyuucvexs2kckhlh7x3mce
+- valory/task_execution:0.1.0:bafybeigbueebww7nbja5jo3x7o3524e26hhfnmvxrprpbmnvjffcxm7k54
+- valory/task_submission_abci:0.1.0:bafybeib2v5zeeu4cwnxt37avxysdxgqh4gmotcvz6wthepqnvupafbpy7e
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
 - valory/websocket_client:0.1.0:bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -15,14 +15,14 @@ connections:
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 - valory/websocket_client:0.1.0:bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli
 contracts:
-- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
+- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeihx4j2k4gwst4qswkgqlcsr3zmplroc7zjwuqo3ttngjq3fwyumpu
 - valory/hash_checkpoint:0.1.0:bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 - valory/service_registry:0.1.0:bafybeibuq4p66jdpnrq7viz4zylydu3zneteukfy3gwdgp273vptnq3dvi
-- valory/mech_marketplace:0.1.0:bafybeicsfg2kc2m4ffhrjkxxylq5pstl2tdevxzgwp45u6n7465tennet4
+- valory/mech_marketplace:0.1.0:bafybeidisebfdbrjxjscpskuw6uq4r6fdzxsgr5fhnxa5xvxhflfge653u
 - valory/balance_tracker:0.1.0:bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4
 protocols:
 - open_aea/signing:1.0.0:bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeifv2dynqo3o57nr6jntsvdkduytz3f6i52csv2bjwrr4qhi4mkm7i
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/contract_subscription:0.1.0:bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy
-- valory/mech_abci:0.1.0:bafybeihcyo7w7dq2kgftrqxuaaadntr6mpsi6tddgmxuc34zhppfeggmee
+- valory/mech_abci:0.1.0:bafybeiadaqbl6jtkspozviho7xuv372hbv7lt3txg5ngdyzg7237x2fwyu
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/delivery_rate_abci:0.1.0:bafybeifs6pjhm6474dpdkfoyqnbjx3npdganwk5unsg4vgjiohcjp57mhi
-- valory/task_execution:0.1.0:bafybeicknvidmx5v3rhc5yee6dptzrskvxlhyhqyne6r5gqv4nclwanltq
-- valory/task_submission_abci:0.1.0:bafybeibxfn6yqdpc36jxv7ht45tpu26rtzq72nywej2o3ybivx7lx7fprq
+- valory/delivery_rate_abci:0.1.0:bafybeihptz72mjmlunudw6slhoyfkl5lz3f4m4fjb4jvkf7husjclxmsp4
+- valory/task_execution:0.1.0:bafybeicmpxhzj3hj5ces5f34gibxin5vpvztufy74za4vsliwocj2b7mde
+- valory/task_submission_abci:0.1.0:bafybeif6pjl2av5fhwt5o6wwdoduiokleu3tqtomjq5yog43m75m453kei
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
 - valory/websocket_client:0.1.0:bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -15,14 +15,14 @@ connections:
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 - valory/websocket_client:0.1.0:bafybeic4ag3gqc7kd3k2o3pucddj2odck5yrfbgmwh5veqny7zao5qayli
 contracts:
-- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
+- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeihx4j2k4gwst4qswkgqlcsr3zmplroc7zjwuqo3ttngjq3fwyumpu
 - valory/hash_checkpoint:0.1.0:bafybeihyzjja65zrhjdgm5p4oecjm7ijrs6aur2ux2fkmfgfiurautm2da
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 - valory/service_registry:0.1.0:bafybeibuq4p66jdpnrq7viz4zylydu3zneteukfy3gwdgp273vptnq3dvi
-- valory/mech_marketplace:0.1.0:bafybeidisebfdbrjxjscpskuw6uq4r6fdzxsgr5fhnxa5xvxhflfge653u
+- valory/mech_marketplace:0.1.0:bafybeifjforrarhg4mksmesr6pkbcotbqfsxtbuidqjypensprshlwfpza
 - valory/balance_tracker:0.1.0:bafybeiceepsgckl7x5ljvkv4ztg7ubc3re6d4xzan6msywuifao3nxyyq4
 protocols:
 - open_aea/signing:1.0.0:bafybeig2d36zxy65vd7fwhs7scotuktydcarm74aprmrb5nioiymr3yixm
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeifv2dynqo3o57nr6jntsvdkduytz3f6i52csv2bjwrr4qhi4mkm7i
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/contract_subscription:0.1.0:bafybeiefuemlp75obgpxrp6iuleb3hn6vcviwh5oetk5djbuprf4xsmgjy
-- valory/mech_abci:0.1.0:bafybeiadaqbl6jtkspozviho7xuv372hbv7lt3txg5ngdyzg7237x2fwyu
+- valory/mech_abci:0.1.0:bafybeicdmjeas7avybqf4kgock54z3g66676zsk7iaiqgwwlerjxhczbza
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/delivery_rate_abci:0.1.0:bafybeihptz72mjmlunudw6slhoyfkl5lz3f4m4fjb4jvkf7husjclxmsp4
-- valory/task_execution:0.1.0:bafybeicmpxhzj3hj5ces5f34gibxin5vpvztufy74za4vsliwocj2b7mde
-- valory/task_submission_abci:0.1.0:bafybeif6pjl2av5fhwt5o6wwdoduiokleu3tqtomjq5yog43m75m453kei
+- valory/delivery_rate_abci:0.1.0:bafybeiayuegt6f4vvbcc3x7anshe52byswvcohlot4ktnv7zrnvdsysxfe
+- valory/task_execution:0.1.0:bafybeiemosyhfcalxk5nlmgw5godpg2vcsdw22retk4b4ipw7t7agj5wxm
+- valory/task_submission_abci:0.1.0:bafybeidnkudjprawobejyyc72eiqluoih5hxqstnu6hyautackmcqmavhe
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
 - valory/websocket_client:0.1.0:bafybeif7rrvsu6z4evqkhblxj3u6wwv2eqou576hgkyoehxuj7cntw7o2m

--- a/packages/valory/contracts/agent_mech/contract.py
+++ b/packages/valory/contracts/agent_mech/contract.py
@@ -28,8 +28,11 @@ from aea.configurations.base import PublicId
 from aea.contracts.base import Contract
 from aea.crypto.base import LedgerApi
 from aea_ledger_ethereum import EthereumApi
+from eth_utils import event_abi_to_log_topic
+from hexbytes import HexBytes
 from web3 import Web3
-from web3.types import BlockIdentifier, TxReceipt
+from web3._utils.events import get_event_data
+from web3.types import BlockIdentifier, FilterParams, TxReceipt
 
 
 PUBLIC_ID = PublicId.from_str("valory/agent_mech:0.1.0")
@@ -153,11 +156,22 @@ partial_abis = [
 ]
 
 
+TOPIC_BYTES = 32
+TOPIC_CHARS = TOPIC_BYTES * 2
+Ox = "0x"
+Ox_CHARS = len(Ox)
+
+
 class MechOperation(Enum):
     """Operation types."""
 
     CALL = 0
     DELEGATE_CALL = 1
+
+
+def pad_address_for_topic(address: str) -> HexBytes:
+    """Left-pad an Ethereum address to 32 bytes for use in a topic."""
+    return HexBytes(Ox + address[Ox_CHARS:].zfill(TOPIC_CHARS))
 
 
 class AgentMechContract(Contract):
@@ -291,10 +305,13 @@ class AgentMechContract(Contract):
         all_entries = []
         for abi in partial_abis:
             contract_instance = ledger_api.api.eth.contract(contract_address, abi=abi)
-            entries = contract_instance.events.Request.create_filter(
-                fromBlock=from_block,
-                toBlock=to_block,
-            ).get_all_entries()
+            entries = cls.get_event_entries(
+                ledger_api=ledger_api,
+                from_block=from_block,
+                to_block=to_block,
+                contract_instance=contract_instance,
+            )
+
             all_entries.extend(entries)
 
         request_events = list(
@@ -321,10 +338,12 @@ class AgentMechContract(Contract):
         all_entries = []
         for abi in partial_abis:
             contract_instance = ledger_api.api.eth.contract(contract_address, abi=abi)
-            entries = contract_instance.events.Deliver.create_filter(
-                fromBlock=from_block,
-                toBlock=to_block,
-            ).get_all_entries()
+            entries = cls.get_event_entries(
+                ledger_api=ledger_api,
+                from_block=from_block,
+                to_block=to_block,
+                contract_instance=contract_instance,
+            )
             all_entries.extend(entries)
 
         deliver_events = list(
@@ -544,10 +563,12 @@ class AgentMechContract(Contract):
         """Get the Request events emitted by the contract."""
         ledger_api = cast(EthereumApi, ledger_api)
         contract_instance = cls.get_instance(ledger_api, contract_address)
-        entries = contract_instance.events.Request.create_filter(
-            fromBlock=from_block,
-            toBlock=to_block,
-        ).get_all_entries()
+        entries = cls.get_event_entries(
+            ledger_api=ledger_api,
+            from_block=from_block,
+            to_block=to_block,
+            contract_instance=contract_instance,
+        )
 
         request_events = list(
             {
@@ -571,10 +592,12 @@ class AgentMechContract(Contract):
         """Get the Deliver events emitted by the contract."""
         ledger_api = cast(EthereumApi, ledger_api)
         contract_instance = cls.get_instance(ledger_api, contract_address)
-        entries = contract_instance.events.Deliver.create_filter(
-            fromBlock=from_block,
-            toBlock=to_block,
-        ).get_all_entries()
+        entries = cls.get_event_entries(
+            ledger_api=ledger_api,
+            from_block=from_block,
+            to_block=to_block,
+            contract_instance=contract_instance,
+        )
 
         deliver_events = list(
             {
@@ -689,3 +712,28 @@ class AgentMechContract(Contract):
             args=[new_max_delivery_rate],
         )
         return {"data": bytes.fromhex(data[2:])}  # type: ignore
+
+    @classmethod
+    def get_event_entries(
+        cls,
+        ledger_api: EthereumApi,
+        contract_instance: Any,
+        from_block: BlockIdentifier = "earliest",
+        to_block: BlockIdentifier = "latest",
+    ) -> List:
+        """Helper method to extract the events."""
+        event_abi = contract_instance.events.SafeReceived().abi
+
+        event_topic = event_abi_to_log_topic(event_abi)
+
+        filter_params: FilterParams = {
+            "fromBlock": from_block,
+            "toBlock": to_block,
+            "address": contract_instance.address,
+            "topics": [event_topic],
+        }
+
+        w3 = ledger_api.api.eth
+        logs = w3.get_logs(filter_params)
+        entries = [get_event_data(w3.codec, event_abi, log) for log in logs]
+        return entries

--- a/packages/valory/contracts/agent_mech/contract.yaml
+++ b/packages/valory/contracts/agent_mech/contract.yaml
@@ -18,4 +18,9 @@ dependencies:
     version: ==1.63.0
   web3:
     version: <7,>=6.0.0
+  eth-abi:
+    version: ==4.0.0
+  eth-utils:
+    version: ==2.2.0
+  hexbytes: {}
 contracts: []

--- a/packages/valory/contracts/agent_mech/contract.yaml
+++ b/packages/valory/contracts/agent_mech/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeigpq5lxfj2aza6ok3fjuywtdafelkbvoqwaits7regfbgu4oynmku
   build/AgentMech.json: bafybeigtikt7m5nyhlsxscgfciejkfvot56a7gbwe2og6dziwzvgkvo7hq
-  contract.py: bafybeigrxjyresx6jtssbvvw6gdceioz5wx3k6yo5unal3gu23weu7fwmy
+  contract.py: bafybeie6kif2ap77jzfo62c637nismy3a5d2jpa63hm3sgfe33qk7zxtue
 fingerprint_ignore_patterns: []
 class_name: AgentMechContract
 contract_interface_paths:

--- a/packages/valory/contracts/agent_mech/contract.yaml
+++ b/packages/valory/contracts/agent_mech/contract.yaml
@@ -23,4 +23,5 @@ dependencies:
   eth-utils:
     version: ==2.2.0
   hexbytes: {}
+  eth_typing: {}
 contracts: []

--- a/packages/valory/contracts/agent_mech/contract.yaml
+++ b/packages/valory/contracts/agent_mech/contract.yaml
@@ -8,7 +8,7 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeigpq5lxfj2aza6ok3fjuywtdafelkbvoqwaits7regfbgu4oynmku
   build/AgentMech.json: bafybeigtikt7m5nyhlsxscgfciejkfvot56a7gbwe2og6dziwzvgkvo7hq
-  contract.py: bafybeie6kif2ap77jzfo62c637nismy3a5d2jpa63hm3sgfe33qk7zxtue
+  contract.py: bafybeigbe2x57etfsqkf5xocgeaejid2tpyoc7xp6zud55mey7odnpn7jy
 fingerprint_ignore_patterns: []
 class_name: AgentMechContract
 contract_interface_paths:

--- a/packages/valory/contracts/mech_marketplace/contract.py
+++ b/packages/valory/contracts/mech_marketplace/contract.py
@@ -21,6 +21,8 @@
 
 import logging
 from enum import Enum
+
+from eth_typing import ChecksumAddress
 from eth_utils import event_abi_to_log_topic
 from hexbytes import HexBytes
 from typing import Any, Dict, List, cast
@@ -190,11 +192,14 @@ class MechMarketplaceContract(Contract):
         """Get the Request events emitted by the contract."""
         ledger_api = cast(EthereumApi, ledger_api)
         contract_instance = cls.get_instance(ledger_api, contract_address)
-
-        entries = cls.get_event_entries(ledger_api=ledger_api,
-                                        from_block=from_block,
-                                        to_block=to_block,
-                                        contract_instance=contract_instance)
+        event_abi = contract_instance.events.MarketplaceRequest().abi
+        entries = cls.get_event_entries(
+            ledger_api=ledger_api,
+            event_abi=event_abi,
+            address=contract_instance.address,
+            from_block=from_block,
+            to_block=to_block,
+        )
 
         request_events = list(
             {
@@ -218,10 +223,14 @@ class MechMarketplaceContract(Contract):
         """Get the Deliver events emitted by the contract."""
         ledger_api = cast(EthereumApi, ledger_api)
         contract_instance = cls.get_instance(ledger_api, contract_address)
-        entries = cls.get_event_entries(ledger_api=ledger_api,
-                                        from_block=from_block,
-                                        to_block=to_block,
-                                        contract_instance=contract_instance)
+        event_abi = contract_instance.events.MarketplaceDeliver().abi
+        entries = cls.get_event_entries(
+            ledger_api=ledger_api,
+            event_abi=event_abi,
+            address=contract_instance.address,
+            from_block=from_block,
+            to_block=to_block,
+        )
 
         request_events = list(
             {
@@ -391,21 +400,22 @@ class MechMarketplaceContract(Contract):
         return dict(data=balance_tracker_address)
 
     @classmethod
-    def get_event_entries(cls,
-                          ledger_api: EthereumApi,
-                          contract_instance: Any,
-                          from_block: BlockIdentifier = "earliest",
-                          to_block: BlockIdentifier = "latest"
+    def get_event_entries(
+        cls,
+        ledger_api: EthereumApi,
+        event_abi: Any,
+        address: ChecksumAddress,
+        from_block: BlockIdentifier = "earliest",
+        to_block: BlockIdentifier = "latest",
     ) -> List:
         """Helper method to extract the events."""
-        event_abi = contract_instance.events.SafeReceived().abi
 
         event_topic = event_abi_to_log_topic(event_abi)
 
         filter_params: FilterParams = {
             "fromBlock": from_block,
             "toBlock": to_block,
-            "address": contract_instance.address,
+            "address": address,
             "topics": [event_topic],
         }
 

--- a/packages/valory/contracts/mech_marketplace/contract.py
+++ b/packages/valory/contracts/mech_marketplace/contract.py
@@ -21,6 +21,8 @@
 
 import logging
 from enum import Enum
+from eth_utils import event_abi_to_log_topic
+from hexbytes import HexBytes
 from typing import Any, Dict, List, cast
 
 from aea.common import JSONLike
@@ -28,7 +30,8 @@ from aea.configurations.base import PublicId
 from aea.contracts.base import Contract
 from aea.crypto.base import LedgerApi
 from aea_ledger_ethereum import EthereumApi
-from web3.types import BlockIdentifier, TxReceipt
+from web3.types import BlockIdentifier, FilterParams, TxReceipt
+from web3._utils.events import get_event_data
 
 
 PUBLIC_ID = PublicId.from_str("valory/agent_mech:0.1.0")
@@ -61,12 +64,23 @@ BATCH_PRIORITY_PASSED_DATA = {
     "bytecode": "0x608060405234801561001057600080fd5b5060405161081738038061081783398181016040528101906100329190610511565b60008151905060008167ffffffffffffffff81111561005457610053610398565b5b6040519080825280602002602001820160405280156100825781602001602082028036833780820191505090505b5090506000805b838110156102055760008773ffffffffffffffffffffffffffffffffffffffff1663cb261bec8784815181106100c2576100c1610580565b5b60200260200101516040518263ffffffff1660e01b81526004016100e691906105be565b608060405180830381865afa158015610103573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906101279190610692565b90508673ffffffffffffffffffffffffffffffffffffffff16816000015173ffffffffffffffffffffffffffffffffffffffff1614806101715750806060015163ffffffff164210155b80156101ad5750600073ffffffffffffffffffffffffffffffffffffffff16816020015173ffffffffffffffffffffffffffffffffffffffff16145b156101f9578582815181106101c5576101c4610580565b5b60200260200101518484815181106101e0576101df610580565b5b602002602001018181525050826101f6906106ee565b92505b81600101915050610089565b5060008167ffffffffffffffff81111561022257610221610398565b5b6040519080825280602002602001820160405280156102505781602001602082028036833780820191505090505b50905060005b828110156102a35783818151811061027157610270610580565b5b602002602001015182828151811061028c5761028b610580565b5b602002602001018181525050806001019050610256565b506000816040516020016102b791906107f4565b60405160208183030381529060405290506020810180590381f35b6000604051905090565b600080fd5b600080fd5b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b6000610311826102e6565b9050919050565b600061032382610306565b9050919050565b61033381610318565b811461033e57600080fd5b50565b6000815190506103508161032a565b92915050565b61035f81610306565b811461036a57600080fd5b50565b60008151905061037c81610356565b92915050565b600080fd5b6000601f19601f8301169050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6103d082610387565b810181811067ffffffffffffffff821117156103ef576103ee610398565b5b80604052505050565b60006104026102d2565b905061040e82826103c7565b919050565b600067ffffffffffffffff82111561042e5761042d610398565b5b602082029050602081019050919050565b600080fd5b6000819050919050565b61045781610444565b811461046257600080fd5b50565b6000815190506104748161044e565b92915050565b600061048d61048884610413565b6103f8565b905080838252602082019050602084028301858111156104b0576104af61043f565b5b835b818110156104d957806104c58882610465565b8452602084019350506020810190506104b2565b5050509392505050565b600082601f8301126104f8576104f7610382565b5b815161050884826020860161047a565b91505092915050565b60008060006060848603121561052a576105296102dc565b5b600061053886828701610341565b93505060206105498682870161036d565b925050604084015167ffffffffffffffff81111561056a576105696102e1565b5b610576868287016104e3565b9150509250925092565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fd5b6105b881610444565b82525050565b60006020820190506105d360008301846105af565b92915050565b600080fd5b600063ffffffff82169050919050565b6105f7816105de565b811461060257600080fd5b50565b600081519050610614816105ee565b92915050565b6000608082840312156106305761062f6105d9565b5b61063a60806103f8565b9050600061064a8482850161036d565b600083015250602061065e8482850161036d565b60208301525060406106728482850161036d565b604083015250606061068684828501610605565b60608301525092915050565b6000608082840312156106a8576106a76102dc565b5b60006106b68482850161061a565b91505092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b60006106f982610444565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff820361072b5761072a6106bf565b5b600182019050919050565b600081519050919050565b600082825260208201905092915050565b6000819050602082019050919050565b61076b81610444565b82525050565b600061077d8383610762565b60208301905092915050565b6000602082019050919050565b60006107a182610736565b6107ab8185610741565b93506107b683610752565b8060005b838110156107e75781516107ce8882610771565b97506107d983610789565b9250506001810190506107ba565b5085935050505092915050565b6000602082019050818103600083015261080e8184610796565b90509291505056fe",
 }
 
+TOPIC_BYTES = 32
+TOPIC_CHARS = TOPIC_BYTES * 2
+Ox = "0x"
+Ox_CHARS = len(Ox)
+
 
 class MechOperation(Enum):
     """Operation types."""
 
     CALL = 0
     DELEGATE_CALL = 1
+
+
+def pad_address_for_topic(address: str) -> HexBytes:
+    """Left-pad an Ethereum address to 32 bytes for use in a topic."""
+    return HexBytes(Ox + address[Ox_CHARS:].zfill(TOPIC_CHARS))
+
 
 
 class MechMarketplaceContract(Contract):
@@ -176,10 +190,11 @@ class MechMarketplaceContract(Contract):
         """Get the Request events emitted by the contract."""
         ledger_api = cast(EthereumApi, ledger_api)
         contract_instance = cls.get_instance(ledger_api, contract_address)
-        entries = contract_instance.events.MarketplaceRequest.create_filter(
-            fromBlock=from_block,
-            toBlock=to_block,
-        ).get_all_entries()
+
+        entries = cls.get_event_entries(ledger_api=ledger_api,
+                                        from_block=from_block,
+                                        to_block=to_block,
+                                        contract_instance=contract_instance)
 
         request_events = list(
             {
@@ -203,10 +218,10 @@ class MechMarketplaceContract(Contract):
         """Get the Deliver events emitted by the contract."""
         ledger_api = cast(EthereumApi, ledger_api)
         contract_instance = cls.get_instance(ledger_api, contract_address)
-        entries = contract_instance.events.MarketplaceDeliver.create_filter(
-            fromBlock=from_block,
-            toBlock=to_block,
-        ).get_all_entries()
+        entries = cls.get_event_entries(ledger_api=ledger_api,
+                                        from_block=from_block,
+                                        to_block=to_block,
+                                        contract_instance=contract_instance)
 
         request_events = list(
             {
@@ -374,3 +389,27 @@ class MechMarketplaceContract(Contract):
             contract_instance.functions.mapPaymentTypeBalanceTrackers(mech_type).call()
         )
         return dict(data=balance_tracker_address)
+
+    @classmethod
+    def get_event_entries(cls,
+                          ledger_api: EthereumApi,
+                          contract_instance: Any,
+                          from_block: BlockIdentifier = "earliest",
+                          to_block: BlockIdentifier = "latest"
+    ) -> List:
+        """Helper method to extract the events."""
+        event_abi = contract_instance.events.SafeReceived().abi
+
+        event_topic = event_abi_to_log_topic(event_abi)
+
+        filter_params: FilterParams = {
+            "fromBlock": from_block,
+            "toBlock": to_block,
+            "address": contract_instance.address,
+            "topics": [event_topic],
+        }
+
+        w3 = ledger_api.api.eth
+        logs = w3.get_logs(filter_params)
+        entries = [get_event_data(w3.codec, event_abi, log) for log in logs]
+        return entries

--- a/packages/valory/contracts/mech_marketplace/contract.yaml
+++ b/packages/valory/contracts/mech_marketplace/contract.yaml
@@ -9,7 +9,7 @@ fingerprint:
   BatchPriorityPassedCheck.sol: bafybeie3hfpyss43sggqh5rjzwsqe7o37td4v4k6f3hlweiosnayyseo4i
   __init__.py: bafybeigqedpnruwcvjarngql7yfnpqwozvvgzcei2xcrp7mjf4ccspa62y
   build/MechMarketplace.json: bafybeiauqsmm5aqqzqqr7vi46obq7exa7id5vbq57e3e3wxxkzblgqnjoy
-  contract.py: bafybeia4wjdonluamlhls6nymvx4tkxefgouiom4yyjtxvb6sr55jngzmm
+  contract.py: bafybeihyob46cn2hzogvle4a74uy77bozhubflqupmiwzy5z56jybxctyu
 fingerprint_ignore_patterns: []
 class_name: MechMarketplaceContract
 contract_interface_paths:

--- a/packages/valory/contracts/mech_marketplace/contract.yaml
+++ b/packages/valory/contracts/mech_marketplace/contract.yaml
@@ -19,4 +19,9 @@ dependencies:
     version: ==1.63.0
   web3:
     version: <7,>=6.0.0
+  eth-abi:
+    version: ==4.0.0
+  eth-utils:
+    version: ==2.2.0
+  hexbytes: {}
 contracts: []

--- a/packages/valory/contracts/mech_marketplace/contract.yaml
+++ b/packages/valory/contracts/mech_marketplace/contract.yaml
@@ -9,7 +9,7 @@ fingerprint:
   BatchPriorityPassedCheck.sol: bafybeie3hfpyss43sggqh5rjzwsqe7o37td4v4k6f3hlweiosnayyseo4i
   __init__.py: bafybeigqedpnruwcvjarngql7yfnpqwozvvgzcei2xcrp7mjf4ccspa62y
   build/MechMarketplace.json: bafybeiauqsmm5aqqzqqr7vi46obq7exa7id5vbq57e3e3wxxkzblgqnjoy
-  contract.py: bafybeihecvdkxkeebiwattzrsnzctopetlgqd2vyiyca7qheeqyiww7w4a
+  contract.py: bafybeia4wjdonluamlhls6nymvx4tkxefgouiom4yyjtxvb6sr55jngzmm
 fingerprint_ignore_patterns: []
 class_name: MechMarketplaceContract
 contract_interface_paths:

--- a/packages/valory/contracts/mech_marketplace/contract.yaml
+++ b/packages/valory/contracts/mech_marketplace/contract.yaml
@@ -24,4 +24,5 @@ dependencies:
   eth-utils:
     version: ==2.2.0
   hexbytes: {}
+  eth_typing: {}
 contracts: []

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeie6lucimqu4k22hfth5fjnpuyhe7v7kor3ak2tfnrfwlg5jaioplm
+agent: valory/mech:0.1.0:bafybeiesbbt467twifwjvoa5kay54y7tiizevvuaybqhmhtgvtjswer2t4
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeib3gh6mpkrj4hajasevz3fksqfx2tgmfdbupehcgc3pq26oouxof4
+agent: valory/mech:0.1.0:bafybeiftjhemjjnxmvppzmm5tnpmal5hg6rpczbs27ny6hw3z6ersa7bja
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeib6hj6zsvmggbsq5t3ca3cjmnv4hapkxazrpt72262qc6bobcb3za
+agent: valory/mech:0.1.0:bafybeie6lucimqu4k22hfth5fjnpuyhe7v7kor3ak2tfnrfwlg5jaioplm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiftjhemjjnxmvppzmm5tnpmal5hg6rpczbs27ny6hw3z6ersa7bja
+agent: valory/mech:0.1.0:bafybeib6hj6zsvmggbsq5t3ca3cjmnv4hapkxazrpt72262qc6bobcb3za
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/delivery_rate_abci/skill.yaml
+++ b/packages/valory/skills/delivery_rate_abci/skill.yaml
@@ -18,7 +18,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
+- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 protocols:

--- a/packages/valory/skills/delivery_rate_abci/skill.yaml
+++ b/packages/valory/skills/delivery_rate_abci/skill.yaml
@@ -18,7 +18,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
+- valory/agent_mech:0.1.0:bafybeibjlxgwwqodubwy3mhstnjqjsyat4ray32xgkkv5adysjwz5mzcau
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 protocols:

--- a/packages/valory/skills/delivery_rate_abci/skill.yaml
+++ b/packages/valory/skills/delivery_rate_abci/skill.yaml
@@ -18,7 +18,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeigs3jle7n57sqwdnwi2egfia6ingt7wxhzykft7ssasjj26ig32xi
+- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 protocols:

--- a/packages/valory/skills/delivery_rate_abci/skill.yaml
+++ b/packages/valory/skills/delivery_rate_abci/skill.yaml
@@ -18,7 +18,7 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
+- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
 protocols:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -23,10 +23,10 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/task_submission_abci:0.1.0:bafybeidnkudjprawobejyyc72eiqluoih5hxqstnu6hyautackmcqmavhe
+- valory/task_submission_abci:0.1.0:bafybeib2v5zeeu4cwnxt37avxysdxgqh4gmotcvz6wthepqnvupafbpy7e
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/delivery_rate_abci:0.1.0:bafybeiayuegt6f4vvbcc3x7anshe52byswvcohlot4ktnv7zrnvdsysxfe
+- valory/delivery_rate_abci:0.1.0:bafybeiakedzpbl2v4ajpovpzrgpigwbzfqlwjyuucvexs2kckhlh7x3mce
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -23,10 +23,10 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/task_submission_abci:0.1.0:bafybeibxfn6yqdpc36jxv7ht45tpu26rtzq72nywej2o3ybivx7lx7fprq
+- valory/task_submission_abci:0.1.0:bafybeif6pjl2av5fhwt5o6wwdoduiokleu3tqtomjq5yog43m75m453kei
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/delivery_rate_abci:0.1.0:bafybeifs6pjhm6474dpdkfoyqnbjx3npdganwk5unsg4vgjiohcjp57mhi
+- valory/delivery_rate_abci:0.1.0:bafybeihptz72mjmlunudw6slhoyfkl5lz3f4m4fjb4jvkf7husjclxmsp4
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -23,10 +23,10 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/task_submission_abci:0.1.0:bafybeif6pjl2av5fhwt5o6wwdoduiokleu3tqtomjq5yog43m75m453kei
+- valory/task_submission_abci:0.1.0:bafybeidnkudjprawobejyyc72eiqluoih5hxqstnu6hyautackmcqmavhe
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/delivery_rate_abci:0.1.0:bafybeihptz72mjmlunudw6slhoyfkl5lz3f4m4fjb4jvkf7husjclxmsp4
+- valory/delivery_rate_abci:0.1.0:bafybeiayuegt6f4vvbcc3x7anshe52byswvcohlot4ktnv7zrnvdsysxfe
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -23,10 +23,10 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/registration_abci:0.1.0:bafybeigp2g6uhhgjlkqyhjlk4abfjuecmulnwlki6acbpfu45thslqujlu
 - valory/reset_pause_abci:0.1.0:bafybeidhqvc4cl6alvkql5kadiv7snudl7o2ctfqbmhrihtejm3zhkmbby
-- valory/task_submission_abci:0.1.0:bafybeifwqqfhlpnrzyu4u4jzdnaecdnkphshv7zqz6mtua77frj6clrmbq
+- valory/task_submission_abci:0.1.0:bafybeibxfn6yqdpc36jxv7ht45tpu26rtzq72nywej2o3ybivx7lx7fprq
 - valory/termination_abci:0.1.0:bafybeig4stz7s6phndruvrgqptbc62ue2filttj4wbnempkur5ybso5edu
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/delivery_rate_abci:0.1.0:bafybeifa2gmumovmta3tkjcgref6347ubml54o3g64vymeolodcjuh2zoq
+- valory/delivery_rate_abci:0.1.0:bafybeifs6pjhm6474dpdkfoyqnbjx3npdganwk5unsg4vgjiohcjp57mhi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -23,7 +23,7 @@ connections:
 - valory/ipfs:0.1.0:bafybeigjspoceazd5roxo4pcqcgyu3ozixkdoc44domwcaumt2zwoz2x3m
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 contracts:
-- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
+- valory/agent_mech:0.1.0:bafybeibjlxgwwqodubwy3mhstnjqjsyat4ray32xgkkv5adysjwz5mzcau
 protocols:
 - valory/acn_data_share:0.1.0:bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq
 - valory/contract_api:1.0.0:bafybeid247uig2ekykdumh7ewhp2cdq7rchaeqjj6e7urx35zfpdl5zrn4

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -23,7 +23,7 @@ connections:
 - valory/ipfs:0.1.0:bafybeigjspoceazd5roxo4pcqcgyu3ozixkdoc44domwcaumt2zwoz2x3m
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 contracts:
-- valory/agent_mech:0.1.0:bafybeigs3jle7n57sqwdnwi2egfia6ingt7wxhzykft7ssasjj26ig32xi
+- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
 protocols:
 - valory/acn_data_share:0.1.0:bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq
 - valory/contract_api:1.0.0:bafybeid247uig2ekykdumh7ewhp2cdq7rchaeqjj6e7urx35zfpdl5zrn4

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -23,7 +23,7 @@ connections:
 - valory/ipfs:0.1.0:bafybeigjspoceazd5roxo4pcqcgyu3ozixkdoc44domwcaumt2zwoz2x3m
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 contracts:
-- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
+- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
 protocols:
 - valory/acn_data_share:0.1.0:bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq
 - valory/contract_api:1.0.0:bafybeid247uig2ekykdumh7ewhp2cdq7rchaeqjj6e7urx35zfpdl5zrn4

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -23,7 +23,7 @@ connections:
 - valory/ipfs:0.1.0:bafybeigjspoceazd5roxo4pcqcgyu3ozixkdoc44domwcaumt2zwoz2x3m
 - valory/p2p_libp2p_client:0.1.0:bafybeic6ayusdwy4dks75njwk32ac7ur7salgllwf4fdc34ue5z2k5iz4q
 contracts:
-- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
+- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
 protocols:
 - valory/acn_data_share:0.1.0:bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq
 - valory/contract_api:1.0.0:bafybeid247uig2ekykdumh7ewhp2cdq7rchaeqjj6e7urx35zfpdl5zrn4

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -19,8 +19,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeigs3jle7n57sqwdnwi2egfia6ingt7wxhzykft7ssasjj26ig32xi
-- valory/mech_marketplace:0.1.0:bafybeic7xtjx7a6i2h6apxjaupezqsxlhidsnvnasv6ms3rlekn7vorkgi
+- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
+- valory/mech_marketplace:0.1.0:bafybeicsfg2kc2m4ffhrjkxxylq5pstl2tdevxzgwp45u6n7465tennet4
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
@@ -34,7 +34,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/task_execution:0.1.0:bafybeiegmmap2vsoqwcjic746gxfypwah533tk6wjd6lpyt4bo2uxyu3hm
+- valory/task_execution:0.1.0:bafybeicknvidmx5v3rhc5yee6dptzrskvxlhyhqyne6r5gqv4nclwanltq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -19,8 +19,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeieq6e545yf74uhndg4isnvifj6zona42ejxu6uqgswy66zxkno6lm
-- valory/mech_marketplace:0.1.0:bafybeicsfg2kc2m4ffhrjkxxylq5pstl2tdevxzgwp45u6n7465tennet4
+- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
+- valory/mech_marketplace:0.1.0:bafybeidisebfdbrjxjscpskuw6uq4r6fdzxsgr5fhnxa5xvxhflfge653u
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
@@ -34,7 +34,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/task_execution:0.1.0:bafybeicknvidmx5v3rhc5yee6dptzrskvxlhyhqyne6r5gqv4nclwanltq
+- valory/task_execution:0.1.0:bafybeicmpxhzj3hj5ces5f34gibxin5vpvztufy74za4vsliwocj2b7mde
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -19,8 +19,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeienzimzl37bggnabeluarp2cpaqbnmij7ppn5scd7e7h42gpzsw2u
-- valory/mech_marketplace:0.1.0:bafybeidisebfdbrjxjscpskuw6uq4r6fdzxsgr5fhnxa5xvxhflfge653u
+- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
+- valory/mech_marketplace:0.1.0:bafybeifjforrarhg4mksmesr6pkbcotbqfsxtbuidqjypensprshlwfpza
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
@@ -34,7 +34,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/task_execution:0.1.0:bafybeicmpxhzj3hj5ces5f34gibxin5vpvztufy74za4vsliwocj2b7mde
+- valory/task_execution:0.1.0:bafybeiemosyhfcalxk5nlmgw5godpg2vcsdw22retk4b4ipw7t7agj5wxm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -19,8 +19,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/agent_mech:0.1.0:bafybeice6dztz4e23vjbwebx2nzkibrnpromnlowdnobeq7ya7nvfidu34
-- valory/mech_marketplace:0.1.0:bafybeifjforrarhg4mksmesr6pkbcotbqfsxtbuidqjypensprshlwfpza
+- valory/agent_mech:0.1.0:bafybeibjlxgwwqodubwy3mhstnjqjsyat4ray32xgkkv5adysjwz5mzcau
+- valory/mech_marketplace:0.1.0:bafybeicx4aw7kbp4zxbdsafshkagzb53ji5m2ak537on2ryrzpnoxs2jkq
 - valory/agent_registry:0.1.0:bafybeiarzhzs2wm2sl47qg37tqoc3qok54enxlcj6vx3hldozg537uslnq
 - valory/gnosis_safe:0.1.0:bafybeidw3uxuxyp3lso5mh43nhauzvra4jabnuk34bkqd6mrv4ojz37nui
 - valory/multisend:0.1.0:bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y
@@ -34,7 +34,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiba3zhx5drsf7ailfboeuvwykocmkffs2j426u4q7d4erig67lyhm
 - valory/transaction_settlement_abci:0.1.0:bafybeicvfbyp4lfqcohmvw6ozlvsbp2eugl2wxqxsdpp36ro7bk3waxjky
-- valory/task_execution:0.1.0:bafybeiemosyhfcalxk5nlmgw5godpg2vcsdw22retk4b4ipw7t7agj5wxm
+- valory/task_execution:0.1.0:bafybeigbueebww7nbja5jo3x7o3524e26hhfnmvxrprpbmnvjffcxm7k54
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Proposed changes

Replaces filtering operations with simple logs retrieval.

The problem with using eth_newFilter is that we are creating filters that are stored in the memory of the RPC node, causing issues on the providers' side.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...