### PR TITLE
Fix/attack surface hardening

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty",
-        "skill/valory/mech_abci/0.1.0": "bafybeieqqsopesprm2xvyhyawwnz2qwplwqyuaqu6nzwmaps524ieh5mja",
-        "skill/valory/task_execution/0.1.0": "bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihxp4jhz4r2ant3d6hj5izcs7h3zkbkfwgajxfzvaubzv6vntva3e",
+        "skill/valory/mech_abci/0.1.0": "bafybeih54mcn5pp2uanbkurgd5vnk2paky6z7plfe6ygl24dyvtc4ipryy",
+        "skill/valory/task_execution/0.1.0": "bafybeig7pzey3umn2uub6gkafnam5znwic4skziyp2l5wcqcp2xmljcwde",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeig27jre4yhwyugi6mynm3bv5b5t3nba34amyebeatyd44ozdxesbq",
         "skill/valory/websocket_client/0.1.0": "bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu",
-        "agent/valory/mech/0.1.0": "bafybeidrfivkhnip3kfd2i6dxfgmidqyriualayarnjrdv7x3v3u26lcxu",
-        "service/valory/mech/0.1.0": "bafybeief4vqbogw6yvud2emtrzkpp3exslnzqjdqsb5vu5d4ygbo2axsse"
+        "agent/valory/mech/0.1.0": "bafybeidzvn54rfjub3od4xmotfu7qbsgjd5snp367mitlv6zkpeihulubi",
+        "service/valory/mech/0.1.0": "bafybeidxaovlb7ph6ula36dqe7vezgi5vgqeebuiza7ldy65maoxz62xqi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty",
-        "skill/valory/mech_abci/0.1.0": "bafybeibi5cktlpek374i65ldudcqw7d2v7ueofgxzd2giapotd6fziqtma",
-        "skill/valory/task_execution/0.1.0": "bafybeiauyj3eaz6ek7ua7qvhsv7j6sgw2z4ct3dff37mlflcfq4o2nhapq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiaiuy4q5c27kbibwaqpp2ls4q7l2snctrej55fbu7wtgl2dod5wwu",
+        "skill/valory/mech_abci/0.1.0": "bafybeieqqsopesprm2xvyhyawwnz2qwplwqyuaqu6nzwmaps524ieh5mja",
+        "skill/valory/task_execution/0.1.0": "bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihxp4jhz4r2ant3d6hj5izcs7h3zkbkfwgajxfzvaubzv6vntva3e",
         "skill/valory/websocket_client/0.1.0": "bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu",
-        "agent/valory/mech/0.1.0": "bafybeify5v3p53udxryaixn3smyxn2cv5ejry265dvr4enrthzef2cjoji",
-        "service/valory/mech/0.1.0": "bafybeihdokd75bv6cvgislo2dye2ozs7gwa7dfwjchclqj5hto3bl4m3ha"
+        "agent/valory/mech/0.1.0": "bafybeidrfivkhnip3kfd2i6dxfgmidqyriualayarnjrdv7x3v3u26lcxu",
+        "service/valory/mech/0.1.0": "bafybeief4vqbogw6yvud2emtrzkpp3exslnzqjdqsb5vu5d4ygbo2axsse"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeict6h3wfmddpvam5gmmanqzuokup6ppoev3t4j5uyl7xxahjaols4
 - valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/contract_subscription:0.1.0:bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem
-- valory/mech_abci:0.1.0:bafybeieqqsopesprm2xvyhyawwnz2qwplwqyuaqu6nzwmaps524ieh5mja
+- valory/mech_abci:0.1.0:bafybeih54mcn5pp2uanbkurgd5vnk2paky6z7plfe6ygl24dyvtc4ipryy
 - valory/registration_abci:0.1.0:bafybeif3gpewppz5wr5mmgyvaowsamjufyons3oif7cb4x5ubvvfb6rtda
 - valory/reset_pause_abci:0.1.0:bafybeidcnf77bc3o7pssa5zesilpbm4ley2k45taii5j5rrvvty7uhu3lq
 - valory/delivery_rate_abci:0.1.0:bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty
-- valory/task_execution:0.1.0:bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy
-- valory/task_submission_abci:0.1.0:bafybeihxp4jhz4r2ant3d6hj5izcs7h3zkbkfwgajxfzvaubzv6vntva3e
+- valory/task_execution:0.1.0:bafybeig7pzey3umn2uub6gkafnam5znwic4skziyp2l5wcqcp2xmljcwde
+- valory/task_submission_abci:0.1.0:bafybeig27jre4yhwyugi6mynm3bv5b5t3nba34amyebeatyd44ozdxesbq
 - valory/termination_abci:0.1.0:bafybeia33hlouukdpwaxctunauudv5gpfdxndimra7yqiof4a3skcwdqkq
 - valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
 - valory/websocket_client:0.1.0:bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeict6h3wfmddpvam5gmmanqzuokup6ppoev3t4j5uyl7xxahjaols4
 - valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/contract_subscription:0.1.0:bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem
-- valory/mech_abci:0.1.0:bafybeibi5cktlpek374i65ldudcqw7d2v7ueofgxzd2giapotd6fziqtma
+- valory/mech_abci:0.1.0:bafybeieqqsopesprm2xvyhyawwnz2qwplwqyuaqu6nzwmaps524ieh5mja
 - valory/registration_abci:0.1.0:bafybeif3gpewppz5wr5mmgyvaowsamjufyons3oif7cb4x5ubvvfb6rtda
 - valory/reset_pause_abci:0.1.0:bafybeidcnf77bc3o7pssa5zesilpbm4ley2k45taii5j5rrvvty7uhu3lq
 - valory/delivery_rate_abci:0.1.0:bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty
-- valory/task_execution:0.1.0:bafybeiauyj3eaz6ek7ua7qvhsv7j6sgw2z4ct3dff37mlflcfq4o2nhapq
-- valory/task_submission_abci:0.1.0:bafybeiaiuy4q5c27kbibwaqpp2ls4q7l2snctrej55fbu7wtgl2dod5wwu
+- valory/task_execution:0.1.0:bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy
+- valory/task_submission_abci:0.1.0:bafybeihxp4jhz4r2ant3d6hj5izcs7h3zkbkfwgajxfzvaubzv6vntva3e
 - valory/termination_abci:0.1.0:bafybeia33hlouukdpwaxctunauudv5gpfdxndimra7yqiof4a3skcwdqkq
 - valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
 - valory/websocket_client:0.1.0:bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeify5v3p53udxryaixn3smyxn2cv5ejry265dvr4enrthzef2cjoji
+agent: valory/mech:0.1.0:bafybeidrfivkhnip3kfd2i6dxfgmidqyriualayarnjrdv7x3v3u26lcxu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidrfivkhnip3kfd2i6dxfgmidqyriualayarnjrdv7x3v3u26lcxu
+agent: valory/mech:0.1.0:bafybeidzvn54rfjub3od4xmotfu7qbsgjd5snp367mitlv6zkpeihulubi
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/registration_abci:0.1.0:bafybeif3gpewppz5wr5mmgyvaowsamjufyons3oif7cb4x5ubvvfb6rtda
 - valory/reset_pause_abci:0.1.0:bafybeidcnf77bc3o7pssa5zesilpbm4ley2k45taii5j5rrvvty7uhu3lq
-- valory/task_submission_abci:0.1.0:bafybeihxp4jhz4r2ant3d6hj5izcs7h3zkbkfwgajxfzvaubzv6vntva3e
+- valory/task_submission_abci:0.1.0:bafybeig27jre4yhwyugi6mynm3bv5b5t3nba34amyebeatyd44ozdxesbq
 - valory/termination_abci:0.1.0:bafybeia33hlouukdpwaxctunauudv5gpfdxndimra7yqiof4a3skcwdqkq
 - valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
 - valory/delivery_rate_abci:0.1.0:bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty
-- valory/task_execution:0.1.0:bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy
+- valory/task_execution:0.1.0:bafybeig7pzey3umn2uub6gkafnam5znwic4skziyp2l5wcqcp2xmljcwde
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/registration_abci:0.1.0:bafybeif3gpewppz5wr5mmgyvaowsamjufyons3oif7cb4x5ubvvfb6rtda
 - valory/reset_pause_abci:0.1.0:bafybeidcnf77bc3o7pssa5zesilpbm4ley2k45taii5j5rrvvty7uhu3lq
-- valory/task_submission_abci:0.1.0:bafybeiaiuy4q5c27kbibwaqpp2ls4q7l2snctrej55fbu7wtgl2dod5wwu
+- valory/task_submission_abci:0.1.0:bafybeihxp4jhz4r2ant3d6hj5izcs7h3zkbkfwgajxfzvaubzv6vntva3e
 - valory/termination_abci:0.1.0:bafybeia33hlouukdpwaxctunauudv5gpfdxndimra7yqiof4a3skcwdqkq
 - valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
 - valory/delivery_rate_abci:0.1.0:bafybeifpoqkcdwpyq4lijumyt3gzj3vs3pfxxm4xefqxagd4b5pg6x3vty
-- valory/task_execution:0.1.0:bafybeiauyj3eaz6ek7ua7qvhsv7j6sgw2z4ct3dff37mlflcfq4o2nhapq
+- valory/task_execution:0.1.0:bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -83,6 +83,7 @@ SUBSEQUENT_DEADLINE = 300.0  # 5min of deadline
 STATUS_CHECK_INTERVAL = 600.0  # 10min interval
 RESPONSE_SCHEMA_VERSION = "2.0"
 IPFS_MAX_TASK_BYTES = 1_048_576  # 1MB cap on attacker-controlled task payload
+MAX_PROMPT_BYTES = 100_000  # 100KB cap on the prompt field
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -988,13 +989,22 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         is_data_valid = (
             task_data
             and isinstance(task_data, dict)
-            and "prompt" in task_data
-            and "tool" in task_data
+            and isinstance(task_data.get("prompt"), str)
+            and isinstance(task_data.get("tool"), str)
         )  # pylint: disable=C0301
 
         executing_task = cast(Dict[str, Any], self._executing_task)
         if not is_data_valid:
             self.context.logger.warning(f"Invalid {task_data=} for {executing_task=}.")
+            self._invalid_request = True
+            return
+
+        prompt_bytes = len(task_data["prompt"].encode("utf-8", errors="replace"))
+        if prompt_bytes > MAX_PROMPT_BYTES:
+            self.context.logger.warning(
+                f"Prompt for request {req_id} is {prompt_bytes} bytes, "
+                f"exceeds cap of {MAX_PROMPT_BYTES}. Skipping request."
+            )
             self._invalid_request = True
             return
 

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -82,6 +82,7 @@ INITIAL_DEADLINE = 1200.0  # 20mins of deadline
 SUBSEQUENT_DEADLINE = 300.0  # 5min of deadline
 STATUS_CHECK_INTERVAL = 600.0  # 10min interval
 RESPONSE_SCHEMA_VERSION = "2.0"
+IPFS_MAX_TASK_BYTES = 1_048_576  # 1MB cap on attacker-controlled task payload
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -952,6 +953,25 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._async_result = None
             self._request_handling_deadline = None
             self.tool_preparation_start_time = 0.0
+            return
+
+        executing_task = cast(Dict[str, Any], self._executing_task)
+        req_id = executing_task.get("requestId", "unknown")
+        total_bytes = sum(
+            (
+                len(content)
+                if isinstance(content, (bytes, bytearray))
+                else len(content.encode("utf-8", errors="replace"))
+            )
+            for content in message.files.values()
+        )
+        if total_bytes > IPFS_MAX_TASK_BYTES:
+            self.context.logger.warning(
+                f"IPFS task payload for request {req_id} is "
+                f"{total_bytes} bytes, exceeds cap of {IPFS_MAX_TASK_BYTES}. "
+                f"Skipping request."
+            )
+            self._invalid_request = True
             return
 
         try:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -84,6 +84,7 @@ STATUS_CHECK_INTERVAL = 600.0  # 10min interval
 RESPONSE_SCHEMA_VERSION = "2.0"
 IPFS_MAX_TASK_BYTES = 1_048_576  # 1MB cap on attacker-controlled task payload
 MAX_PROMPT_BYTES = 100_000  # 100KB cap on the prompt field
+PAYMENT_MODEL_REQUEST_TIMEOUT = 60.0  # reset stuck payment-model in_flight_req
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -203,6 +204,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         self._async_result: Optional[Future] = None
         self._keychain: Optional[KeyChain] = None
         self._ignored_request_ids: Set[int] = set()
+        self._payment_model_request_sent_at: Optional[float] = None
         # We fetch the requests and their status on the startup so this should be fairly accurate
         self.last_status_check_time: float = time.time()
         self.tool_preparation_start_time: float = 0.0
@@ -228,6 +230,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         )
         self.context.outbox.put_message(message=contract_api_msg)
         self.params.in_flight_req = True
+        self._payment_model_request_sent_at = time.time()
 
     def setup(self) -> None:
         """Implement the setup."""
@@ -241,11 +244,24 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         if not self.params.use_mech_marketplace:
             return True
 
-        if self.params.in_flight_req:
-            return False
-
         if self.payment_model:
+            self._payment_model_request_sent_at = None
             return True
+
+        if self.params.in_flight_req:
+            sent_at = self._payment_model_request_sent_at
+            if (
+                sent_at is not None
+                and time.time() - sent_at > PAYMENT_MODEL_REQUEST_TIMEOUT
+            ):
+                self.context.logger.warning(
+                    f"Payment-model request has been in flight for "
+                    f">{PAYMENT_MODEL_REQUEST_TIMEOUT}s with no response. "
+                    f"Resetting in_flight_req so it can be retried."
+                )
+                self.params.in_flight_req = False
+                self._payment_model_request_sent_at = None
+            return False
 
         self.context.logger.info("Setting the mech's payment model...")
         self._request_payment_model()

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -978,7 +978,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             (
                 len(content)
                 if isinstance(content, (bytes, bytearray))
-                else len(content.encode("utf-8", errors="replace"))
+                else len(content.encode("utf-8"))
             )
             for content in message.files.values()
         )
@@ -994,8 +994,6 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         try:
             task_data = [json.loads(content) for content in message.files.values()][0]
         except (json.JSONDecodeError, IndexError, TypeError, UnicodeDecodeError) as e:
-            executing_task = cast(Dict[str, Any], self._executing_task)
-            req_id = executing_task.get("requestId", "unknown")
             self.context.logger.warning(
                 f"Malformed IPFS content for request {req_id}: {e}. "
                 f"Skipping request."
@@ -1009,13 +1007,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             and isinstance(task_data.get("tool"), str)
         )  # pylint: disable=C0301
 
-        executing_task = cast(Dict[str, Any], self._executing_task)
         if not is_data_valid:
             self.context.logger.warning(f"Invalid {task_data=} for {executing_task=}.")
             self._invalid_request = True
             return
 
-        prompt_bytes = len(task_data["prompt"].encode("utf-8", errors="replace"))
+        prompt_bytes = len(task_data["prompt"].encode("utf-8"))
         if prompt_bytes > MAX_PROMPT_BYTES:
             self.context.logger.warning(
                 f"Prompt for request {req_id} is {prompt_bytes} bytes, "

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -75,6 +75,8 @@ PROMETHEUS_PORT = 9000
 
 # Off-chain HTTP hardening
 MAX_HTTP_BODY_BYTES = 1_048_576  # 1MB cap on inbound HTTP bodies
+MIN_DELIVERY_RATE = 0  # 0 allowed for free tasks; rejects only negatives
+MAX_DELIVERY_RATE = 2**256 - 1  # uint256 upper bound
 IPFS_HASH_RE = re.compile(r"^0x[0-9a-fA-F]+$")
 # 0x + 32-byte (64 hex) or 34-byte multihash (68 hex) payload
 VALID_IPFS_HASH_LENGTHS = (66, 70)
@@ -593,6 +595,18 @@ class MechHttpHandler(AbstractResponseHandler):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id}: invalid ipfs_hash "
                 f"format (len={len(ipfs_hash)})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+
+        if (
+            request_delivery_rate < MIN_DELIVERY_RATE
+            or request_delivery_rate > MAX_DELIVERY_RATE
+        ):
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id}: "
+                f"request_delivery_rate={request_delivery_rate} out of range "
+                f"[{MIN_DELIVERY_RATE}, {MAX_DELIVERY_RATE}]."
             )
             self._handle_bad_request(http_msg, http_dialogue)
             return

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -20,6 +20,7 @@
 """This package contains a scaffold of a handler."""
 
 import json
+import re
 import threading
 import time
 import urllib.parse
@@ -71,6 +72,12 @@ TIMED_OUT_STATUS = 2
 WAIT_FOR_TIMEOUT_STATUS = 1
 DELIVERED_STATUS = 3
 PROMETHEUS_PORT = 9000
+
+# Off-chain HTTP hardening
+MAX_HTTP_BODY_BYTES = 1_048_576  # 1MB cap on inbound HTTP bodies
+IPFS_HASH_RE = re.compile(r"^0x[0-9a-fA-F]+$")
+# 0x + 32-byte (64 hex) or 34-byte multihash (68 hex) payload
+VALID_IPFS_HASH_LENGTHS = (66, 70)
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -574,7 +581,18 @@ class MechHttpHandler(AbstractResponseHandler):
             request_delivery_rate = int(data[RequestKey.DELIVERY_RATE.value])
         except Exception as e:
             self.context.logger.error(
-                f"Error processing signed request. body={http_msg.body!r} error={str(e)}."
+                f"Error processing signed request. body_len={len(http_msg.body)} "
+                f"error={str(e)}."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+
+        if len(ipfs_hash) not in VALID_IPFS_HASH_LENGTHS or not IPFS_HASH_RE.match(
+            ipfs_hash
+        ):
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id}: invalid ipfs_hash "
+                f"format (len={len(ipfs_hash)})."
             )
             self._handle_bad_request(http_msg, http_dialogue)
             return
@@ -770,7 +788,13 @@ class MechHttpHandler(AbstractResponseHandler):
 
     def _parse_http_body(self, http_msg: HttpMessage) -> Dict[str, str]:
         """Parse form-urlencoded HTTP body into a flat key-value dictionary."""
-        request_data = http_msg.body.decode(ENCODING_UTF8)
+        body = http_msg.body
+        if len(body) > MAX_HTTP_BODY_BYTES:
+            raise ValueError(
+                f"HTTP body is {len(body)} bytes, exceeds cap of "
+                f"{MAX_HTTP_BODY_BYTES}"
+            )
+        request_data = body.decode(ENCODING_UTF8)
         parsed_data = urllib.parse.parse_qs(request_data)
         return {key: value[0] for key, value in parsed_data.items()}
 

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -77,9 +77,8 @@ PROMETHEUS_PORT = 9000
 MAX_HTTP_BODY_BYTES = 1_048_576  # 1MB cap on inbound HTTP bodies
 MIN_DELIVERY_RATE = 0  # 0 allowed for free tasks; rejects only negatives
 MAX_DELIVERY_RATE = 2**256 - 1  # uint256 upper bound
-IPFS_HASH_RE = re.compile(r"^0x[0-9a-fA-F]+$")
 # 0x + 32-byte (64 hex) or 34-byte multihash (68 hex) payload
-VALID_IPFS_HASH_LENGTHS = (66, 70)
+IPFS_HASH_RE = re.compile(r"^0x([0-9a-fA-F]{64}|[0-9a-fA-F]{68})$")
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -589,9 +588,7 @@ class MechHttpHandler(AbstractResponseHandler):
             self._handle_bad_request(http_msg, http_dialogue)
             return
 
-        if len(ipfs_hash) not in VALID_IPFS_HASH_LENGTHS or not IPFS_HASH_RE.match(
-            ipfs_hash
-        ):
+        if not IPFS_HASH_RE.match(ipfs_hash):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id}: invalid ipfs_hash "
                 f"format (len={len(ipfs_hash)})."

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,15 +7,15 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeic4ojrjeknvkl54xiheez3kpvgvxxle4gf6bj22mg5ev3rfyiam6i
+  behaviours.py: bafybeiargkth77lnnjkvoqwz5kr7pid2twuqiu75vall3nneqysbi2ucta
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
-  handlers.py: bafybeibc6dkgardlgfsdza5vkzd6ipinvc22g47yniw3nblxucr32xfor4
+  handlers.py: bafybeie34re2eb5h5qpkvw4jgnmbofbgv4eoixdrhowjta32lahjudxoym
   models.py: bafybeigeczmmo5m4a5hwkubh2ulq2i2lod7jvbmmsaua7atskeq2hyy4bm
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeib43nrx6rozfp5ez3dkevy2qzj2yclzs7kmlnqnowd3mhfhqxvxsi
-  tests/test_behaviours.py: bafybeiesfht4xizgwunf6rpuyktvsujvfkrxz63gy4c55e3k77emkyg37y
+  tests/test_behaviours.py: bafybeifs24xoybnhkhixxghqidy6dmyvo36gendnvucrv6sobtxo6drwwi
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeihgqnoyuys7hpoaz7c42idekitguv7sdjwguhs5zwainpao5a4zyi
+  tests/test_handlers.py: bafybeigslk2cmfc67sf2lksqhnsjvfkxmzrm2ymhqlj2eueal6hixw64si
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeiargkth77lnnjkvoqwz5kr7pid2twuqiu75vall3nneqysbi2ucta
+  behaviours.py: bafybeif32p44hyyrjppyrwycaftco33izxcc2imj2l3yzn5c2qyodj774i
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
-  handlers.py: bafybeie34re2eb5h5qpkvw4jgnmbofbgv4eoixdrhowjta32lahjudxoym
+  handlers.py: bafybeid5xyeunhbuccsylmw2xh3sjhgzmkrqtemohbehwhcpuyxbfosnda
   models.py: bafybeigeczmmo5m4a5hwkubh2ulq2i2lod7jvbmmsaua7atskeq2hyy4bm
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeib43nrx6rozfp5ez3dkevy2qzj2yclzs7kmlnqnowd3mhfhqxvxsi
-  tests/test_behaviours.py: bafybeifs24xoybnhkhixxghqidy6dmyvo36gendnvucrv6sobtxo6drwwi
+  tests/test_behaviours.py: bafybeibp3yojr6y77e3mksrbelqeog6qifdpcrdo4bqduk4gpg42us2kba
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeigslk2cmfc67sf2lksqhnsjvfkxmzrm2ymhqlj2eueal6hixw64si
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -2624,3 +2624,54 @@ def test_handle_get_task_rejects_prompt_over_cap(
 
     assert behaviour._invalid_request is True
     assert mech_lookup_calls == [], "prompt cap did not gate the happy path"
+
+
+# ---------------------------------------------------------------------------
+# Payment-model request deadline
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_payment_model_resets_stuck_inflight_request(
+    behaviour: Any, params_stub: Any
+) -> None:
+    """Stale payment-model in_flight_req is cleared after PAYMENT_MODEL_REQUEST_TIMEOUT."""
+    params_stub.use_mech_marketplace = True
+    params_stub.in_flight_req = True
+    behaviour._payment_model_request_sent_at = (
+        time.time() - beh_mod.PAYMENT_MODEL_REQUEST_TIMEOUT - 1.0
+    )
+
+    result = behaviour._ensure_payment_model()
+
+    assert result is False
+    assert params_stub.in_flight_req is False
+    assert behaviour._payment_model_request_sent_at is None
+
+
+def test_ensure_payment_model_does_not_reset_fresh_inflight_request(
+    behaviour: Any, params_stub: Any
+) -> None:
+    """Fresh payment-model request is not reset before the timeout elapses."""
+    params_stub.use_mech_marketplace = True
+    params_stub.in_flight_req = True
+    behaviour._payment_model_request_sent_at = time.time()
+
+    result = behaviour._ensure_payment_model()
+
+    assert result is False
+    assert params_stub.in_flight_req is True
+    assert behaviour._payment_model_request_sent_at is not None
+
+
+def test_ensure_payment_model_does_not_reset_inflight_from_other_flow(
+    behaviour: Any, params_stub: Any
+) -> None:
+    """When no payment-model timestamp exists, in_flight_req is not tampered with."""
+    params_stub.use_mech_marketplace = True
+    params_stub.in_flight_req = True
+    behaviour._payment_model_request_sent_at = None
+
+    result = behaviour._ensure_payment_model()
+
+    assert result is False
+    assert params_stub.in_flight_req is True

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -2528,3 +2528,35 @@ def test_valid_32_byte_data_still_works(
     assert behaviour._invalid_request is False
     # IPFS get request should have been sent
     assert len(send_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# IPFS task payload size cap
+# ---------------------------------------------------------------------------
+
+
+def test_handle_get_task_rejects_oversized_ipfs_payload(
+    behaviour: Any, params_stub: Any, monkeypatch: Any
+) -> None:
+    """IPFS payload above cap is rejected before JSON parsing runs."""
+    behaviour._executing_task = {"requestId": 99}
+    behaviour._request_handling_deadline = None
+    behaviour._invalid_request = False
+
+    padding = "x" * (beh_mod.IPFS_MAX_TASK_BYTES + 1)
+    payload = json.dumps({"prompt": padding, "tool": "sum"})
+    msg = SimpleNamespace(files={"task.json": payload})
+
+    loads_calls: list = []
+    original_loads = beh_mod.json.loads
+
+    def spy_loads(*args: Any, **kwargs: Any) -> Any:
+        loads_calls.append(args)
+        return original_loads(*args, **kwargs)
+
+    monkeypatch.setattr(beh_mod.json, "loads", spy_loads)
+
+    behaviour._handle_get_task(msg, MagicMock())
+
+    assert behaviour._invalid_request is True
+    assert loads_calls == [], "json.loads was called despite oversized payload"

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -2560,3 +2560,67 @@ def test_handle_get_task_rejects_oversized_ipfs_payload(
 
     assert behaviour._invalid_request is True
     assert loads_calls == [], "json.loads was called despite oversized payload"
+
+
+# ---------------------------------------------------------------------------
+# task_data prompt type and length validation
+# ---------------------------------------------------------------------------
+
+
+def _track_mech_lookup(calls: list) -> Callable[[], str]:
+    """Return a stub for _get_designated_marketplace_mech_address that records calls."""
+
+    def _lookup() -> str:
+        calls.append(True)
+        return "0xmech"
+
+    return _lookup
+
+
+def test_handle_get_task_rejects_non_string_prompt(
+    behaviour: Any, monkeypatch: Any
+) -> None:
+    """Non-string prompt is rejected before the designated-mech lookup runs."""
+    behaviour._executing_task = {"requestId": 7}
+    behaviour._request_handling_deadline = None
+    behaviour._invalid_request = False
+
+    mech_lookup_calls: list = []
+    monkeypatch.setattr(
+        behaviour,
+        "_get_designated_marketplace_mech_address",
+        _track_mech_lookup(mech_lookup_calls),
+    )
+
+    payload = json.dumps({"prompt": {"nested": "dict"}, "tool": "sum"})
+    msg = SimpleNamespace(files={"task.json": payload})
+
+    behaviour._handle_get_task(msg, MagicMock())
+
+    assert behaviour._invalid_request is True
+    assert mech_lookup_calls == [], "type check did not gate the happy path"
+
+
+def test_handle_get_task_rejects_prompt_over_cap(
+    behaviour: Any, monkeypatch: Any
+) -> None:
+    """Oversized prompt is rejected before the designated-mech lookup runs."""
+    behaviour._executing_task = {"requestId": 8}
+    behaviour._request_handling_deadline = None
+    behaviour._invalid_request = False
+
+    mech_lookup_calls: list = []
+    monkeypatch.setattr(
+        behaviour,
+        "_get_designated_marketplace_mech_address",
+        _track_mech_lookup(mech_lookup_calls),
+    )
+
+    huge_prompt = "A" * (beh_mod.MAX_PROMPT_BYTES + 1)
+    payload = json.dumps({"prompt": huge_prompt, "tool": "sum"})
+    msg = SimpleNamespace(files={"task.json": payload})
+
+    behaviour._handle_get_task(msg, MagicMock())
+
+    assert behaviour._invalid_request is True
+    assert mech_lookup_calls == [], "prompt cap did not gate the happy path"

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -2654,13 +2654,14 @@ def test_ensure_payment_model_does_not_reset_fresh_inflight_request(
     """Fresh payment-model request is not reset before the timeout elapses."""
     params_stub.use_mech_marketplace = True
     params_stub.in_flight_req = True
-    behaviour._payment_model_request_sent_at = time.time()
+    sent_at = time.time()
+    behaviour._payment_model_request_sent_at = sent_at
 
     result = behaviour._ensure_payment_model()
 
     assert result is False
     assert params_stub.in_flight_req is True
-    assert behaviour._payment_model_request_sent_at is not None
+    assert behaviour._payment_model_request_sent_at == sent_at
 
 
 def test_ensure_payment_model_does_not_reset_inflight_from_other_flow(

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -1662,3 +1662,52 @@ def test_signed_requests_rejects_invalid_ipfs_hash(
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
     assert handler_context.shared_state["pending_tasks"] == []
+
+
+@pytest.mark.parametrize(
+    "delivery_rate_str,case_id",
+    [
+        ("-1", "negative"),
+        (str(hmod.MAX_DELIVERY_RATE + 1), "above_uint256"),
+    ],
+)
+def test_signed_requests_rejects_out_of_range_delivery_rate(
+    handler_context: Any,
+    http_dialogue: Any,
+    monkeypatch: Any,
+    delivery_rate_str: str,
+    case_id: str,
+) -> None:
+    """Delivery rate outside [MIN_DELIVERY_RATE, MAX_DELIVERY_RATE] is rejected."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    _install_balance_ok(mh, monkeypatch)
+    mh.setup()
+
+    body = _make_signed_request_body(
+        delivery_rate=delivery_rate_str, request_id=f"req-{case_id}"
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_signed_requests_accepts_zero_delivery_rate(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """delivery_rate=0 is accepted so free off-chain tasks can be enqueued."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    _install_balance_ok(mh, monkeypatch)
+    mh.setup()
+
+    body = _make_signed_request_body(delivery_rate="0", request_id="req-zero-rate")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 1

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -412,7 +412,7 @@ def test_signed_requests_balance_scenarios(
     )
     mh.setup()
 
-    ipfs_hash: str = "0x" + "ab" * 64
+    ipfs_hash: str = "0x" + "ab" * 32
     body: Dict[str, str] = {
         "ipfs_hash": ipfs_hash,
         "request_id": request_id,
@@ -477,7 +477,7 @@ def test_fetch_offchain_request_info_returns_insufficient_balance_response(
     mh.setup()
 
     request_id = "req-insufficient-fetch"
-    ipfs_hash: str = "0x" + "ab" * 64
+    ipfs_hash: str = "0x" + "ab" * 32
     send_msg: Any = make_http_msg(
         {
             "ipfs_hash": ipfs_hash,
@@ -525,7 +525,7 @@ def test_signed_requests_rollback_partial_enqueue(
 
     handler_context.shared_state["ipfs_tasks"] = FailingList()
 
-    ipfs_hash: str = "0x" + "ab" * 64
+    ipfs_hash: str = "0x" + "ab" * 32
     body: Dict[str, str] = {
         "ipfs_hash": ipfs_hash,
         "request_id": "req-rollback",
@@ -1564,3 +1564,101 @@ def test_filter_requests_empty_list(
     ch.filter_requests([])
 
     assert len(ch.pending_tasks) == 0
+
+
+# ---------------------------------------------------------------------------
+# Offchain HTTP body cap and ipfs_hash format validation
+# ---------------------------------------------------------------------------
+
+
+def _make_signed_request_body(
+    ipfs_hash: str = "0x" + "ab" * 32,
+    delivery_rate: str = "123",
+    request_id: str = "req-hardening",
+) -> Dict[str, str]:
+    """Build a valid signed-request body used by hardening tests."""
+    return {
+        "ipfs_hash": ipfs_hash,
+        "request_id": request_id,
+        "ipfs_data": '{"foo":"bar"}',
+        "delivery_rate": delivery_rate,
+        "sender": "0x0000000000000000000000000000000000000001",
+    }
+
+
+def _install_balance_ok(mh: Any, monkeypatch: Any) -> None:
+    """Make _check_offchain_requester_balance return an OK, sufficient response."""
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: {
+            "status": "ok",
+            "required_amount": int(delivery_rate),
+            "available_amount": int(delivery_rate) + 1,
+            "reason": "ok",
+        },
+    )
+
+
+def test_signed_requests_rejects_oversized_http_body(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """HTTP body larger than MAX_HTTP_BODY_BYTES is rejected with 400 before decode."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    _install_balance_ok(mh, monkeypatch)
+    mh.setup()
+
+    padding_bytes = hmod.MAX_HTTP_BODY_BYTES + 1
+    base = _make_signed_request_body(request_id="req-oversized")
+    base["ipfs_data"] = '{"foo":"' + "x" * padding_bytes + '"}'
+    http_msg: Any = make_http_msg(base)
+    assert len(http_msg.body) > hmod.MAX_HTTP_BODY_BYTES
+
+    parse_calls: List[Any] = []
+    original_parse_qs = hmod.urllib.parse.parse_qs
+
+    def spy_parse_qs(*args: Any, **kwargs: Any) -> Any:
+        parse_calls.append(args)
+        return original_parse_qs(*args, **kwargs)
+
+    monkeypatch.setattr(hmod.urllib.parse, "parse_qs", spy_parse_qs)
+
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []
+    assert parse_calls == [], "parse_qs was called despite oversized body"
+
+
+@pytest.mark.parametrize(
+    "bad_hash,case_id",
+    [
+        ("0xabc", "too_short"),
+        ("0x" + "ab" * 33, "wrong_length_66_byte_hex"),
+        ("0x" + "ab" * 64, "far_too_long"),
+        ("ab" * 32, "missing_0x_prefix"),
+        ("0x" + "z" * 64, "non_hex_chars"),
+    ],
+)
+def test_signed_requests_rejects_invalid_ipfs_hash(
+    handler_context: Any,
+    http_dialogue: Any,
+    monkeypatch: Any,
+    bad_hash: str,
+    case_id: str,
+) -> None:
+    """Malformed ipfs_hash strings are rejected with 400, nothing enqueued."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    _install_balance_ok(mh, monkeypatch)
+    mh.setup()
+
+    body = _make_signed_request_body(ipfs_hash=bad_hash, request_id=f"req-{case_id}")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
-- valory/task_execution:0.1.0:bafybeiauyj3eaz6ek7ua7qvhsv7j6sgw2z4ct3dff37mlflcfq4o2nhapq
+- valory/task_execution:0.1.0:bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeihygetmlgnhawrbyswvpvv3wpztr2hlhxkljmohp4r7qcmvglpwdq
 - valory/transaction_settlement_abci:0.1.0:bafybeiajyrszyyo6z4lxogutv4ougiaeoxak6xkq5gtrbey32gbgnirznq
-- valory/task_execution:0.1.0:bafybeiecggxojaqpseamguzivxeyq52okl2onbeddgp4x6t2qz6kl2nyvy
+- valory/task_execution:0.1.0:bafybeig7pzey3umn2uub6gkafnam5znwic4skziyp2l5wcqcp2xmljcwde
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
# Add input validation and request-deadline handling in task_execution

## Summary

Addresses the [mech audit](https://github.com/valory-xyz/launch-predict/blob/main/mech-audit/AUDIT.md). Tightens input validation on the two places the agent ingests external data (IPFS-delivered task payloads and the off-chain HTTP handler) and adds a deadline to the payment-model request so a missing response can no longer block task execution indefinitely.

## Changes

Split across six commits for easier review:

1. Cap IPFS task payload size. Reject combined file content over 1 MB in `_handle_get_task` before JSON parsing runs.
2. Validate task_data prompt type and length. Require `prompt` and `tool` to be strings and cap `prompt` at 100 KB.
3. Add deadline to payment-model request. If the contract response for the payment model does not arrive within 60s, clear `in_flight_req` so the request can be retried instead of wedging `_ensure_payment_model`.
4. Validate offchain HTTP request body and ipfs_hash format. Cap inbound bodies at 1 MB in `_parse_http_body`, validate `ipfs_hash` matches `^0x[0-9a-fA-F]+$` with length 66 or 70 before parsing, and stop logging raw request bodies on failure.
5. Bound delivery_rate range. Reject negative and above-uint256 values on the off-chain HTTP path. `delivery_rate=0` remains accepted for free tasks.
6. Update package hashes. Mechanical lock bump.

## Test plan

- [ ] `make code-checks` (black, isort, flake8, mypy, pylint, darglint)
- [ ] `pytest packages/valory/skills/mech_abci/tests packages/valory/skills/task_submission_abci/tests packages/valory/skills/task_execution/tests` (532 pass, 17 new)
- [ ] `tox -e check-hash` and `tox -e check-packages`
- [ ] `tox -e check-abci-docstrings`, `tox -e check-abciapp-specs`, `tox -e check-handlers`
- [ ] `autonomy push-all --remote` before pushing the branch

## New test coverage

Behaviour-level:

- Oversized IPFS payload rejection, spying on `json.loads` to confirm the cap gates before parse
- Non-string `prompt` rejection
- Over-cap `prompt` length rejection. Both prompt tests spy on the designated-mech lookup to confirm the check gates the happy path
- Payment-model `in_flight_req` reset after timeout
- Payment-model `in_flight_req` preserved within timeout window
- Payment-model `in_flight_req` untouched when no payment-model timestamp exists

Handler-level:

- Oversized HTTP body rejection, spying on `urllib.parse.parse_qs` to confirm the cap trips before decode
- Invalid `ipfs_hash` rejection across 5 malformed shapes (too short, wrong length, too long, missing prefix, non-hex)
- Out-of-range `delivery_rate` rejection (negative, above uint256)
- `delivery_rate=0` accepted for free tasks
