### PR TITLE
fix: route IPFS timeouts through retry path instead of marking invalid

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeibheck73evaonbm5edhg5bfzgoqibpbd7yxeac2tgeswbisj7rmx4",
-        "skill/valory/mech_abci/0.1.0": "bafybeie5vmu453xkvi6aabp4eldbca2iczi5r2aq3vbrdggsawe2vysoem",
-        "skill/valory/task_execution/0.1.0": "bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeigm6kxmlsku6qrpns2phxol2jxuhvgmn7b3txkbtqmklz4uzpfxkm",
+        "skill/valory/mech_abci/0.1.0": "bafybeignesxsa3lprl746wlku7suzcoiboq27x5ihdfqhp2e5lnplg3baa",
+        "skill/valory/task_execution/0.1.0": "bafybeieg3y4dmgq35s7woiigcik7lu6wfd7t5ekvdmzrpjsavlm65p7j4a",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiahccbebqxtbusxc5ispbzljbb7v3rberctimrv2gtvocebkgck5e",
         "skill/valory/websocket_client/0.1.0": "bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu",
-        "agent/valory/mech/0.1.0": "bafybeiflpanmy2gveefaajv5wnww7yfbtk2puwgby52szblvedsa3p3s3q",
-        "service/valory/mech/0.1.0": "bafybeiainebg5xq6b3qtglmjymzkj2g6qztwprpoye5go2ozufmlj2ymqi"
+        "agent/valory/mech/0.1.0": "bafybeieb2olxzufu4r7keqlhonygpkcvlnxgfnslcfpqfzxq7kypyorc2u",
+        "service/valory/mech/0.1.0": "bafybeibhqdlixrtlgeqoke5pgrew2o7inqlxn46xydo3vyhyhpqec3qkmm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeibheck73evaonbm5edhg5bfzgoqibpbd7yxeac2tgeswbisj7rmx4",
-        "skill/valory/mech_abci/0.1.0": "bafybeibqefqukwx57fpgtj3cbdvs657ufzx2jxylbeme43aqy3unkca6ly",
-        "skill/valory/task_execution/0.1.0": "bafybeihaodsuapiriafm5iq4m376f2dgqalfeiaol2yh65lnnxzn23r3xq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeig33iplacumu4chnb7nkxh3ilmy2tjeumrjonsk5crhev64q2jft4",
+        "skill/valory/mech_abci/0.1.0": "bafybeie5vmu453xkvi6aabp4eldbca2iczi5r2aq3vbrdggsawe2vysoem",
+        "skill/valory/task_execution/0.1.0": "bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeigm6kxmlsku6qrpns2phxol2jxuhvgmn7b3txkbtqmklz4uzpfxkm",
         "skill/valory/websocket_client/0.1.0": "bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu",
-        "agent/valory/mech/0.1.0": "bafybeigxoxtpv4orueubhdcnsdk3k5kfzp7vqdzsddyvfhwyt3uqqn3s7m",
-        "service/valory/mech/0.1.0": "bafybeieradywsjf7g5ljrmza3sxdocvxggmlses6k6a2krlmilsqvr2w2m"
+        "agent/valory/mech/0.1.0": "bafybeiflpanmy2gveefaajv5wnww7yfbtk2puwgby52szblvedsa3p3s3q",
+        "service/valory/mech/0.1.0": "bafybeiainebg5xq6b3qtglmjymzkj2g6qztwprpoye5go2ozufmlj2ymqi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeif4jcv22xrmkwiaecyyli7iknmdhtkg6dmzqmwpqekmvxyr7ba3xy
 - valory/abstract_round_abci:0.1.0:bafybeihgbc5geup3ljdfgyontr2p5e4myxjkthaplm5ei727uw2pawstcy
 - valory/contract_subscription:0.1.0:bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem
-- valory/mech_abci:0.1.0:bafybeie5vmu453xkvi6aabp4eldbca2iczi5r2aq3vbrdggsawe2vysoem
+- valory/mech_abci:0.1.0:bafybeignesxsa3lprl746wlku7suzcoiboq27x5ihdfqhp2e5lnplg3baa
 - valory/registration_abci:0.1.0:bafybeib7midws7obgz34tqsebowa73z46pm34hhsssa3rjet2npp5ekvwm
 - valory/reset_pause_abci:0.1.0:bafybeiezqq76bdcrlgshyo2e544sm3u57amerpwla3sacosle5zivaij24
 - valory/delivery_rate_abci:0.1.0:bafybeibheck73evaonbm5edhg5bfzgoqibpbd7yxeac2tgeswbisj7rmx4
-- valory/task_execution:0.1.0:bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy
-- valory/task_submission_abci:0.1.0:bafybeigm6kxmlsku6qrpns2phxol2jxuhvgmn7b3txkbtqmklz4uzpfxkm
+- valory/task_execution:0.1.0:bafybeieg3y4dmgq35s7woiigcik7lu6wfd7t5ekvdmzrpjsavlm65p7j4a
+- valory/task_submission_abci:0.1.0:bafybeiahccbebqxtbusxc5ispbzljbb7v3rberctimrv2gtvocebkgck5e
 - valory/termination_abci:0.1.0:bafybeigp6mrueymod7a7arxn2p5mvvz2klvhhda3pls32z4fyxibqjisqu
 - valory/transaction_settlement_abci:0.1.0:bafybeic6f4ujckiutqxueagohb5iv7kgzpamhuhiq7shn6fmiwbkt3cqny
 - valory/websocket_client:0.1.0:bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeif4jcv22xrmkwiaecyyli7iknmdhtkg6dmzqmwpqekmvxyr7ba3xy
 - valory/abstract_round_abci:0.1.0:bafybeihgbc5geup3ljdfgyontr2p5e4myxjkthaplm5ei727uw2pawstcy
 - valory/contract_subscription:0.1.0:bafybeibtcbtgm5ptzn6srfts3lxts5722sygmkypcknv5ocmydqwcvgeem
-- valory/mech_abci:0.1.0:bafybeibqefqukwx57fpgtj3cbdvs657ufzx2jxylbeme43aqy3unkca6ly
+- valory/mech_abci:0.1.0:bafybeie5vmu453xkvi6aabp4eldbca2iczi5r2aq3vbrdggsawe2vysoem
 - valory/registration_abci:0.1.0:bafybeib7midws7obgz34tqsebowa73z46pm34hhsssa3rjet2npp5ekvwm
 - valory/reset_pause_abci:0.1.0:bafybeiezqq76bdcrlgshyo2e544sm3u57amerpwla3sacosle5zivaij24
 - valory/delivery_rate_abci:0.1.0:bafybeibheck73evaonbm5edhg5bfzgoqibpbd7yxeac2tgeswbisj7rmx4
-- valory/task_execution:0.1.0:bafybeihaodsuapiriafm5iq4m376f2dgqalfeiaol2yh65lnnxzn23r3xq
-- valory/task_submission_abci:0.1.0:bafybeig33iplacumu4chnb7nkxh3ilmy2tjeumrjonsk5crhev64q2jft4
+- valory/task_execution:0.1.0:bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy
+- valory/task_submission_abci:0.1.0:bafybeigm6kxmlsku6qrpns2phxol2jxuhvgmn7b3txkbtqmklz4uzpfxkm
 - valory/termination_abci:0.1.0:bafybeigp6mrueymod7a7arxn2p5mvvz2klvhhda3pls32z4fyxibqjisqu
 - valory/transaction_settlement_abci:0.1.0:bafybeic6f4ujckiutqxueagohb5iv7kgzpamhuhiq7shn6fmiwbkt3cqny
 - valory/websocket_client:0.1.0:bafybeie63j65ffblz6g6oiaynjpz4ae5mgyjz2w6o5ovqitzdbnvqzlhzu

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigxoxtpv4orueubhdcnsdk3k5kfzp7vqdzsddyvfhwyt3uqqn3s7m
+agent: valory/mech:0.1.0:bafybeiflpanmy2gveefaajv5wnww7yfbtk2puwgby52szblvedsa3p3s3q
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiflpanmy2gveefaajv5wnww7yfbtk2puwgby52szblvedsa3p3s3q
+agent: valory/mech:0.1.0:bafybeieb2olxzufu4r7keqlhonygpkcvlnxgfnslcfpqfzxq7kypyorc2u
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeihgbc5geup3ljdfgyontr2p5e4myxjkthaplm5ei727uw2pawstcy
 - valory/registration_abci:0.1.0:bafybeib7midws7obgz34tqsebowa73z46pm34hhsssa3rjet2npp5ekvwm
 - valory/reset_pause_abci:0.1.0:bafybeiezqq76bdcrlgshyo2e544sm3u57amerpwla3sacosle5zivaij24
-- valory/task_submission_abci:0.1.0:bafybeig33iplacumu4chnb7nkxh3ilmy2tjeumrjonsk5crhev64q2jft4
+- valory/task_submission_abci:0.1.0:bafybeigm6kxmlsku6qrpns2phxol2jxuhvgmn7b3txkbtqmklz4uzpfxkm
 - valory/termination_abci:0.1.0:bafybeigp6mrueymod7a7arxn2p5mvvz2klvhhda3pls32z4fyxibqjisqu
 - valory/transaction_settlement_abci:0.1.0:bafybeic6f4ujckiutqxueagohb5iv7kgzpamhuhiq7shn6fmiwbkt3cqny
 - valory/delivery_rate_abci:0.1.0:bafybeibheck73evaonbm5edhg5bfzgoqibpbd7yxeac2tgeswbisj7rmx4
-- valory/task_execution:0.1.0:bafybeihaodsuapiriafm5iq4m376f2dgqalfeiaol2yh65lnnxzn23r3xq
+- valory/task_execution:0.1.0:bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeihgbc5geup3ljdfgyontr2p5e4myxjkthaplm5ei727uw2pawstcy
 - valory/registration_abci:0.1.0:bafybeib7midws7obgz34tqsebowa73z46pm34hhsssa3rjet2npp5ekvwm
 - valory/reset_pause_abci:0.1.0:bafybeiezqq76bdcrlgshyo2e544sm3u57amerpwla3sacosle5zivaij24
-- valory/task_submission_abci:0.1.0:bafybeigm6kxmlsku6qrpns2phxol2jxuhvgmn7b3txkbtqmklz4uzpfxkm
+- valory/task_submission_abci:0.1.0:bafybeiahccbebqxtbusxc5ispbzljbb7v3rberctimrv2gtvocebkgck5e
 - valory/termination_abci:0.1.0:bafybeigp6mrueymod7a7arxn2p5mvvz2klvhhda3pls32z4fyxibqjisqu
 - valory/transaction_settlement_abci:0.1.0:bafybeic6f4ujckiutqxueagohb5iv7kgzpamhuhiq7shn6fmiwbkt3cqny
 - valory/delivery_rate_abci:0.1.0:bafybeibheck73evaonbm5edhg5bfzgoqibpbd7yxeac2tgeswbisj7rmx4
-- valory/task_execution:0.1.0:bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy
+- valory/task_execution:0.1.0:bafybeieg3y4dmgq35s7woiigcik7lu6wfd7t5ekvdmzrpjsavlm65p7j4a
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -750,11 +750,32 @@ class TaskExecutionBehaviour(SimpleBehaviour):
     def _handle_ipfs_error(self, reason: str) -> None:
         """Handle an IPFS error reported by the handler.
 
+        Classify the error: a reason containing the substring "timed out"
+        is treated as a transient socket-level timeout from the IPFS
+        client and routed through :meth:`_handle_timeout_task`, so the
+        task is retried up to ``timeout_limit`` times before a terminal
+        error is delivered on-chain. Everything else (malformed content,
+        gateway HTTP errors, missing content) is a terminal failure and
+        marks the request invalid on the first attempt.
+
+        The "timed out" substring is the message forwarded verbatim by
+        ``aea_cli_ipfs.ipfs_client.TimeoutError``, which wraps the
+        underlying ``socket.timeout`` or ``urllib`` timeout. See
+        ``plugins/aea-cli-ipfs/aea_cli_ipfs/ipfs_client.py`` in open-aea
+        for the producing sites.
+
         :param reason: the error reason from the IPFS connection.
         """
-        self._ipfs_error_reason = (
+        full_reason = (
             f"Request data could not be retrieved from IPFS (detail: {reason})"
         )
+        if reason and "timed out" in reason.lower():
+            # Transient timeout: retry via the existing timeout machinery.
+            # Pass full_reason so terminal delivery (if timeout_limit is
+            # reached) reflects the IPFS detail.
+            self._handle_timeout_task(error_reason=full_reason)
+            return
+        self._ipfs_error_reason = full_reason
         self._invalid_request = True
 
     def _get_designated_marketplace_mech_address(self) -> str:
@@ -888,8 +909,20 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # create a new executor
         self._executor = ProcessPool(max_workers=1)
 
-    def _handle_timeout_task(self) -> None:
-        """Handle timeout tasks"""
+    def _handle_timeout_task(self, error_reason: Optional[str] = None) -> None:
+        """Handle timeout tasks.
+
+        :param error_reason: optional underlying error reason (e.g. an IPFS
+            timeout detail) to include in the terminal delivery when
+            ``timeout_limit`` has been reached. When provided, this takes
+            precedence over any previously set ``_ipfs_error_reason``.
+        :returns: None
+        """
+        # Preserve the reason across the reset below so that, if we end
+        # up delivering a terminal result due to timeout_limit, the
+        # message reflects the underlying cause instead of only the
+        # generic "timed out N times" string.
+        preserved_reason = error_reason or self._ipfs_error_reason
         self.params.in_flight_req = False
         self.params.is_cold_start = False
         self._request_handling_deadline = None
@@ -942,8 +975,16 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 f"Task {req_id} has reached the timeout limit of{self.params.timeout_limit}. "
                 f"It won't be added to the end of the queue again."
             )
+            base_msg = (
+                f"Task timed out {self.params.timeout_limit} times during execution."
+            )
+            terminal_msg = (
+                f"{base_msg} Last detail: {preserved_reason}"
+                if preserved_reason
+                else f"{base_msg} "
+            )
             task_result = (
-                f"Task timed out {self.params.timeout_limit} times during execution. ",
+                terminal_msg,
                 "",
                 None,
                 None,

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -983,6 +983,9 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 if preserved_reason
                 else f"{base_msg} "
             )
+            # _handle_done_task uses _ipfs_error_reason as the "result"
+            # field of the on-chain response on the failure path.
+            self._ipfs_error_reason = terminal_msg
             task_result = (
                 terminal_msg,
                 "",

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeib24oubcz6idpxohz2g34o47m6jxyqmvspwo6v2qdjvrtfjzhbhn4
+  behaviours.py: bafybeifz2ligizvacutndjarzqvwi7blx4bv2utfe3tg6ulhvbvde5p364
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
   handlers.py: bafybeid5xyeunhbuccsylmw2xh3sjhgzmkrqtemohbehwhcpuyxbfosnda
   models.py: bafybeigeczmmo5m4a5hwkubh2ulq2i2lod7jvbmmsaua7atskeq2hyy4bm
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeib43nrx6rozfp5ez3dkevy2qzj2yclzs7kmlnqnowd3mhfhqxvxsi
-  tests/test_behaviours.py: bafybeidow2rt3omoilsmsekxcol2cnb4aze6wako76lin4vilbkamnrnay
+  tests/test_behaviours.py: bafybeidughroqd2yjkvf5omek3vuhswzcodb44obl5jq2ey3i53cn7fsyi
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeiduj6dmmdweroe7uwchp7k6pyeyk5uwmcy3wqa7vpese5ks3trllq
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeif32p44hyyrjppyrwycaftco33izxcc2imj2l3yzn5c2qyodj774i
+  behaviours.py: bafybeib24oubcz6idpxohz2g34o47m6jxyqmvspwo6v2qdjvrtfjzhbhn4
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
   handlers.py: bafybeid5xyeunhbuccsylmw2xh3sjhgzmkrqtemohbehwhcpuyxbfosnda
   models.py: bafybeigeczmmo5m4a5hwkubh2ulq2i2lod7jvbmmsaua7atskeq2hyy4bm
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeib43nrx6rozfp5ez3dkevy2qzj2yclzs7kmlnqnowd3mhfhqxvxsi
-  tests/test_behaviours.py: bafybeibp3yojr6y77e3mksrbelqeog6qifdpcrdo4bqduk4gpg42us2kba
+  tests/test_behaviours.py: bafybeidow2rt3omoilsmsekxcol2cnb4aze6wako76lin4vilbkamnrnay
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeiduj6dmmdweroe7uwchp7k6pyeyk5uwmcy3wqa7vpese5ks3trllq
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1546,10 +1546,44 @@ def test_send_message_registers_callback_and_deadline(
 # ---------------------------------------------------------------------------
 
 
-def test_handle_ipfs_error_sets_state(behaviour: Any) -> None:
-    """_handle_ipfs_error sets _ipfs_error_reason and _invalid_request."""
-    behaviour._handle_ipfs_error("some error detail")
-    assert "some error detail" in (behaviour._ipfs_error_reason or "")
+def test_handle_ipfs_error_non_timeout_sets_invalid(behaviour: Any) -> None:
+    """Non-timeout IPFS errors mark the request invalid on the first attempt."""
+    behaviour._handle_ipfs_error("IPFS API returned status 404")
+    assert "IPFS API returned status 404" in (behaviour._ipfs_error_reason or "")
+    assert behaviour._invalid_request is True
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "timed out",
+        "The read operation timed out",
+        "<urlopen error timed out>",
+        "TIMED OUT",
+        "Read operation Timed Out",
+    ],
+)
+def test_handle_ipfs_error_timeout_routes_to_retry(
+    behaviour: Any, monkeypatch: Any, reason: str
+) -> None:
+    """Timeout-class IPFS errors route through the retry machinery."""
+    behaviour._executing_task = {"requestId": 1, "request_delivery_rate": 100}
+    captured: Dict[str, Any] = {}
+
+    def fake_handle_timeout_task(error_reason: Any = None) -> None:
+        captured["called"] = True
+        captured["error_reason"] = error_reason
+
+    monkeypatch.setattr(behaviour, "_handle_timeout_task", fake_handle_timeout_task)
+    behaviour._handle_ipfs_error(reason)
+    assert captured.get("called") is True
+    assert reason in (captured.get("error_reason") or "")
+    assert behaviour._invalid_request is False
+
+
+def test_handle_ipfs_error_empty_reason_is_not_timeout(behaviour: Any) -> None:
+    """Empty reason is not treated as a timeout; falls through to invalid path."""
+    behaviour._handle_ipfs_error("")
     assert behaviour._invalid_request is True
 
 
@@ -1785,6 +1819,67 @@ def test_handle_timeout_task_limit_reached_calls_handle_done(
     )
     behaviour._handle_timeout_task()
     assert len(handle_done_calls) == 1
+
+
+def test_handle_timeout_task_limit_reached_preserves_error_reason(
+    behaviour: Any, params_stub: Any, monkeypatch: Any
+) -> None:
+    """Terminal delivery uses the passed error_reason when limit is reached."""
+    behaviour._executing_task = {"requestId": 11, "request_delivery_rate": 100}
+    behaviour._async_result = None
+    params_stub.request_id_to_num_timeouts[11] = 0
+    params_stub.timeout_limit = 1
+    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
+    handle_done_calls: list = []
+    monkeypatch.setattr(
+        behaviour, "_handle_done_task", lambda r: handle_done_calls.append(r)
+    )
+    detail = "Request data could not be retrieved from IPFS (detail: timed out)"
+    behaviour._handle_timeout_task(error_reason=detail)
+    assert len(handle_done_calls) == 1
+    terminal_msg = handle_done_calls[0][0]
+    assert "Task timed out 1 times during execution." in terminal_msg
+    assert detail in terminal_msg
+
+
+def test_handle_timeout_task_limit_reached_preserves_preexisting_reason(
+    behaviour: Any, params_stub: Any, monkeypatch: Any
+) -> None:
+    """Pre-existing _ipfs_error_reason is included in terminal delivery."""
+    behaviour._executing_task = {"requestId": 12, "request_delivery_rate": 100}
+    behaviour._async_result = None
+    params_stub.request_id_to_num_timeouts[12] = 0
+    params_stub.timeout_limit = 1
+    behaviour._ipfs_error_reason = "pre-existing reason"
+    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
+    handle_done_calls: list = []
+    monkeypatch.setattr(
+        behaviour, "_handle_done_task", lambda r: handle_done_calls.append(r)
+    )
+    behaviour._handle_timeout_task()
+    assert len(handle_done_calls) == 1
+    assert "pre-existing reason" in handle_done_calls[0][0]
+
+
+def test_handle_timeout_task_limit_reached_no_reason_generic_message(
+    behaviour: Any, params_stub: Any, monkeypatch: Any
+) -> None:
+    """Backward-compat: falls back to the generic message with no reason."""
+    behaviour._executing_task = {"requestId": 13, "request_delivery_rate": 100}
+    behaviour._async_result = None
+    params_stub.request_id_to_num_timeouts[13] = 0
+    params_stub.timeout_limit = 1
+    behaviour._ipfs_error_reason = None
+    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
+    handle_done_calls: list = []
+    monkeypatch.setattr(
+        behaviour, "_handle_done_task", lambda r: handle_done_calls.append(r)
+    )
+    behaviour._handle_timeout_task()
+    assert len(handle_done_calls) == 1
+    terminal_msg = handle_done_calls[0][0]
+    assert "Task timed out 1 times during execution." in terminal_msg
+    assert "Last detail:" not in terminal_msg
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1821,65 +1821,94 @@ def test_handle_timeout_task_limit_reached_calls_handle_done(
     assert len(handle_done_calls) == 1
 
 
-def test_handle_timeout_task_limit_reached_preserves_error_reason(
-    behaviour: Any, params_stub: Any, monkeypatch: Any
-) -> None:
-    """Terminal delivery uses the passed error_reason when limit is reached."""
-    behaviour._executing_task = {"requestId": 11, "request_delivery_rate": 100}
+def _setup_timeout_delivery_capture(
+    behaviour: Any,
+    monkeypatch: Any,
+    fake_dialogue: Any,
+    req_id: int,
+) -> list:
+    """Wire up a behaviour to capture the on-chain payload from a timeout delivery.
+
+    Sets _executing_task with enough fields for _handle_done_task to run
+    the full failure path, monkeypatches the IPFS store builder and
+    send_message to capture the stored payload, and returns the capture
+    list so the test can assert on the final response dict.
+
+    :param behaviour: the TaskExecutionBehaviour instance.
+    :param monkeypatch: pytest monkeypatch fixture.
+    :param fake_dialogue: dialogue stub to return from the fake store builder.
+    :param req_id: the requestId to seed.
+    :returns: list that will be populated with the parsed payload dict.
+    """
+    behaviour._executing_task = {
+        "requestId": req_id,
+        "requestIdWithNonce": f"{req_id}-nonce",
+        "contract_address": "0xmech",
+        "tool": "some_tool",
+        "model": "gpt-4o",
+        "request_delivery_rate": 100,
+    }
+    behaviour._tools_to_package_hash["some_tool"] = "QmHash"
     behaviour._async_result = None
+    behaviour.tool_execution_start_time = time.perf_counter() - 1.0
+    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
+    stored_payloads: list = []
+
+    def capture_store(files: Dict[str, str], **k: Any) -> Tuple[object, Any]:
+        stored_payloads.append(files)
+        return object(), fake_dialogue
+
+    monkeypatch.setattr(behaviour, "_build_ipfs_store_file_req", capture_store)
+    monkeypatch.setattr(
+        behaviour,
+        "send_message",
+        lambda msg, dlg, cb, error_cb=None: None,
+    )
+    return stored_payloads
+
+
+def test_handle_timeout_task_limit_reached_preserves_error_reason(
+    behaviour: Any, params_stub: Any, monkeypatch: Any, fake_dialogue: Any
+) -> None:
+    """Terminal on-chain result contains error_reason detail when limit reached."""
     params_stub.request_id_to_num_timeouts[11] = 0
     params_stub.timeout_limit = 1
-    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
-    handle_done_calls: list = []
-    monkeypatch.setattr(
-        behaviour, "_handle_done_task", lambda r: handle_done_calls.append(r)
-    )
+    stored = _setup_timeout_delivery_capture(behaviour, monkeypatch, fake_dialogue, 11)
     detail = "Request data could not be retrieved from IPFS (detail: timed out)"
     behaviour._handle_timeout_task(error_reason=detail)
-    assert len(handle_done_calls) == 1
-    terminal_msg = handle_done_calls[0][0]
-    assert "Task timed out 1 times during execution." in terminal_msg
-    assert detail in terminal_msg
+    assert len(stored) == 1
+    payload = json.loads(stored[0]["11"])
+    assert "Task timed out 1 times during execution." in payload["result"]
+    assert detail in payload["result"]
 
 
 def test_handle_timeout_task_limit_reached_preserves_preexisting_reason(
-    behaviour: Any, params_stub: Any, monkeypatch: Any
+    behaviour: Any, params_stub: Any, monkeypatch: Any, fake_dialogue: Any
 ) -> None:
-    """Pre-existing _ipfs_error_reason is included in terminal delivery."""
-    behaviour._executing_task = {"requestId": 12, "request_delivery_rate": 100}
-    behaviour._async_result = None
+    """Pre-existing _ipfs_error_reason is preserved into the on-chain result."""
     params_stub.request_id_to_num_timeouts[12] = 0
     params_stub.timeout_limit = 1
+    stored = _setup_timeout_delivery_capture(behaviour, monkeypatch, fake_dialogue, 12)
     behaviour._ipfs_error_reason = "pre-existing reason"
-    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
-    handle_done_calls: list = []
-    monkeypatch.setattr(
-        behaviour, "_handle_done_task", lambda r: handle_done_calls.append(r)
-    )
     behaviour._handle_timeout_task()
-    assert len(handle_done_calls) == 1
-    assert "pre-existing reason" in handle_done_calls[0][0]
+    assert len(stored) == 1
+    payload = json.loads(stored[0]["12"])
+    assert "pre-existing reason" in payload["result"]
 
 
 def test_handle_timeout_task_limit_reached_no_reason_generic_message(
-    behaviour: Any, params_stub: Any, monkeypatch: Any
+    behaviour: Any, params_stub: Any, monkeypatch: Any, fake_dialogue: Any
 ) -> None:
-    """Backward-compat: falls back to the generic message with no reason."""
-    behaviour._executing_task = {"requestId": 13, "request_delivery_rate": 100}
-    behaviour._async_result = None
+    """With no reason set, on-chain result contains the generic timeout message."""
     params_stub.request_id_to_num_timeouts[13] = 0
     params_stub.timeout_limit = 1
+    stored = _setup_timeout_delivery_capture(behaviour, monkeypatch, fake_dialogue, 13)
     behaviour._ipfs_error_reason = None
-    monkeypatch.setattr(beh_mod, "ProcessPool", lambda max_workers: MagicMock())
-    handle_done_calls: list = []
-    monkeypatch.setattr(
-        behaviour, "_handle_done_task", lambda r: handle_done_calls.append(r)
-    )
     behaviour._handle_timeout_task()
-    assert len(handle_done_calls) == 1
-    terminal_msg = handle_done_calls[0][0]
-    assert "Task timed out 1 times during execution." in terminal_msg
-    assert "Last detail:" not in terminal_msg
+    assert len(stored) == 1
+    payload = json.loads(stored[0]["13"])
+    assert "Task timed out 1 times during execution." in payload["result"]
+    assert "Last detail:" not in payload["result"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeihgbc5geup3ljdfgyontr2p5e4myxjkthaplm5ei727uw2pawstcy
 - valory/transaction_settlement_abci:0.1.0:bafybeic6f4ujckiutqxueagohb5iv7kgzpamhuhiq7shn6fmiwbkt3cqny
-- valory/task_execution:0.1.0:bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy
+- valory/task_execution:0.1.0:bafybeieg3y4dmgq35s7woiigcik7lu6wfd7t5ekvdmzrpjsavlm65p7j4a
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeihgbc5geup3ljdfgyontr2p5e4myxjkthaplm5ei727uw2pawstcy
 - valory/transaction_settlement_abci:0.1.0:bafybeic6f4ujckiutqxueagohb5iv7kgzpamhuhiq7shn6fmiwbkt3cqny
-- valory/task_execution:0.1.0:bafybeihaodsuapiriafm5iq4m376f2dgqalfeiaol2yh65lnnxzn23r3xq
+- valory/task_execution:0.1.0:bafybeibz3wrqacukwveo67iu7i2t5jsecfekqls3i777rb2f6wjn4fsjgy
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Summary

Route transient IPFS socket timeouts through the existing `timeout_limit` retry machinery instead of marking the request invalid on the first attempt. Preserve the underlying IPFS failure detail in the terminal delivery message when the retry limit is exhausted.

## Motivation

`_handle_ipfs_error` currently sets `_invalid_request = True` for every error reason. This treats a transient socket-level timeout the same as a genuine content error (malformed protobuf, missing hash). The former should be retried via the existing `timeout_limit` machinery; the latter should not.

With an IPFS connection that emits a proper `Performative.ERROR` envelope on socket timeouts (reason string containing `"timed out"`), the skill can distinguish timeout failures from other IPFS errors at the handler and route them through the retry path that already exists for executor-level timeouts.

## Changes

### `packages/valory/skills/task_execution/behaviours.py`

**`_handle_ipfs_error`** — classify the reason. A case-insensitive substring match on `"timed out"` routes through `_handle_timeout_task` with the full reason preserved. All other reasons keep the existing invalid-request behaviour.

```python
def _handle_ipfs_error(self, reason: str) -> None:
    full_reason = (
        f"Request data could not be retrieved from IPFS (detail: {reason})"
    )
    if reason and "timed out" in reason.lower():
        self._handle_timeout_task(error_reason=full_reason)
        return
    self._ipfs_error_reason = full_reason
    self._invalid_request = True
```

Non-timeout error reasons from the IPFS connection (`"IPFS API returned status 404"`, protobuf decode errors, etc.) do not contain `"timed out"`, so the classifier doesn't cross-fire.

**`_handle_timeout_task`** — new optional `error_reason: Optional[str] = None` kwarg. When set, it's preserved across the internal reset and used in the terminal `task_result` message on `timeout_limit_reached`. Existing callers (`_execute_task` deadline branch and per-task timeout branch) pass no kwarg and continue to emit the original generic message.

## Behavior matrix

| Failure mode | Before | After |
|---|---|---|
| Socket timeout on IPFS GET | `_invalid_request = True` → error response on attempt 1 | Retried up to `timeout_limit` (=3) times; terminal message preserves the IPFS detail when limit is exceeded |
| Genuine HTTP/content error (404, 500, malformed) | `_invalid_request = True` → error response on attempt 1 | Unchanged |
| Per-task `timeout_deadline` during tool execution | Retried via `_handle_timeout_task()` | Unchanged; callers pass no `error_reason` kwarg |

## Tests

Added in `packages/valory/skills/task_execution/tests/test_behaviours.py`:

- Non-timeout reasons keep the invalid-request path.
- Parametrised timeout reasons (`"timed out"`, `"The read operation timed out"`, `"<urlopen error timed out>"`, mixed case) route through `_handle_timeout_task` with the reason preserved.
- Empty reason does not match the timeout path.
- `timeout_limit`-reached terminal delivery contains the preserved error detail when `error_reason` is passed.
- Pre-existing `_ipfs_error_reason` is preserved into the terminal delivery when no kwarg is passed.
- Backward-compat: with neither kwarg nor pre-existing reason, terminal message matches the original generic format.

## Test plan

- [x] Full task_execution test suite
- [x] `tox -e black-check isort-check flake8 mypy pylint darglint`
- [x] `tox -e check-abci-docstrings check-abciapp-specs check-handlers`
- [x] `tox -e check-hash check-packages`
- [x] `autonomy packages lock`

## Related

- Builds on #398 (IPFS `ERROR` performative handling).
- Builds on #429 (staleness pattern for stuck in-flight requests on the payment-model path).
- This PR lands the skill-side logic independently. It becomes active once the IPFS connection is upgraded to the version that emits an `ERROR` envelope on socket timeouts — not `open-autonomy` v0.21.18, a subsequent release that ships the new `aea_cli_ipfs.ipfs_client` hierarchy. Until then, the branch is dormant and does not change behaviour.

## Follow-ups

- Apply the same staleness pattern from #429 to the remaining outbound call sites that hold `in_flight_req` (`get_mech_types`, `get_marketplace_undelivered_reqs`, `fetch_batch_request_id_status`, `get_block`). Same bug class, not yet protected.
- Expand test coverage for "no-reply-at-all" scenarios on each outbound call path. Current tests only simulate error replies, not silent hangs.
