### PR TITLE
ci: add All checks passed aggregate gate

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -123,7 +123,7 @@ jobs:
           gitleaks detect --report-format json --report-path leak_report -v
 
   test:
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - lock_check
       - copyright_and_dependencies_check
@@ -198,6 +198,7 @@ jobs:
       - copyright_and_dependencies_check
       - linter_checks
       - scan
+      - test
     runs-on: ubuntu-22.04
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -189,3 +189,18 @@ jobs:
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  all_checks_passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+      - run: echo "All required checks passed."


### PR DESCRIPTION
## Summary
- Adds a single `All checks passed` meta job to `common_checks.yaml` that waits on all mandatory CI jobs and fails if any dependency failed or was cancelled.
- Mandatory jobs in the gate: `lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `scan` (gitleaks), `test`.
- Flips `test.continue-on-error` from `True` to `False` so test failures actually block. Without this flip, adding `test` to `needs` is a no-op — a failing step in a `continue-on-error: true` job still reports success to downstream jobs.

## Why
Per the Valory default repo settings, `main` branch protection uses a single aggregate required status check (`All checks passed`). That keeps the workflow's `needs` list as the source of truth — adding/removing a mandatory job only requires a workflow edit, not a branch-protection change.

Once this PR is merged and the aggregate job has run on `main`, branch protection on `main` will be updated to require the `All checks passed` context with `strict: true`.

## Test plan
- [ ] Verify the `All checks passed` job appears in the PR's checks list and reports success only when all `needs` succeed.
- [ ] Confirm `test` failures now fail the workflow (previously allowed via `continue-on-error`).
- [ ] After merge, confirm the job runs on `main` so the status-check context becomes selectable in branch protection.
