### PR TITLE
fix(deps): bump idna to 3.17 to close ReDoS via crafted input

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1556,11 +1556,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `idna` from `3.13` → `3.17` in `uv.lock` via `uv lock --upgrade-package idna`.
- Closes Dependabot alert #134 (GHSA-65pc-fj4g-8rjx, CVE-2026-45409) and resolves #450.
- 1 file, +3 / -3. Pure lockfile change.

## Why only `uv.lock` and not `pyproject.toml` / agent yaml

`idna` is a pure transitive dep, pulled in by `anyio`, `httpx`, `requests`, and `yarl`. Nothing in the agent stack directly imports it.

The web3 fix (#449) had to touch every pin site because `open-aea-ledger-ethereum` declared `web3<8,>=7.0.0`, so pip would happily resolve into the vulnerable range. For `idna`, none of the transitive consumers cap the version, so pip in the deployed agent image naturally resolves to `3.15+` already. The only place stuck on `3.13` was the committed lockfile, which is also the manifest path the Dependabot alert is filed against.

Adding `idna` to `pyproject.toml` was considered but skipped: the convention enforced by `check_dependencies` is that `pyproject.toml` deps are driven by `aea-config.yaml`, and `idna` isn't in either because nothing in the agent stack imports it. A one-off pin for a transitive would fight the convention without adding real safety — the lockfile pin plus Dependabot is the cleaner regression guard.

## Exploit reachability in mech

Practical risk in this repo is low. No direct `import idna` in `packages/` (production or tests). All outbound URLs the mech agent hits are config-controlled (RPC nodes, IPFS gateways, WebSocket providers) — there is no attacker-controlled hostname path into `idna.encode()`. The advisory itself notes the trigger is input "that would not occur in normal usage." Bumping anyway to keep the lockfile out of the vulnerable range and close the alert cleanly.

## Advisory

GHSA-65pc-fj4g-8rjx is an incomplete-fix follow-up to CVE-2024-3651: specially crafted inputs to `idna.encode()` (e.g. `"٠" * N`) hit the `valid_contexto` path before length rejection and consume significant CPU on large N. Patched in `idna 3.15` by moving the length check ahead of the contextual validation pass.

## Test plan

- [x] `uv lock --check`
- [ ] `tomte tox -e check-dependencies`
- [ ] `tomte tox -e safety`
- [ ] `tomte tox -e py3.11-darwin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)