### PR TITLE
feat(task_execution): skip IPFS upload on offchain, structured 402, Payment-Receipt header

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde",
-        "skill/valory/task_execution/0.1.0": "bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja",
+        "skill/valory/mech_abci/0.1.0": "bafybeicnw7rqykyoavztkirg6elhjdvielblejhlolzt7utt3ei63yzcdq",
+        "skill/valory/task_execution/0.1.0": "bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibuei4oy2htvvhswtvhkyyxnabdcglulr646jnxd5s2zrfpf2tt5i",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeicdamiszm56bgq2x7q7r2c5ie3rg6tpkwdq4o6knqegk6vydqtn5u",
-        "service/valory/mech/0.1.0": "bafybeibsm7xb7bbjwkruk7hixdoeal34pkuv6p2fn4rv5qa6kgn2s7t3je"
+        "agent/valory/mech/0.1.0": "bafybeih43vbkcris2rxeelnslgje4atufzww72otxy3pxzlgbd56jq4pqe",
+        "service/valory/mech/0.1.0": "bafybeib5rin5marrjyr2sd7gt6o63p4ke2pkrzfjhzlqv2xjudsb5mk2qm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeic3silybex6ok5cis7jifbtzjlig4et4icax5cpgjr4pb3qnbkwia",
-        "skill/valory/task_execution/0.1.0": "bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiedosuefwblvgudcu3izgh3cdxzhtjhblezrkkiryhaxnltvxo6uq",
+        "skill/valory/mech_abci/0.1.0": "bafybeibtnwxysqwb3avo7q5ysiudslzitbly6ranwjlpmr27fen2lr7jny",
+        "skill/valory/task_execution/0.1.0": "bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeigqtu7oaha2uzxgkzfosoljbf52p4nl2izxiykg4ba57uzhk7eluy",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeibejugcq5natakejdryxyww7ci7zrexe7b6eu7f4qfuevg7siedvm",
-        "service/valory/mech/0.1.0": "bafybeiamzcqbz4rgpdhhhys343eahzzr6hunqcb6f6zp226hnpvkfwkp7u"
+        "agent/valory/mech/0.1.0": "bafybeiaazsnfwzgo6glialdm6hrffzwul4bwltwwwm37p5wz4nztaudbt4",
+        "service/valory/mech/0.1.0": "bafybeigab66yftqkogxeec5ojsvv5kt3v5yjpvwnst22l3yb6xgvuhclay"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeibtnwxysqwb3avo7q5ysiudslzitbly6ranwjlpmr27fen2lr7jny",
-        "skill/valory/task_execution/0.1.0": "bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeigqtu7oaha2uzxgkzfosoljbf52p4nl2izxiykg4ba57uzhk7eluy",
+        "skill/valory/mech_abci/0.1.0": "bafybeigby7ely7yshanq53l5l74ws5xkhzl6twaetelc2am6bc7ngplhja",
+        "skill/valory/task_execution/0.1.0": "bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidqfkwiu53wvwj5tl2d6bj6cjv6uhrvo5ber2mbaelyrqm2xe3x7u",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiaazsnfwzgo6glialdm6hrffzwul4bwltwwwm37p5wz4nztaudbt4",
-        "service/valory/mech/0.1.0": "bafybeigab66yftqkogxeec5ojsvv5kt3v5yjpvwnst22l3yb6xgvuhclay"
+        "agent/valory/mech/0.1.0": "bafybeiaobcwskxwvww6q4mdwgtpoi6ztm3pqt33nxz4cvd74jpiqfal5oy",
+        "service/valory/mech/0.1.0": "bafybeic2fi2zzexnnuv53ozr2jdzw5thrf2e4mil2ur3gg3cxesah4bnia"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeicnw7rqykyoavztkirg6elhjdvielblejhlolzt7utt3ei63yzcdq",
-        "skill/valory/task_execution/0.1.0": "bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibuei4oy2htvvhswtvhkyyxnabdcglulr646jnxd5s2zrfpf2tt5i",
+        "skill/valory/mech_abci/0.1.0": "bafybeic3silybex6ok5cis7jifbtzjlig4et4icax5cpgjr4pb3qnbkwia",
+        "skill/valory/task_execution/0.1.0": "bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiedosuefwblvgudcu3izgh3cdxzhtjhblezrkkiryhaxnltvxo6uq",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeih43vbkcris2rxeelnslgje4atufzww72otxy3pxzlgbd56jq4pqe",
-        "service/valory/mech/0.1.0": "bafybeib5rin5marrjyr2sd7gt6o63p4ke2pkrzfjhzlqv2xjudsb5mk2qm"
+        "agent/valory/mech/0.1.0": "bafybeibejugcq5natakejdryxyww7ci7zrexe7b6eu7f4qfuevg7siedvm",
+        "service/valory/mech/0.1.0": "bafybeiamzcqbz4rgpdhhhys343eahzzr6hunqcb6f6zp226hnpvkfwkp7u"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeigby7ely7yshanq53l5l74ws5xkhzl6twaetelc2am6bc7ngplhja",
-        "skill/valory/task_execution/0.1.0": "bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidqfkwiu53wvwj5tl2d6bj6cjv6uhrvo5ber2mbaelyrqm2xe3x7u",
+        "skill/valory/mech_abci/0.1.0": "bafybeiht4u3u5566lc74tequwi3bvdtcuxvyf7vav3rifs7amc2vtdbpa4",
+        "skill/valory/task_execution/0.1.0": "bafybeidkspdeqk2weqn5g6g6msrn2oqmun4d2jpbzswilufejhgl3w7dlu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifyvafwa7uovnwgaublbi7d2plww7cdyrosv7og4snvxi6suekn3q",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiaobcwskxwvww6q4mdwgtpoi6ztm3pqt33nxz4cvd74jpiqfal5oy",
-        "service/valory/mech/0.1.0": "bafybeic2fi2zzexnnuv53ozr2jdzw5thrf2e4mil2ur3gg3cxesah4bnia"
+        "agent/valory/mech/0.1.0": "bafybeigzwrgamcs4t2f5c2yfehh6tfzwgn2m3k7fgsckrhrhgyoi6wzsbm",
+        "service/valory/mech/0.1.0": "bafybeicu4uozo3ge4vx62eo2djmsz7uphb4536f4hotfpzci3dfpvq47sy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeibtnwxysqwb3avo7q5ysiudslzitbly6ranwjlpmr27fen2lr7jny
+- valory/mech_abci:0.1.0:bafybeigby7ely7yshanq53l5l74ws5xkhzl6twaetelc2am6bc7ngplhja
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii
-- valory/task_submission_abci:0.1.0:bafybeigqtu7oaha2uzxgkzfosoljbf52p4nl2izxiykg4ba57uzhk7eluy
+- valory/task_execution:0.1.0:bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y
+- valory/task_submission_abci:0.1.0:bafybeidqfkwiu53wvwj5tl2d6bj6cjv6uhrvo5ber2mbaelyrqm2xe3x7u
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicnw7rqykyoavztkirg6elhjdvielblejhlolzt7utt3ei63yzcdq
+- valory/mech_abci:0.1.0:bafybeic3silybex6ok5cis7jifbtzjlig4et4icax5cpgjr4pb3qnbkwia
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm
-- valory/task_submission_abci:0.1.0:bafybeibuei4oy2htvvhswtvhkyyxnabdcglulr646jnxd5s2zrfpf2tt5i
+- valory/task_execution:0.1.0:bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu
+- valory/task_submission_abci:0.1.0:bafybeiedosuefwblvgudcu3izgh3cdxzhtjhblezrkkiryhaxnltvxo6uq
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigby7ely7yshanq53l5l74ws5xkhzl6twaetelc2am6bc7ngplhja
+- valory/mech_abci:0.1.0:bafybeiht4u3u5566lc74tequwi3bvdtcuxvyf7vav3rifs7amc2vtdbpa4
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y
-- valory/task_submission_abci:0.1.0:bafybeidqfkwiu53wvwj5tl2d6bj6cjv6uhrvo5ber2mbaelyrqm2xe3x7u
+- valory/task_execution:0.1.0:bafybeidkspdeqk2weqn5g6g6msrn2oqmun4d2jpbzswilufejhgl3w7dlu
+- valory/task_submission_abci:0.1.0:bafybeifyvafwa7uovnwgaublbi7d2plww7cdyrosv7og4snvxi6suekn3q
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde
+- valory/mech_abci:0.1.0:bafybeicnw7rqykyoavztkirg6elhjdvielblejhlolzt7utt3ei63yzcdq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
-- valory/task_submission_abci:0.1.0:bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja
+- valory/task_execution:0.1.0:bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm
+- valory/task_submission_abci:0.1.0:bafybeibuei4oy2htvvhswtvhkyyxnabdcglulr646jnxd5s2zrfpf2tt5i
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeic3silybex6ok5cis7jifbtzjlig4et4icax5cpgjr4pb3qnbkwia
+- valory/mech_abci:0.1.0:bafybeibtnwxysqwb3avo7q5ysiudslzitbly6ranwjlpmr27fen2lr7jny
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu
-- valory/task_submission_abci:0.1.0:bafybeiedosuefwblvgudcu3izgh3cdxzhtjhblezrkkiryhaxnltvxo6uq
+- valory/task_execution:0.1.0:bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii
+- valory/task_submission_abci:0.1.0:bafybeigqtu7oaha2uzxgkzfosoljbf52p4nl2izxiykg4ba57uzhk7eluy
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeicdamiszm56bgq2x7q7r2c5ie3rg6tpkwdq4o6knqegk6vydqtn5u
+agent: valory/mech:0.1.0:bafybeih43vbkcris2rxeelnslgje4atufzww72otxy3pxzlgbd56jq4pqe
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeibejugcq5natakejdryxyww7ci7zrexe7b6eu7f4qfuevg7siedvm
+agent: valory/mech:0.1.0:bafybeiaazsnfwzgo6glialdm6hrffzwul4bwltwwwm37p5wz4nztaudbt4
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiaazsnfwzgo6glialdm6hrffzwul4bwltwwwm37p5wz4nztaudbt4
+agent: valory/mech:0.1.0:bafybeiaobcwskxwvww6q4mdwgtpoi6ztm3pqt33nxz4cvd74jpiqfal5oy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeih43vbkcris2rxeelnslgje4atufzww72otxy3pxzlgbd56jq4pqe
+agent: valory/mech:0.1.0:bafybeibejugcq5natakejdryxyww7ci7zrexe7b6eu7f4qfuevg7siedvm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiaobcwskxwvww6q4mdwgtpoi6ztm3pqt33nxz4cvd74jpiqfal5oy
+agent: valory/mech:0.1.0:bafybeigzwrgamcs4t2f5c2yfehh6tfzwgn2m3k7fgsckrhrhgyoi6wzsbm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeibuei4oy2htvvhswtvhkyyxnabdcglulr646jnxd5s2zrfpf2tt5i
+- valory/task_submission_abci:0.1.0:bafybeiedosuefwblvgudcu3izgh3cdxzhtjhblezrkkiryhaxnltvxo6uq
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm
+- valory/task_execution:0.1.0:bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeiedosuefwblvgudcu3izgh3cdxzhtjhblezrkkiryhaxnltvxo6uq
+- valory/task_submission_abci:0.1.0:bafybeigqtu7oaha2uzxgkzfosoljbf52p4nl2izxiykg4ba57uzhk7eluy
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu
+- valory/task_execution:0.1.0:bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja
+- valory/task_submission_abci:0.1.0:bafybeibuei4oy2htvvhswtvhkyyxnabdcglulr646jnxd5s2zrfpf2tt5i
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
+- valory/task_execution:0.1.0:bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeidqfkwiu53wvwj5tl2d6bj6cjv6uhrvo5ber2mbaelyrqm2xe3x7u
+- valory/task_submission_abci:0.1.0:bafybeifyvafwa7uovnwgaublbi7d2plww7cdyrosv7og4snvxi6suekn3q
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y
+- valory/task_execution:0.1.0:bafybeidkspdeqk2weqn5g6g6msrn2oqmun4d2jpbzswilufejhgl3w7dlu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeigqtu7oaha2uzxgkzfosoljbf52p4nl2izxiykg4ba57uzhk7eluy
+- valory/task_submission_abci:0.1.0:bafybeidqfkwiu53wvwj5tl2d6bj6cjv6uhrvo5ber2mbaelyrqm2xe3x7u
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii
+- valory/task_execution:0.1.0:bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -910,9 +910,31 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             # path's directory-wrapped CID (see utils/local_cid.py). The on-chain
             # commitment derivation (to_multihash, inside _finalize_done_task) is
             # otherwise identical.
+            if self._invalid_request:
+                # The task ran but produced no valid result, so `response`
+                # carries an error string rather than an answer. Route it through
+                # the same terminal-failure channel as the CID / done-task
+                # failures below instead of serving it as a success: a paying
+                # requester keys refund / retry / dispute on `status`, so a "ran
+                # but failed" delivery must be distinguishable from a successful
+                # one — otherwise the client accepts and pays for a failure.
+                self._record_offchain_failure(
+                    cast(str, req_id),
+                    cast(str, response.get("result") or "task execution failed"),
+                )
+                return
             try:
-                response_bytes = json.dumps(response).encode("utf-8")
-                local_cid = compute_cidv1(response_bytes)
+                # content_bytes is exactly what the CID commits to. The serving
+                # payload below carries this same object verbatim under
+                # "response" (envelope fields hang outside it), so a client that
+                # re-derives compute_cidv1(json.dumps(stored["response"]))
+                # reproduces content_cid byte-for-byte and can verify the
+                # delivery against the on-chain commitment. json.dumps round-trips
+                # stably here (default separators, dict insertion order is
+                # preserved through JSON), matching the on-chain path which also
+                # content-addresses json.dumps(response).
+                content_bytes = json.dumps(response).encode("utf-8")
+                local_cid = compute_cidv1(content_bytes)
             except (ValueError, TypeError) as exc:
                 # compute_cidv1 raises ValueError above the single-block bound;
                 # json.dumps raises TypeError (non-serializable) / ValueError
@@ -934,16 +956,18 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             )
             # Off-chain return channel: the response was not uploaded to IPFS, so
             # persist it under offchain_request_responses for /fetch_offchain_info
-            # to serve. Without this the poll falls back to the done_task, which
-            # carries the CID/multihash but not the result/prompt/cost_dict — i.e.
-            # the requester would have no way to read the actual result.
+            # to serve. The committed object is kept verbatim under "response"
+            # (the exact bytes hashed into content_cid); request_id / status /
+            # content_cid are envelope fields kept outside it so they don't
+            # perturb the hash. Without this the poll falls back to the done_task,
+            # which carries the CID/multihash but not the result/prompt/cost_dict.
             self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
                 cast(str, req_id)
             ] = {
-                **response,
                 "request_id": cast(str, req_id),
                 "status": "ok",
                 "content_cid": local_cid,
+                "response": response,
             }
             self._finalize_done_task(local_cid)
             return

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -63,6 +63,7 @@ from packages.valory.skills.task_execution.utils.ipfs import (
     get_ipfs_file_hash,
     to_multihash,
 )
+from packages.valory.skills.task_execution.utils.local_cid import compute_cidv1
 from packages.valory.skills.task_execution.utils.task import AnyToolAsTask
 
 PENDING_TASKS = "pending_tasks"
@@ -897,6 +898,21 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 reason=response["result"],
             )
 
+        if is_offchain:
+            # Off-chain path: skip the IPFS upload so the response stays private,
+            # compute the same CID a real IPFS upload would have produced, and
+            # finalize the done_task synchronously. The on-chain commitment
+            # (``task_result`` as multihash hex, derived inside _finalize_done_task)
+            # is unchanged.
+            response_bytes = json.dumps(response).encode("utf-8")
+            local_cid = compute_cidv1(response_bytes)
+            self.context.logger.info(
+                f"Off-chain response for request {req_id} kept private; "
+                f"local CID {local_cid}."
+            )
+            self._finalize_done_task(local_cid)
+            return
+
         msg, dialogue = self._build_ipfs_store_file_req(
             {str(req_id): json.dumps(response)}
         )
@@ -1269,13 +1285,30 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             )
             return
 
-        executing_task = self._executing_task
-        # if sender is not present, use mech address
-        req_id = executing_task["requestId"]
         ipfs_hash = to_v1(message.ipfs_hash)
+        req_id = self._executing_task["requestId"]
         self.context.logger.info(
             f"Response for request {req_id} stored on IPFS with hash {ipfs_hash}."
         )
+        self._finalize_done_task(ipfs_hash)
+
+    def _finalize_done_task(self, cid: str) -> None:
+        """Apply the CID to the in-flight done_task and publish it.
+
+        :param cid: the CIDv1 string (multibase-encoded) to record on chain via
+            ``task_result``. Origin is either a real IPFS store response (on
+            the on-chain path) or a locally-computed CID (off-chain path).
+        """
+        # Shared finalization for both the IPFS-backed on-chain path (CID from
+        # a real IPFS store response) and the off-chain path (CID computed
+        # locally). Updates pricing, mech address, task_result, appends to
+        # done_tasks under the lock, and resets the executing-task state so the
+        # next task can be picked up. The CID is converted to the multihash hex
+        # shape the contract expects only after the done_task validity check
+        # passes — this matches the previous ordering so callers that pass a
+        # malformed CID alongside an invalid done_task still take the
+        # early-reset branch cleanly.
+        req_id = cast(Dict[str, Any], self._executing_task)["requestId"]
         self.set_last_executed_task(req_id)
         done_task = cast(Dict[str, Any], self._done_task)
         if done_task is None or not isinstance(done_task, Dict):
@@ -1295,7 +1328,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._async_result = None
             return
 
-        task_result = to_multihash(ipfs_hash)
+        task_result = to_multihash(cid)
         tool = str(done_task.get("tool"))
         dynamic_tool_cost = self._tools_to_pricing.get(tool)
         if dynamic_tool_cost is not None:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -910,15 +910,17 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             # path's directory-wrapped CID (see utils/local_cid.py). The on-chain
             # commitment derivation (to_multihash, inside _finalize_done_task) is
             # otherwise identical.
-            response_bytes = json.dumps(response).encode("utf-8")
             try:
+                response_bytes = json.dumps(response).encode("utf-8")
                 local_cid = compute_cidv1(response_bytes)
-            except ValueError as exc:
-                # Response too large for a single block: we cannot produce a CID a
-                # real IPFS upload would match. Fail cleanly so the executing-task
-                # slot resets and the requester gets a definitive rejection,
-                # rather than crashing the agent (propagate policy) or stalling
-                # forever with a non-None _executing_task (just_log policy).
+            except (ValueError, TypeError) as exc:
+                # compute_cidv1 raises ValueError above the single-block bound;
+                # json.dumps raises TypeError (non-serializable) / ValueError
+                # (circular ref). Both must stay inside this guard, or the crash
+                # this fix targets still escapes through act(). Fail cleanly so
+                # the executing-task slot resets and the requester gets a
+                # definitive rejection, rather than crashing the agent
+                # (propagate policy) or stalling forever (just_log policy).
                 self.context.logger.error(
                     f"Off-chain CID computation failed for request {req_id}: {exc}"
                 )

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -932,6 +932,19 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 f"Off-chain response for request {req_id} kept private; "
                 f"local CID {local_cid}."
             )
+            # Off-chain return channel: the response was not uploaded to IPFS, so
+            # persist it under offchain_request_responses for /fetch_offchain_info
+            # to serve. Without this the poll falls back to the done_task, which
+            # carries the CID/multihash but not the result/prompt/cost_dict — i.e.
+            # the requester would have no way to read the actual result.
+            self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
+                cast(str, req_id)
+            ] = {
+                **response,
+                "request_id": cast(str, req_id),
+                "status": "ok",
+                "content_cid": local_cid,
+            }
             self._finalize_done_task(local_cid)
             return
 

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -79,6 +79,11 @@ LAST_SUCCESSFUL_EXECUTED_TASK = "last_successful_executed_task"
 LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
+# Shared-state keys owned by the MechHttpHandler (handlers.py); mirrored here
+# because the off-chain finalize path writes the rejection signal and clears the
+# buffered request metadata from the behaviour side.
+OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
+IN_MEMORY_REQUESTS = "in_memory_requests"
 INITIAL_DEADLINE = 1200.0  # 20mins of deadline
 SUBSEQUENT_DEADLINE = 300.0  # 5min of deadline
 STATUS_CHECK_INTERVAL = 600.0  # 10min interval
@@ -899,13 +904,28 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             )
 
         if is_offchain:
-            # Off-chain path: skip the IPFS upload so the response stays private,
-            # compute the same CID a real IPFS upload would have produced, and
-            # finalize the done_task synchronously. The on-chain commitment
-            # (``task_result`` as multihash hex, derived inside _finalize_done_task)
-            # is unchanged.
+            # Off-chain path: skip the IPFS upload so the response stays private
+            # and commit a locally-computed CIDv1 instead. This is a bare
+            # single-block file CID; it intentionally differs from the on-chain
+            # path's directory-wrapped CID (see utils/local_cid.py). The on-chain
+            # commitment derivation (to_multihash, inside _finalize_done_task) is
+            # otherwise identical.
             response_bytes = json.dumps(response).encode("utf-8")
-            local_cid = compute_cidv1(response_bytes)
+            try:
+                local_cid = compute_cidv1(response_bytes)
+            except ValueError as exc:
+                # Response too large for a single block: we cannot produce a CID a
+                # real IPFS upload would match. Fail cleanly so the executing-task
+                # slot resets and the requester gets a definitive rejection,
+                # rather than crashing the agent (propagate policy) or stalling
+                # forever with a non-None _executing_task (just_log policy).
+                self.context.logger.error(
+                    f"Off-chain CID computation failed for request {req_id}: {exc}"
+                )
+                self._record_offchain_failure(
+                    cast(str, req_id), f"cid computation failed: {exc}"
+                )
+                return
             self.context.logger.info(
                 f"Off-chain response for request {req_id} kept private; "
                 f"local CID {local_cid}."
@@ -1295,37 +1315,39 @@ class TaskExecutionBehaviour(SimpleBehaviour):
     def _finalize_done_task(self, cid: str) -> None:
         """Apply the CID to the in-flight done_task and publish it.
 
-        :param cid: the CIDv1 string (multibase-encoded) to record on chain via
-            ``task_result``. Origin is either a real IPFS store response (on
-            the on-chain path) or a locally-computed CID (off-chain path).
+        Shared by the on-chain path (CID from a real IPFS store response) and the
+        off-chain path (CID computed locally). Updates pricing / mech address /
+        task_result, appends to done_tasks under the lock, and resets the
+        executing-task slot. The CID is converted to the multihash shape only
+        after the done_task validity check passes, so an invalid done_task takes
+        the early-reset branch cleanly.
+
+        :param cid: the multibase-encoded CIDv1 to record on chain via
+            ``task_result``.
         """
-        # Shared finalization for both the IPFS-backed on-chain path (CID from
-        # a real IPFS store response) and the off-chain path (CID computed
-        # locally). Updates pricing, mech address, task_result, appends to
-        # done_tasks under the lock, and resets the executing-task state so the
-        # next task can be picked up. The CID is converted to the multihash hex
-        # shape the contract expects only after the done_task validity check
-        # passes — this matches the previous ordering so callers that pass a
-        # malformed CID alongside an invalid done_task still take the
-        # early-reset branch cleanly.
-        req_id = cast(Dict[str, Any], self._executing_task)["requestId"]
+        executing_task = self._executing_task
+        if executing_task is None:
+            # Two entry points call this now; if the slot was already cleared
+            # there is nothing to finalize. Guard turns a None-deref into a log.
+            self.context.logger.warning(
+                "_finalize_done_task called with no executing task; skipping."
+            )
+            return
+        req_id = cast(Dict[str, Any], executing_task)["requestId"]
+        is_offchain = bool(executing_task.get("is_offchain", False))
         self.set_last_executed_task(req_id)
         done_task = cast(Dict[str, Any], self._done_task)
         if done_task is None or not isinstance(done_task, Dict):
             self.context.logger.error(
                 f"Invalid done task format. Expected Dict. Actual: {done_task}"
             )
-            # Prometheus has no way to remove/clear metrics, so we set to default 0
-            self.mech_metrics.set_gauge(
-                self.mech_metrics.mech_tasks_inflight,
-                0,
-            )
-            self._executing_task = None
-            self._done_task = None
-            self._invalid_request = False
-            self._ipfs_error_reason = None
-            self._request_handling_deadline = None
-            self._async_result = None
+            if is_offchain:
+                # On-chain has other fallbacks; off-chain the polling client would
+                # otherwise never learn this failed, so emit a definitive
+                # rejection (which also resets the task slot).
+                self._record_offchain_failure(req_id, "invalid done task")
+                return
+            self._reset_executing_task()
             return
 
         task_result = to_multihash(cid)
@@ -1353,20 +1375,42 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)
         self.context.logger.info(f"Done task added to done tasks list: {done_task}.")
+        # Off-chain success: drop the buffered request metadata so it can't grow
+        # unbounded (on-chain tasks never populate it, so this is a no-op there).
+        # .get keeps this safe if the handler-owned key was never initialised.
+        self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(req_id, None)
+        self._reset_executing_task()
 
-        # Prometheus has no way to remove/clear metrics, so we set to default 0
-        self.mech_metrics.set_gauge(
-            self.mech_metrics.mech_tasks_inflight,
-            0,
-        )
-
-        # reset tasks
+    def _reset_executing_task(self) -> None:
+        """Reset the in-flight task slot so the next task can be picked up."""
+        # Prometheus has no clear; set the in-flight gauge back to 0.
+        self.mech_metrics.set_gauge(self.mech_metrics.mech_tasks_inflight, 0)
         self._executing_task = None
         self._done_task = None
         self._invalid_request = False
         self._ipfs_error_reason = None
         self._request_handling_deadline = None
         self._async_result = None
+
+    def _record_offchain_failure(self, req_id: str, reason: str) -> None:
+        """Record an off-chain request failure and reset the task slot.
+
+        Writes the same ``{request_id, status, reason}`` shape the HTTP handler's
+        rejection path uses, so a poll of ``GET /fetch_offchain_info`` returns a
+        definitive rejection instead of an empty "still processing" body forever.
+
+        :param req_id: the off-chain request id that failed.
+        :param reason: a short human-readable failure reason.
+        """
+        # setdefault / get keep this safe if the handler-owned shared-state keys
+        # were never initialised (e.g. on-chain-only deployments, unit tests).
+        self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[req_id] = {
+            "request_id": req_id,
+            "status": "rejected",
+            "reason": reason,
+        }
+        self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(req_id, None)
+        self._reset_executing_task()
 
     def _handle_ipfs_tasks_response(
         self, message: IpfsMessage, dialogue: Dialogue

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -554,12 +554,13 @@ class MechHttpHandler(AbstractResponseHandler):
 
     @property
     def in_memory_requests(self) -> Dict[str, str]:
-        """Get in-memory off-chain request metadata buffered by request id.
+        """Get in-memory off-chain request payloads buffered by request id.
 
-        :return: a dict keyed by request_id with the raw request JSON string.
+        :return: a dict keyed by request_id whose values are the request's
+            ``ipfs_data`` payload (not the full request envelope). Populated when
+            the off-chain path skips the IPFS upload; cleared when the task
+            finalizes.
         """
-        # Populated when the off-chain path skips the IPFS upload and keeps the
-        # request JSON locally instead.
         return self.context.shared_state[IN_MEMORY_REQUESTS]
 
     @property
@@ -596,6 +597,28 @@ class MechHttpHandler(AbstractResponseHandler):
         :param http_msg: the HttpMessage instance
         :param http_dialogue: the HttpDialogue instance
         """
+        # Phase 1 ships dark: the off-chain HTTP path is disabled by default and
+        # enabled per deployment in the Phase 2 rollout (use_offchain). When off,
+        # nothing about the on-chain + IPFS flow changes; off-chain requests are
+        # refused so none of the new off-chain code path runs.
+        if not self.params.use_offchain:
+            self.context.logger.info(
+                "Off-chain request received but the off-chain path is disabled "
+                "(use_offchain=false); refusing."
+            )
+            http_response = http_dialogue.reply(
+                performative=HttpMessage.Performative.RESPONSE,
+                target_message=http_msg,
+                version=http_msg.version,
+                status_code=HttpCode.SERVICE_UNAVAILABLE_CODE.value,
+                status_text="Service unavailable",
+                headers=f"{self.json_content_header}{http_msg.headers}",
+                body=json.dumps({"error": "offchain path disabled"}).encode(
+                    ENCODING_UTF8
+                ),
+            )
+            self.context.outbox.put_message(message=http_response)
+            return
 
         try:
             data = self._parse_http_body(http_msg)
@@ -778,6 +801,10 @@ class MechHttpHandler(AbstractResponseHandler):
             terminated by ``\n``) prepended to the response. Callers use this to
             add audit headers (e.g. ``Payment-Receipt``) without rewriting body.
         """
+        # Each header line must be newline-terminated, else it would silently
+        # merge with the Content-Type line that follows.
+        if extra_headers and not extra_headers.endswith("\n"):
+            raise ValueError("extra_headers must be empty or newline-terminated")
         http_response = http_dialogue.reply(
             performative=HttpMessage.Performative.RESPONSE,
             target_message=http_msg,
@@ -814,6 +841,10 @@ class MechHttpHandler(AbstractResponseHandler):
         :param extra_headers: optional pre-formatted header block to prepend.
         :param body_extras: optional dict merged into the JSON response body.
         """
+        # Each header line must be newline-terminated, else it would silently
+        # merge with the Content-Type line that follows.
+        if extra_headers and not extra_headers.endswith("\n"):
+            raise ValueError("extra_headers must be empty or newline-terminated")
         # ``body_extras`` is merged into the JSON body alongside the canonical
         # ``{request_id, status, reason}`` keys, so legacy clients that only
         # read ``reason`` keep working while new clients can pick up structured
@@ -845,20 +876,30 @@ class MechHttpHandler(AbstractResponseHandler):
     ) -> Dict[str, Any]:
         """Build the structured 402 challenge body.
 
-        :param balance_check: the result dict from ``_check_offchain_requester_balance``.
+        :param balance_check: a successful result dict from
+            ``_check_offchain_requester_balance``; it must carry the
+            balance-tracker address. An error-shaped dict is rejected rather than
+            silently emitting zero-address deposit instructions.
         :param error_msg: a short human-readable error string echoed in the body.
         :return: the structured 402 challenge as a dict ready for JSON encoding.
+        :raises ValueError: if ``balance_check`` lacks the balance-tracker address.
         """
-        # Reads payTo, asset, chainId, currentBalance, required from the
-        # balance-check result and pairs them with deposit instructions the
-        # client can use to construct an on-chain top-up. Native-asset payment
-        # models surface the zero address for ``asset``; clients that see the
-        # zero address must skip the ERC20 approve step.
+        # Native-asset payment models surface the zero address for ``asset``;
+        # clients that see it must skip the ERC20 approve step.
+        if ResponseKey.BALANCE_TRACKER_ADDRESS.value not in balance_check:
+            raise ValueError(
+                "cannot build a 402 challenge from a balance check without a "
+                "balance_tracker_address; refusing to emit zero-address deposit "
+                "instructions"
+            )
         balance_tracker_address = cast(
-            str,
-            balance_check.get(ResponseKey.BALANCE_TRACKER_ADDRESS.value, ZERO_ADDRESS),
+            str, balance_check[ResponseKey.BALANCE_TRACKER_ADDRESS.value]
         )
-        payment_type = cast(str, balance_check.get(ResponseKey.PAYMENT_TYPE.value, ""))
+        # Normalize the lookup key — the map keys are lower-cased at load time
+        # (models.Params) so a checksummed payment_type still resolves.
+        payment_type = cast(
+            str, balance_check.get(ResponseKey.PAYMENT_TYPE.value, "")
+        ).lower()
         asset_address = self.params.payment_type_to_asset_address.get(
             payment_type, ZERO_ADDRESS
         )

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -19,11 +19,13 @@
 
 """This package contains a scaffold of a handler."""
 
+import base64
 import json
 import re
 import threading
 import time
 import urllib.parse
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union, cast
 
@@ -63,6 +65,7 @@ PAYMENT_MODEL = "payment_model"
 PAYMENT_INFO = "payment_info"
 ROUTES_INFO = "routes_info"
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
+IN_MEMORY_REQUESTS = "in_memory_requests"
 JSON_CONTENT_HEADER = "Content-Type: application/json\n"
 ENCODING_UTF8 = "utf-8"
 
@@ -141,6 +144,15 @@ class ResponseKey(str, Enum):
     AVAILABLE_AMOUNT = "available_amount"
     RPC_ADDRESS = "rpc_address"
     CHAIN_ID = "chain_id"
+    BALANCE_TRACKER_ADDRESS = "balance_tracker_address"
+    PAYMENT_TYPE = "payment_type"
+
+
+# 402 challenge constants — surfaced so clients can branch on a stable label.
+PAYMENT_SCHEME = "olas-prepay"
+DEPOSIT_FN_ABI = "depositFor(address requester, uint256 amount)"
+SETTLEMENT_STATUS_PENDING = "pending"
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
 class BaseHandler(Handler):
@@ -541,6 +553,16 @@ class MechHttpHandler(AbstractResponseHandler):
         return self.context.shared_state[OFFCHAIN_REQUEST_RESPONSES]
 
     @property
+    def in_memory_requests(self) -> Dict[str, str]:
+        """Get in-memory off-chain request metadata buffered by request id.
+
+        :return: a dict keyed by request_id with the raw request JSON string.
+        """
+        # Populated when the off-chain path skips the IPFS upload and keeps the
+        # request JSON locally instead.
+        return self.context.shared_state[IN_MEMORY_REQUESTS]
+
+    @property
     def params(self) -> Params:
         """Get the parameters."""
         return cast(Params, self.context.params)
@@ -553,6 +575,7 @@ class MechHttpHandler(AbstractResponseHandler):
         }
         self.context.shared_state[IPFS_TASKS] = []
         self.context.shared_state[OFFCHAIN_REQUEST_RESPONSES] = {}
+        self.context.shared_state[IN_MEMORY_REQUESTS] = {}
         self.json_content_header = JSON_CONTENT_HEADER
         self.start_prometheus_server()
         super().setup()
@@ -636,6 +659,10 @@ class MechHttpHandler(AbstractResponseHandler):
                 reason="insufficient balance",
                 status_code=HttpCode.PAYMENT_REQUIRED_CODE.value,
                 status_text="Payment required",
+                extra_headers=self._build_www_authenticate_header(),
+                body_extras=self._build_402_challenge(
+                    balance_check, error_msg="insufficient balance"
+                ),
             )
             return
 
@@ -655,7 +682,8 @@ class MechHttpHandler(AbstractResponseHandler):
 
         self.context.logger.info(
             f"Offchain task added with data: {req}. "
-            f"pending_tasks={len(self.pending_tasks)} ipfs_tasks={len(self.ipfs_tasks)}."
+            f"pending_tasks={len(self.pending_tasks)} "
+            f"in_memory_requests={len(self.in_memory_requests)}."
         )
 
         self.offchain_request_responses.pop(request_id, None)
@@ -663,6 +691,9 @@ class MechHttpHandler(AbstractResponseHandler):
             http_msg=http_msg,
             http_dialogue=http_dialogue,
             data={RequestKey.REQUEST_ID.value: request_id},
+            extra_headers=self._build_payment_receipt_header(
+                request_id, request_delivery_rate
+            ),
         )
 
     def _handle_offchain_request_info(
@@ -736,15 +767,24 @@ class MechHttpHandler(AbstractResponseHandler):
         http_msg: HttpMessage,
         http_dialogue: HttpDialogue,
         data: Union[Dict, List],
+        extra_headers: str = "",
     ) -> None:
-        """Send an OK response with the provided data"""
+        r"""Send an OK response with the provided data.
+
+        :param http_msg: the incoming HTTP request message.
+        :param http_dialogue: the HTTP dialogue used to reply.
+        :param data: the response body payload, serialized as JSON.
+        :param extra_headers: optional pre-formatted header block (each header
+            terminated by ``\n``) prepended to the response. Callers use this to
+            add audit headers (e.g. ``Payment-Receipt``) without rewriting body.
+        """
         http_response = http_dialogue.reply(
             performative=HttpMessage.Performative.RESPONSE,
             target_message=http_msg,
             version=http_msg.version,
             status_code=HttpCode.OK_CODE.value,
             status_text="Success",
-            headers=f"{self.json_content_header}{http_msg.headers}",
+            headers=f"{extra_headers}{self.json_content_header}{http_msg.headers}",
             body=json.dumps(data).encode(ENCODING_UTF8),
         )
 
@@ -760,13 +800,31 @@ class MechHttpHandler(AbstractResponseHandler):
         reason: str,
         status_code: int,
         status_text: str,
+        extra_headers: str = "",
+        body_extras: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Build a rejection payload, store it, and send the HTTP error response."""
-        response_payload = {
+        """Build a rejection payload, store it, and send the HTTP error response.
+
+        :param http_msg: the incoming HTTP request message.
+        :param http_dialogue: the HTTP dialogue used to reply.
+        :param request_id: the off-chain request id being rejected.
+        :param reason: a short human-readable rejection reason.
+        :param status_code: the HTTP status code to emit.
+        :param status_text: the HTTP status text to emit.
+        :param extra_headers: optional pre-formatted header block to prepend.
+        :param body_extras: optional dict merged into the JSON response body.
+        """
+        # ``body_extras`` is merged into the JSON body alongside the canonical
+        # ``{request_id, status, reason}`` keys, so legacy clients that only
+        # read ``reason`` keep working while new clients can pick up structured
+        # fields such as the 402 challenge.
+        response_payload: Dict[str, Any] = {
             RequestKey.REQUEST_ID.value: request_id,
             ResponseKey.STATUS.value: ResponseStatus.REJECTED.value,
             ResponseKey.REASON.value: reason,
         }
+        if body_extras:
+            response_payload.update(body_extras)
         self.offchain_request_responses[request_id] = response_payload
         http_response = http_dialogue.reply(
             performative=HttpMessage.Performative.RESPONSE,
@@ -774,11 +832,88 @@ class MechHttpHandler(AbstractResponseHandler):
             version=http_msg.version,
             status_code=status_code,
             status_text=status_text,
-            headers=f"{self.json_content_header}{http_msg.headers}",
+            headers=f"{extra_headers}{self.json_content_header}{http_msg.headers}",
             body=json.dumps(response_payload).encode(ENCODING_UTF8),
         )
         self.context.logger.info("Responding with: {}".format(http_response))
         self.context.outbox.put_message(message=http_response)
+
+    def _build_402_challenge(
+        self,
+        balance_check: Dict[str, Any],
+        error_msg: str,
+    ) -> Dict[str, Any]:
+        """Build the structured 402 challenge body.
+
+        :param balance_check: the result dict from ``_check_offchain_requester_balance``.
+        :param error_msg: a short human-readable error string echoed in the body.
+        :return: the structured 402 challenge as a dict ready for JSON encoding.
+        """
+        # Reads payTo, asset, chainId, currentBalance, required from the
+        # balance-check result and pairs them with deposit instructions the
+        # client can use to construct an on-chain top-up. Native-asset payment
+        # models surface the zero address for ``asset``; clients that see the
+        # zero address must skip the ERC20 approve step.
+        balance_tracker_address = cast(
+            str,
+            balance_check.get(ResponseKey.BALANCE_TRACKER_ADDRESS.value, ZERO_ADDRESS),
+        )
+        payment_type = cast(str, balance_check.get(ResponseKey.PAYMENT_TYPE.value, ""))
+        asset_address = self.params.payment_type_to_asset_address.get(
+            payment_type, ZERO_ADDRESS
+        )
+        return {
+            "scheme": PAYMENT_SCHEME,
+            "payTo": balance_tracker_address,
+            "asset": asset_address,
+            "chainId": int(balance_check.get(ResponseKey.CHAIN_ID.value, 0)),
+            "currentBalance": str(
+                balance_check.get(ResponseKey.AVAILABLE_AMOUNT.value, 0)
+            ),
+            "required": str(balance_check.get(ResponseKey.REQUIRED_AMOUNT.value, 0)),
+            "depositInstructions": {
+                "contract": balance_tracker_address,
+                "abi": DEPOSIT_FN_ABI,
+            },
+            "error": error_msg,
+        }
+
+    def _build_www_authenticate_header(self) -> str:
+        """Build the ``WWW-Authenticate`` header line for a 402 response.
+
+        :return: a single header line terminated with newline.
+        """
+        # The ``realm`` carries the mech address so clients with multiple mechs
+        # configured can route the deposit to the right balance tracker.
+        mech_address = self.params.agent_mech_contract_addresses[0]
+        return (
+            f'WWW-Authenticate: Payment scheme="{PAYMENT_SCHEME}" '
+            f'realm="{mech_address}"\n'
+        )
+
+    def _build_payment_receipt_header(
+        self, request_id: str, accepted_amount: int
+    ) -> str:
+        """Build the ``Payment-Receipt`` header line for a 200 response.
+
+        :param request_id: the off-chain request id being acknowledged.
+        :param accepted_amount: the requester-signed delivery rate being committed.
+        :return: a single header line terminated with newline.
+        """
+        # The base64-encoded JSON payload is intentionally a snapshot at HTTP
+        # accept time, NOT a settlement confirmation. ``settlement_status`` is
+        # always ``"pending"`` here; on-chain settlement happens later via the
+        # task_submission flow.
+        receipt = {
+            "request_id": request_id,
+            "accepted_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "accepted_amount": str(accepted_amount),
+            "settlement_status": SETTLEMENT_STATUS_PENDING,
+        }
+        encoded = base64.b64encode(json.dumps(receipt).encode(ENCODING_UTF8))
+        return f"Payment-Receipt: {encoded.decode('ascii')}\n"
 
     def _rollback_offchain_enqueue(self, request_id: str) -> None:
         """Rollback a partial off-chain enqueue in case of unexpected failure."""
@@ -787,14 +922,11 @@ class MechHttpHandler(AbstractResponseHandler):
             for req in self.pending_tasks
             if req.get(RequestKey.REQUEST_ID_CAMEL.value) != request_id
         ]
-        self.context.shared_state[IPFS_TASKS] = [
-            req
-            for req in self.ipfs_tasks
-            if req.get(RequestKey.REQUEST_ID.value) != request_id
-        ]
+        self.in_memory_requests.pop(request_id, None)
         self.context.logger.error(
             f"Queue rollback applied for {request_id=}. "
-            f"pending_tasks={len(self.pending_tasks)} ipfs_tasks={len(self.ipfs_tasks)}"
+            f"pending_tasks={len(self.pending_tasks)} "
+            f"in_memory_requests={len(self.in_memory_requests)}"
         )
 
     def _parse_http_body(self, http_msg: HttpMessage) -> Dict[str, str]:
@@ -816,7 +948,19 @@ class MechHttpHandler(AbstractResponseHandler):
         request_delivery_rate: int,
         data: Dict[str, str],
     ) -> Dict[str, Any]:
-        """Enqueue the off-chain task and its IPFS upload payload."""
+        """Enqueue the off-chain task and buffer its request metadata locally.
+
+        :param request_id: the off-chain request id.
+        :param ipfs_hash: the requester-supplied content hash (0x-prefixed hex).
+        :param request_delivery_rate: the requester-signed delivery rate.
+        :param data: the parsed HTTP body dict (signature, sender, ipfs_data, etc).
+        :return: the queued task dict.
+        :raises Exception: if either queue write fails; partial state is rolled back.
+        """
+        # The off-chain path skips the IPFS upload entirely and keeps the
+        # request JSON in process memory under ``in_memory_requests``. The
+        # content commitment on chain still comes from the locally-computed
+        # CID (response side), so the mech's on-chain receipt is unchanged.
         req = {
             RequestKey.REQUEST_ID_CAMEL.value: request_id,
             BodyKey.DATA.value: bytes.fromhex(ipfs_hash[2:]),
@@ -826,12 +970,7 @@ class MechHttpHandler(AbstractResponseHandler):
         }
         try:
             self.pending_tasks.append(req)
-            self.ipfs_tasks.append(
-                {
-                    RequestKey.REQUEST_ID.value: request_id,
-                    RequestKey.IPFS_DATA.value: data[RequestKey.IPFS_DATA.value],
-                }
-            )
+            self.in_memory_requests[request_id] = data[RequestKey.IPFS_DATA.value]
         except Exception:
             self._rollback_offchain_enqueue(request_id)
             raise
@@ -918,6 +1057,9 @@ class MechHttpHandler(AbstractResponseHandler):
                 ResponseKey.REQUIRED_AMOUNT.value: required_amount,
                 ResponseKey.AVAILABLE_AMOUNT.value: int(available_amount),
                 ResponseKey.REASON.value: "balance check completed",
+                ResponseKey.BALANCE_TRACKER_ADDRESS.value: balance_tracker_address,
+                ResponseKey.PAYMENT_TYPE.value: payment_type,
+                ResponseKey.CHAIN_ID.value: chain_id,
             }
         except Exception as e:
             return self._make_unavailable_balance_response(

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -675,6 +675,20 @@ class MechHttpHandler(AbstractResponseHandler):
 
         available_amount = cast(int, balance_check[ResponseKey.AVAILABLE_AMOUNT.value])
         if available_amount < request_delivery_rate:
+            try:
+                extra_headers = self._build_www_authenticate_header()
+                challenge_body = self._build_402_challenge(
+                    balance_check, error_msg="insufficient balance"
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                # The 402 / header builders raise on malformed internal state
+                # (missing balance-tracker address, mis-terminated header).
+                # Reply 500 rather than letting it escape with no HTTP response.
+                self.context.logger.exception(
+                    f"Failed to build 402 challenge for {request_id}."
+                )
+                self._send_internal_error(http_msg, http_dialogue, request_id)
+                return
             self._send_rejection_response(
                 http_msg,
                 http_dialogue,
@@ -682,10 +696,8 @@ class MechHttpHandler(AbstractResponseHandler):
                 reason="insufficient balance",
                 status_code=HttpCode.PAYMENT_REQUIRED_CODE.value,
                 status_text="Payment required",
-                extra_headers=self._build_www_authenticate_header(),
-                body_extras=self._build_402_challenge(
-                    balance_check, error_msg="insufficient balance"
-                ),
+                extra_headers=extra_headers,
+                body_extras=challenge_body,
             )
             return
 
@@ -710,14 +722,24 @@ class MechHttpHandler(AbstractResponseHandler):
         )
 
         self.offchain_request_responses.pop(request_id, None)
-        self._send_ok_response(
-            http_msg=http_msg,
-            http_dialogue=http_dialogue,
-            data={RequestKey.REQUEST_ID.value: request_id},
-            extra_headers=self._build_payment_receipt_header(
+        try:
+            receipt_header = self._build_payment_receipt_header(
                 request_id, request_delivery_rate
-            ),
-        )
+            )
+            self._send_ok_response(
+                http_msg=http_msg,
+                http_dialogue=http_dialogue,
+                data={RequestKey.REQUEST_ID.value: request_id},
+                extra_headers=receipt_header,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            # The receipt-header builder / OK sender raise only on malformed
+            # internal state. The task is already enqueued, so reply 500 rather
+            # than hanging the client; the mech still processes the request.
+            self.context.logger.exception(
+                f"Failed to send OK response for {request_id}."
+            )
+            self._send_internal_error(http_msg, http_dialogue, request_id)
 
     def _handle_offchain_request_info(
         self, http_msg: HttpMessage, http_dialogue: HttpDialogue
@@ -869,6 +891,29 @@ class MechHttpHandler(AbstractResponseHandler):
         self.context.logger.info("Responding with: {}".format(http_response))
         self.context.outbox.put_message(message=http_response)
 
+    def _send_internal_error(
+        self, http_msg: HttpMessage, http_dialogue: HttpDialogue, request_id: str
+    ) -> None:
+        """Send a 500 with no extra headers / body extras.
+
+        Used when a defensive guard in the 402 / header builders fires on the
+        request-handling path: a bare ``raise`` there would leave the client
+        with no HTTP reply (hung). This emits a definitive 500 instead; passing
+        no extra_headers keeps the senders' own newline guard from re-raising.
+
+        :param http_msg: the incoming HTTP request message.
+        :param http_dialogue: the HTTP dialogue used to reply.
+        :param request_id: the off-chain request id being rejected.
+        """
+        self._send_rejection_response(
+            http_msg,
+            http_dialogue,
+            request_id,
+            reason="internal error",
+            status_code=HttpCode.INTERNAL_SERVER_ERROR_CODE.value,
+            status_text="Internal server error",
+        )
+
     def _build_402_challenge(
         self,
         balance_check: Dict[str, Any],
@@ -895,11 +940,11 @@ class MechHttpHandler(AbstractResponseHandler):
         balance_tracker_address = cast(
             str, balance_check[ResponseKey.BALANCE_TRACKER_ADDRESS.value]
         )
-        # Normalize the lookup key — the map keys are lower-cased at load time
+        # Normalize the lookup key — `or ""` guards a present-but-None
+        # payment_type (a bare cast would be a runtime no-op and .lower() would
+        # then AttributeError); the map keys are lower-cased at load time
         # (models.Params) so a checksummed payment_type still resolves.
-        payment_type = cast(
-            str, balance_check.get(ResponseKey.PAYMENT_TYPE.value, "")
-        ).lower()
+        payment_type = (balance_check.get(ResponseKey.PAYMENT_TYPE.value) or "").lower()
         asset_address = self.params.payment_type_to_asset_address.get(
             payment_type, ZERO_ADDRESS
         )

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -117,9 +117,18 @@ class Params(Model):
         self.gnosis_ledger_rpc: str = kwargs.get("gnosis_ledger_rpc", "")
         self.polygon_ledger_rpc: str = kwargs.get("polygon_ledger_rpc", "")
         self.base_ledger_rpc: str = kwargs.get("base_ledger_rpc", "")
-        self.payment_type_to_asset_address: Dict[str, str] = kwargs.get(
-            "payment_type_to_asset_address", {}
-        )
+        # Lower-case the payment_type keys at load so a checksummed-vs-lowercase
+        # hex mismatch at lookup time can't silently fall back to the zero
+        # address (which would signal a native-asset deposit for what is really
+        # an ERC-20 payment model).
+        self.payment_type_to_asset_address: Dict[str, str] = {
+            key.lower(): value
+            for key, value in kwargs.get("payment_type_to_asset_address", {}).items()
+        }
+        # Phase 1 ships dark: the offchain HTTP path is disabled by default and
+        # enabled per deployment in the Phase 2 rollout. False = today's
+        # on-chain + IPFS behaviour, unchanged.
+        self.use_offchain: bool = kwargs.get("use_offchain", False)
         self.tools_to_pricing: Dict[str, int] = kwargs.get("tools_to_pricing", {})
         if self.tools_to_pricing:
             self._ensure_same_keys(

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -117,6 +117,9 @@ class Params(Model):
         self.gnosis_ledger_rpc: str = kwargs.get("gnosis_ledger_rpc", "")
         self.polygon_ledger_rpc: str = kwargs.get("polygon_ledger_rpc", "")
         self.base_ledger_rpc: str = kwargs.get("base_ledger_rpc", "")
+        self.payment_type_to_asset_address: Dict[str, str] = kwargs.get(
+            "payment_type_to_asset_address", {}
+        )
         self.tools_to_pricing: Dict[str, int] = kwargs.get("tools_to_pricing", {})
         if self.tools_to_pricing:
             self._ensure_same_keys(

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,29 +7,29 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeie4sgmbm7k735mvx67je4bx6cheow2hgcyrsokffuuozbgq5zboiy
+  behaviours.py: bafybeid47shaw3hm7vxvlus66kvrwi5aqggyaegebmzkod36ckwjt34uze
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
-  handlers.py: bafybeie2rl3bfrontprcyuhjh35v5gglsogekgvinhyavr2fao4uvmrkoq
-  models.py: bafybeicu3edap3bwze7vt5sigwjtwjbhevyuu3s4qlweobraqzvxr4opwu
+  handlers.py: bafybeihfyqiyifecggmjl7grqwhkapmgwr47oxcwzv5ycv4w6oyolhrobq
+  models.py: bafybeifforxauf2fvsobta63wrlfnound565y52dgipw42ek3gq4aod67i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
-  tests/conftest.py: bafybeibl5a7shgy62sjytz7tjon6niad2x2g5vter6cavcji6vgmvvh5ni
-  tests/test_behaviours.py: bafybeicof4lz26b4v5x345r2a3yrpsp6f5ooqoyedrfphfuh476uiphk6y
+  tests/conftest.py: bafybeihx3f37n7y5kbgerhl4qsrit5gxktnmwvkrzkdyoox3jkfcyp234y
+  tests/test_behaviours.py: bafybeigwmqbeyl7lx6w3kgmw2zp2ctabcmguct7pymhn42i6orkzkcbdfe
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeihbuo7w7dliq2gqy74jqnxpy3zaxajtqbruek7msi5dcrulriiyyy
+  tests/test_handlers.py: bafybeigzttqwp5zlcdkhdmyfi6vuektmar2bfqwru2lprunmbaxligmqaq
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
-  tests/utils/test_local_cid.py: bafybeicsnmis2ry4zuqk5yjpenav2vdpntnkmkfl2jflhhnddpsho34e3y
+  tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_task.py: bafybeigdfi37m5taw6jecd7t2bg54ctcv4u3js5u3xd2lyckoazy4efpv4
   utils/__init__.py: bafybeiccdijaigu6e5p2iruwo5mkk224o7ywedc7nr6xeu5fpmhjqgk24e
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeicbidcifpfgr7q7q2qihud4hdplsoijukagbtcsnw7qjy5vob7sni
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
-  utils/local_cid.py: bafybeicdvmuoujnjzzuq6w7rvhukmxx473drxmgee6436vpdo3jioblprq
+  utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:
@@ -106,6 +106,7 @@ models:
       serious_slash_unit_amount: 8000000000000000
       mech_marketplace_address: '0x0000000000000000000000000000000000000000'
       payment_type_to_asset_address: {}
+      use_offchain: false
       default_chain_id: gnosis
       gnosis_ledger_rpc: http://localhost:8545
       polygon_ledger_rpc: http://localhost:8545

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeiemuq5kawwawelx2v2fdzptexc5sqlyapdcrhzl6w3k7t3hnpqzum
+  behaviours.py: bafybeifcqqgvye52g7pwv2mulptzhspvr7h75spdyt72ea724nf5w25k5y
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
   handlers.py: bafybeic2dcptbz6gw7ior47m7bxsmjti6mmq4y4sija45qwwyedfeq7s3q
   models.py: bafybeifforxauf2fvsobta63wrlfnound565y52dgipw42ek3gq4aod67i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeidhdwsz2upnmd23jcksenfay7rioekg54xv6e5l7x7aryq6p2d24q
-  tests/test_behaviours.py: bafybeiegzdngugmj3kycamybdhpiy6buto35dxehasn7ox4vepvvgv7h7u
+  tests/test_behaviours.py: bafybeifo25uodji5alqwldgv2wf2g5warrh4dqwww5mm6vgshdi7l452gm
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,27 +7,29 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifz2ligizvacutndjarzqvwi7blx4bv2utfe3tg6ulhvbvde5p364
+  behaviours.py: bafybeie4sgmbm7k735mvx67je4bx6cheow2hgcyrsokffuuozbgq5zboiy
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
-  handlers.py: bafybeid5xyeunhbuccsylmw2xh3sjhgzmkrqtemohbehwhcpuyxbfosnda
-  models.py: bafybeigeczmmo5m4a5hwkubh2ulq2i2lod7jvbmmsaua7atskeq2hyy4bm
+  handlers.py: bafybeie2rl3bfrontprcyuhjh35v5gglsogekgvinhyavr2fao4uvmrkoq
+  models.py: bafybeicu3edap3bwze7vt5sigwjtwjbhevyuu3s4qlweobraqzvxr4opwu
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
-  tests/conftest.py: bafybeib43nrx6rozfp5ez3dkevy2qzj2yclzs7kmlnqnowd3mhfhqxvxsi
-  tests/test_behaviours.py: bafybeidughroqd2yjkvf5omek3vuhswzcodb44obl5jq2ey3i53cn7fsyi
+  tests/conftest.py: bafybeibl5a7shgy62sjytz7tjon6niad2x2g5vter6cavcji6vgmvvh5ni
+  tests/test_behaviours.py: bafybeicof4lz26b4v5x345r2a3yrpsp6f5ooqoyedrfphfuh476uiphk6y
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeiduj6dmmdweroe7uwchp7k6pyeyk5uwmcy3wqa7vpese5ks3trllq
+  tests/test_handlers.py: bafybeihbuo7w7dliq2gqy74jqnxpy3zaxajtqbruek7msi5dcrulriiyyy
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
+  tests/utils/test_local_cid.py: bafybeicsnmis2ry4zuqk5yjpenav2vdpntnkmkfl2jflhhnddpsho34e3y
   tests/utils/test_task.py: bafybeigdfi37m5taw6jecd7t2bg54ctcv4u3js5u3xd2lyckoazy4efpv4
   utils/__init__.py: bafybeiccdijaigu6e5p2iruwo5mkk224o7ywedc7nr6xeu5fpmhjqgk24e
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeicbidcifpfgr7q7q2qihud4hdplsoijukagbtcsnw7qjy5vob7sni
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
+  utils/local_cid.py: bafybeicdvmuoujnjzzuq6w7rvhukmxx473drxmgee6436vpdo3jioblprq
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:
@@ -103,6 +105,7 @@ models:
       light_slash_unit_amount: 5000000000000000
       serious_slash_unit_amount: 8000000000000000
       mech_marketplace_address: '0x0000000000000000000000000000000000000000'
+      payment_type_to_asset_address: {}
       default_chain_id: gnosis
       gnosis_ledger_rpc: http://localhost:8545
       polygon_ledger_rpc: http://localhost:8545

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifhirbb4ixlhnedwqqzzxfaez3xz25kcf4wmxoa6yeot7ylgo7lye
+  behaviours.py: bafybeiemuq5kawwawelx2v2fdzptexc5sqlyapdcrhzl6w3k7t3hnpqzum
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
   handlers.py: bafybeic2dcptbz6gw7ior47m7bxsmjti6mmq4y4sija45qwwyedfeq7s3q
   models.py: bafybeifforxauf2fvsobta63wrlfnound565y52dgipw42ek3gq4aod67i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeidhdwsz2upnmd23jcksenfay7rioekg54xv6e5l7x7aryq6p2d24q
-  tests/test_behaviours.py: bafybeielhidvqdjdf4g42pxpeu4pubimhynl3pvanpea7yrpsyqomav7m4
+  tests/test_behaviours.py: bafybeiegzdngugmj3kycamybdhpiy6buto35dxehasn7ox4vepvvgv7h7u
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,15 +7,15 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeid47shaw3hm7vxvlus66kvrwi5aqggyaegebmzkod36ckwjt34uze
+  behaviours.py: bafybeifhirbb4ixlhnedwqqzzxfaez3xz25kcf4wmxoa6yeot7ylgo7lye
   dialogues.py: bafybeiha73ja2fz3edxe3nld2yjxz3dvftdyi4j3we7hwyw4urvvzdrlmy
-  handlers.py: bafybeihfyqiyifecggmjl7grqwhkapmgwr47oxcwzv5ycv4w6oyolhrobq
+  handlers.py: bafybeic2dcptbz6gw7ior47m7bxsmjti6mmq4y4sija45qwwyedfeq7s3q
   models.py: bafybeifforxauf2fvsobta63wrlfnound565y52dgipw42ek3gq4aod67i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
-  tests/conftest.py: bafybeihx3f37n7y5kbgerhl4qsrit5gxktnmwvkrzkdyoox3jkfcyp234y
-  tests/test_behaviours.py: bafybeigwmqbeyl7lx6w3kgmw2zp2ctabcmguct7pymhn42i6orkzkcbdfe
+  tests/conftest.py: bafybeidhdwsz2upnmd23jcksenfay7rioekg54xv6e5l7x7aryq6p2d24q
+  tests/test_behaviours.py: bafybeielhidvqdjdf4g42pxpeu4pubimhynl3pvanpea7yrpsyqomav7m4
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeigzttqwp5zlcdkhdmyfi6vuektmar2bfqwru2lprunmbaxligmqaq
+  tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u

--- a/packages/valory/skills/task_execution/tests/conftest.py
+++ b/packages/valory/skills/task_execution/tests/conftest.py
@@ -144,6 +144,9 @@ def params_stub() -> SimpleNamespace:
         use_mech_marketplace=True,
         mech_marketplace_address="0xMarketplace",
         payment_type_to_asset_address={},
+        # Offchain path enabled for the tests that exercise it; the
+        # default-off gate is covered by a dedicated test.
+        use_offchain=True,
         max_block_window=10_000,
         task_deadline=15.0,
         timeout_limit=2,

--- a/packages/valory/skills/task_execution/tests/conftest.py
+++ b/packages/valory/skills/task_execution/tests/conftest.py
@@ -143,6 +143,7 @@ def params_stub() -> SimpleNamespace:
         },
         use_mech_marketplace=True,
         mech_marketplace_address="0xMarketplace",
+        payment_type_to_asset_address={},
         max_block_window=10_000,
         task_deadline=15.0,
         timeout_limit=2,

--- a/packages/valory/skills/task_execution/tests/conftest.py
+++ b/packages/valory/skills/task_execution/tests/conftest.py
@@ -53,6 +53,7 @@ def _make_logger(include_debug: bool = False) -> SimpleNamespace:
         info=lambda *a, **k: None,
         warning=lambda *a, **k: None,
         error=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
     )
     if include_debug:
         ns.debug = lambda *a, **k: None  # type: ignore[attr-defined]

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1687,7 +1687,7 @@ def _seed_executing_task(
     behaviour: Any,
     params_stub: Any,
     is_offchain: bool,
-    req_id: int = 7,
+    req_id: Any = 7,
 ) -> None:
     """Wire enough state on the behaviour for _handle_done_task to run end-to-end."""
     my_mech = params_stub.agent_mech_contract_address.lower()
@@ -1817,7 +1817,9 @@ def test_handle_done_task_offchain_oversized_records_failure_and_resets(
     monkeypatch: Any,
 ) -> None:
     """Oversized off-chain response fails cleanly and writes a rejection."""
-    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id=13)
+    # String request_id — production keys these shared-state dicts by the str
+    # request_id parsed from the HTTP body, never an int.
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id="req-13")
     monkeypatch.setattr(
         beh_mod,
         "compute_cidv1",
@@ -1834,7 +1836,7 @@ def test_handle_done_task_offchain_oversized_records_failure_and_resets(
     assert send_calls == []
     assert shared_state[beh_mod.DONE_TASKS] == []
     assert behaviour._executing_task is None
-    rejection = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES][13]
+    rejection = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["req-13"]
     assert rejection["status"] == "rejected"
 
 
@@ -1845,8 +1847,8 @@ def test_handle_done_task_offchain_clears_in_memory_request(
     monkeypatch: Any,
 ) -> None:
     """A successful off-chain delivery clears the buffered in_memory request."""
-    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id=14)
-    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {14: "buffered-ipfs-data"}
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id="req-14")
+    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {"req-14": "buffered-ipfs-data"}
     monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
     monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
@@ -1854,7 +1856,19 @@ def test_handle_done_task_offchain_clears_in_memory_request(
 
     behaviour._handle_done_task(task_result=None)
 
-    assert 14 not in shared_state[beh_mod.IN_MEMORY_REQUESTS]
+    assert "req-14" not in shared_state[beh_mod.IN_MEMORY_REQUESTS]
+    assert behaviour._executing_task is None
+
+
+def test_finalize_done_task_no_executing_task_is_safe(
+    behaviour: Any, monkeypatch: Any
+) -> None:
+    """_finalize_done_task guards a None executing task (logs, returns, no crash)."""
+    behaviour._executing_task = None
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+
+    behaviour._finalize_done_task("bafysomecid")  # must not raise
+
     assert behaviour._executing_task is None
 
 

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1678,6 +1678,110 @@ def test_get_executing_task_result_exception(behaviour: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _handle_done_task: offchain skips IPFS and finalizes via local CID;
+# onchain path keeps uploading to IPFS.
+# ---------------------------------------------------------------------------
+
+
+def _seed_executing_task(
+    behaviour: Any,
+    params_stub: Any,
+    is_offchain: bool,
+    req_id: int = 7,
+) -> None:
+    """Wire enough state on the behaviour for _handle_done_task to run end-to-end."""
+    my_mech = params_stub.agent_mech_contract_address.lower()
+    params_stub.mech_to_config = {
+        my_mech: SimpleNamespace(is_marketplace_mech=True, use_dynamic_pricing=False)
+    }
+    behaviour._executing_task = {
+        "requestId": req_id,
+        "tool": "mytool",
+        "is_offchain": is_offchain,
+        "contract_address": params_stub.agent_mech_contract_address,
+    }
+    behaviour._done_task = None  # _handle_done_task assigns it
+    behaviour._invalid_request = True  # take the "Invalid response" failure shape
+    behaviour._ipfs_error_reason = None
+
+
+def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """Off-chain path skips the IPFS store call and writes a locally-computed CID."""
+    # Catches a mutation that flipped the gating predicate: any future change
+    # that fires the IPFS upload on the off-chain branch makes this test fail
+    # because send_message would then be invoked.
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id=11)
+
+    send_calls: list = []
+    monkeypatch.setattr(
+        behaviour,
+        "send_message",
+        lambda *a, **k: send_calls.append((a, k)),
+    )
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=None)
+
+    # The IPFS store request must not have been sent.
+    assert send_calls == []
+
+    # The done_task is published with the locally-derived multihash.
+    done_tasks = shared_state[beh_mod.DONE_TASKS]
+    assert len(done_tasks) == 1
+    done = done_tasks[0]
+    assert done["request_id"] == 11
+    assert isinstance(done["task_result"], str) and len(done["task_result"]) > 0
+    # Result string is hex (no 0x), matching the existing to_multihash output shape.
+    int(done["task_result"], 16)
+    assert behaviour._executing_task is None
+
+
+def test_handle_done_task_onchain_still_uploads_to_ipfs(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+) -> None:
+    """On-chain path keeps the IPFS upload, locking in the off-chain gate."""
+    # If a future refactor accidentally pulled the on-chain path through the
+    # new local-CID branch, the IPFS upload would not fire and this test would
+    # notice.
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=12)
+
+    monkeypatch.setattr(
+        behaviour,
+        "_build_ipfs_store_file_req",
+        lambda files, **k: (object(), fake_dialogue),
+    )
+    send_calls: list = []
+    monkeypatch.setattr(
+        behaviour,
+        "send_message",
+        lambda msg, dlg, cb, **k: send_calls.append((msg, dlg, cb)),
+    )
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=None)
+
+    assert len(send_calls) == 1
+    # IPFS callback is the existing store-response handler, not the local path.
+    # Bound methods compare unequal across access, so check by name.
+    assert send_calls[0][2].__func__ is behaviour._handle_store_response.__func__
+    # The IPFS path defers finalization to the callback; done_tasks empty for now.
+    assert shared_state[beh_mod.DONE_TASKS] == []
+
+
+# ---------------------------------------------------------------------------
 # _handle_store_response branches
 # ---------------------------------------------------------------------------
 

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1810,6 +1810,54 @@ def test_handle_store_response_invalid_done_task_resets_state(
     assert behaviour._done_task is None
 
 
+def test_handle_done_task_offchain_oversized_records_failure_and_resets(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """Oversized off-chain response fails cleanly and writes a rejection."""
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id=13)
+    monkeypatch.setattr(
+        beh_mod,
+        "compute_cidv1",
+        MagicMock(side_effect=ValueError("exceeds single-block bound")),
+    )
+    send_calls: list = []
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: send_calls.append(a))
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=None)
+
+    assert send_calls == []
+    assert shared_state[beh_mod.DONE_TASKS] == []
+    assert behaviour._executing_task is None
+    rejection = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES][13]
+    assert rejection["status"] == "rejected"
+
+
+def test_handle_done_task_offchain_clears_in_memory_request(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """A successful off-chain delivery clears the buffered in_memory request."""
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id=14)
+    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {14: "buffered-ipfs-data"}
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=None)
+
+    assert 14 not in shared_state[beh_mod.IN_MEMORY_REQUESTS]
+    assert behaviour._executing_task is None
+
+
 def test_handle_store_response_dynamic_pricing_recorded(
     behaviour: Any, params_stub: Any, shared_state: Dict[str, Any], monkeypatch: Any
 ) -> None:

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1742,6 +1742,16 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     int(done["task_result"], 16)
     assert behaviour._executing_task is None
 
+    # Off-chain return channel: the result is persisted under
+    # offchain_request_responses so /fetch_offchain_info can serve it. The
+    # response never hit public IPFS, and the done_task fallback carries the
+    # CID but not the result/prompt/cost_dict.
+    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES][11]
+    assert stored["status"] == "ok"
+    assert stored["request_id"] == 11
+    assert "result" in stored
+    assert isinstance(stored["content_cid"], str) and stored["content_cid"]
+
 
 def test_handle_done_task_onchain_still_uploads_to_ipfs(
     behaviour: Any,

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1701,7 +1701,7 @@ def _seed_executing_task(
         "contract_address": params_stub.agent_mech_contract_address,
     }
     behaviour._done_task = None  # _handle_done_task assigns it
-    behaviour._invalid_request = True  # take the "Invalid response" failure shape
+    behaviour._invalid_request = False  # default to the success shape
     behaviour._ipfs_error_reason = None
 
 
@@ -1727,7 +1727,7 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
 
-    behaviour._handle_done_task(task_result=None)
+    behaviour._handle_done_task(task_result=_make_success_result())
 
     # The IPFS store request must not have been sent.
     assert send_calls == []
@@ -1749,8 +1749,49 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES][11]
     assert stored["status"] == "ok"
     assert stored["request_id"] == 11
-    assert "result" in stored
     assert isinstance(stored["content_cid"], str) and stored["content_cid"]
+    # The committed object is served verbatim under "response" (envelope fields
+    # hang outside it), and it carries the real tool result.
+    assert stored["response"]["result"] == "prediction: yes"
+    # content_cid must be reproducible by re-hashing exactly the served
+    # "response" object — this is the verification contract every offchain
+    # consumer (mech-client, mech-interact, historical ETL) relies on.
+    recomputed = beh_mod.compute_cidv1(json.dumps(stored["response"]).encode("utf-8"))
+    assert recomputed == stored["content_cid"]
+
+
+def test_handle_done_task_offchain_invalid_request_recorded_as_failure(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """A failed off-chain task is served as a rejection, never as status 'ok'."""
+    # A tool/execution failure (_invalid_request) must not land in the success
+    # bucket: a paying requester keys refund/retry on `status`, so "ran but
+    # failed" has to be distinguishable from "succeeded".
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id="req-15")
+    behaviour._invalid_request = True
+    behaviour._ipfs_error_reason = "tool boom"
+
+    send_calls: list = []
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: send_calls.append(a))
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=None)
+
+    # No IPFS upload, no on-chain delivery for a failed offchain task.
+    assert send_calls == []
+    assert shared_state[beh_mod.DONE_TASKS] == []
+    assert behaviour._executing_task is None
+
+    rejection = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["req-15"]
+    assert rejection["status"] == "rejected"
+    assert rejection["status"] != "ok"
+    # The failure reason surfaces to the requester rather than being masked.
+    assert rejection["reason"] == "tool boom"
 
 
 def test_handle_done_task_onchain_still_uploads_to_ipfs(
@@ -1864,7 +1905,7 @@ def test_handle_done_task_offchain_clears_in_memory_request(
     monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
 
-    behaviour._handle_done_task(task_result=None)
+    behaviour._handle_done_task(task_result=_make_success_result())
 
     assert "req-14" not in shared_state[beh_mod.IN_MEMORY_REQUESTS]
     assert behaviour._executing_task is None

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -465,6 +465,31 @@ def test_signed_requests_bad_request(
     assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
 
 
+def test_signed_requests_offchain_disabled_returns_503(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """use_offchain=False (the Phase 1 default) makes the off-chain endpoint 503."""
+    handler_context.params.use_offchain = False
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    http_msg: Any = make_http_msg(
+        {
+            "ipfs_hash": "0x" + "ab" * 32,
+            "sender": "0xSender",
+            "delivery_rate": "1",
+            "request_id": "req-disabled",
+            "ipfs_data": "{}",
+        }
+    )
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert mh.pending_tasks == []
+
+
 def test_fetch_offchain_request_info_returns_insufficient_balance_response(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -408,6 +408,9 @@ def test_signed_requests_balance_scenarios(
                 if balance_status == "ok"
                 else "rpc unavailable"
             ),
+            "balance_tracker_address": "0xBalanceTracker",
+            "payment_type": "0xpaymenttype",
+            "chain_id": 100,
         },
     )
     mh.setup()
@@ -425,13 +428,17 @@ def test_signed_requests_balance_scenarios(
 
     pend = handler_context.shared_state["pending_tasks"]
     ipfsq = handler_context.shared_state["ipfs_tasks"]
+    in_mem = handler_context.shared_state["in_memory_requests"]
     if enqueued:
-        assert len(pend) == 1 and len(ipfsq) == 1
+        # Off-chain path: pending task is queued and the request metadata is
+        # buffered in memory. The IPFS task queue stays empty by design — the
+        # off-chain flow no longer publishes request metadata to IPFS.
+        assert len(pend) == 1 and ipfsq == [] and len(in_mem) == 1
         assert pend[0]["is_offchain"] is True
         assert pend[0]["requestId"] == request_id
-        assert ipfsq[0]["request_id"] == request_id
+        assert in_mem[request_id] == '{"foo":"bar"}'
     else:
-        assert pend == [] and ipfsq == []
+        assert pend == [] and ipfsq == [] and in_mem == {}
 
     assert handler_context.outbox.sent, "no HTTP response sent"
     resp: SimpleNamespace = handler_context.outbox.sent[-1]
@@ -472,6 +479,9 @@ def test_fetch_offchain_request_info_returns_insufficient_balance_response(
             "required_amount": int(delivery_rate),
             "available_amount": int(delivery_rate) - 1,
             "reason": "balance check completed",
+            "balance_tracker_address": "0xBalanceTracker",
+            "payment_type": "0xpaymenttype",
+            "chain_id": 100,
         },
     )
     mh.setup()
@@ -503,6 +513,9 @@ def test_signed_requests_rollback_partial_enqueue(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
     """Rollback queue entries when enqueue fails after partial append."""
+    # Simulates a failure mid-enqueue (the buffered metadata write blows up
+    # after pending_tasks has already accepted the entry). The handler must
+    # roll the pending entry back and surface 400, not leave dangling state.
     mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
     monkeypatch.setattr(
@@ -513,17 +526,20 @@ def test_signed_requests_rollback_partial_enqueue(
             "required_amount": int(delivery_rate),
             "available_amount": int(delivery_rate),
             "reason": "balance check completed",
+            "balance_tracker_address": "0xBalanceTracker",
+            "payment_type": "0xpaymenttype",
+            "chain_id": 100,
         },
     )
     mh.setup()
 
-    class FailingList(list):
-        """List that fails on append to simulate partial queue write."""
+    class FailingDict(dict):
+        """Dict that raises on assignment to simulate partial buffer write."""
 
-        def append(self, item: Any) -> None:
-            raise RuntimeError("simulated append failure")
+        def __setitem__(self, key: Any, value: Any) -> None:
+            raise RuntimeError("simulated buffer write failure")
 
-    handler_context.shared_state["ipfs_tasks"] = FailingList()
+    handler_context.shared_state["in_memory_requests"] = FailingDict()
 
     ipfs_hash: str = "0x" + "ab" * 32
     body: Dict[str, str] = {
@@ -537,10 +553,166 @@ def test_signed_requests_rollback_partial_enqueue(
     mh._handle_signed_requests(http_msg, http_dialogue)
 
     assert handler_context.shared_state["pending_tasks"] == []
-    assert handler_context.shared_state["ipfs_tasks"] == []
+    assert dict(handler_context.shared_state["in_memory_requests"]) == {}
 
     resp: SimpleNamespace = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+
+
+def _patched_handler_for_balance(
+    handler_context: Any,
+    monkeypatch: Any,
+    available_offset: int,
+    payment_type: str = "0xpaymenttype",
+    balance_tracker_address: str = "0xBalanceTracker",
+    chain_id: int = 100,
+) -> MechHttpHandler:
+    """Build a MechHttpHandler with the balance check patched to a fixed result."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: {
+            "status": "ok",
+            "required_amount": int(delivery_rate),
+            "available_amount": int(delivery_rate) + available_offset,
+            "reason": "balance check completed",
+            "balance_tracker_address": balance_tracker_address,
+            "payment_type": payment_type,
+            "chain_id": chain_id,
+        },
+    )
+    mh.setup()
+    return mh
+
+
+def _send_signed_request(
+    mh: MechHttpHandler, http_dialogue: Any, request_id: str
+) -> SimpleNamespace:
+    """Drive a signed offchain request and return the final HTTP response."""
+    http_msg: Any = make_http_msg(
+        {
+            "ipfs_hash": "0x" + "ab" * 32,
+            "request_id": request_id,
+            "ipfs_data": '{"foo":"bar"}',
+            "delivery_rate": "123",
+            "sender": "0x0000000000000000000000000000000000000001",
+        }
+    )
+    mh._handle_signed_requests(http_msg, http_dialogue)
+    return mh.context.outbox.sent[-1]
+
+
+def test_402_body_includes_structured_challenge(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """402 body carries the structured challenge fields alongside the legacy keys."""
+    handler_context.params.payment_type_to_asset_address = {
+        "0xpaymenttype": "0xUSDCToken",
+    }
+    mh = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=-50
+    )
+
+    resp = _send_signed_request(mh, http_dialogue, request_id="req-402-schema")
+    assert resp.status_code == HttpCode.PAYMENT_REQUIRED_CODE.value
+
+    payload = json.loads(resp.body.decode("utf-8"))
+    # Legacy keys still present so clients ignoring the new schema keep working.
+    assert payload["status"] == "rejected"
+    assert payload["reason"] == "insufficient balance"
+    # Structured challenge fields.
+    assert payload["scheme"] == "olas-prepay"
+    assert payload["payTo"] == "0xBalanceTracker"
+    assert payload["asset"] == "0xUSDCToken"
+    assert payload["chainId"] == 100
+    assert payload["currentBalance"] == "73"  # 123 + (-50) = 73
+    assert payload["required"] == "123"
+    assert payload["depositInstructions"] == {
+        "contract": "0xBalanceTracker",
+        "abi": "depositFor(address requester, uint256 amount)",
+    }
+    assert payload["error"] == "insufficient balance"
+
+
+def test_402_emits_www_authenticate_header(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """402 response carries the WWW-Authenticate header keyed by mech address."""
+    mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=-1)
+    resp = _send_signed_request(mh, http_dialogue, request_id="req-402-header")
+
+    assert resp.status_code == HttpCode.PAYMENT_REQUIRED_CODE.value
+    assert (
+        'WWW-Authenticate: Payment scheme="olas-prepay" '
+        'realm="0xMechAddr"' in resp.headers
+    )
+
+
+def test_402_native_asset_when_payment_type_unmapped(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Unmapped payment types surface the zero address as the asset."""
+    # Clients seeing the zero address must skip the ERC20 approve step and
+    # treat the payment as a native-asset deposit.
+    handler_context.params.payment_type_to_asset_address = {}
+    mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=-1)
+    resp = _send_signed_request(mh, http_dialogue, request_id="req-402-native")
+
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["asset"] == "0x0000000000000000000000000000000000000000"
+
+
+def test_200_emits_payment_receipt_header(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """200 response carries a Payment-Receipt header with valid base64-encoded JSON."""
+    mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=10)
+    resp = _send_signed_request(mh, http_dialogue, request_id="req-200-receipt")
+
+    assert resp.status_code == HttpCode.OK_CODE.value
+    receipt_line = next(
+        line for line in resp.headers.split("\n") if line.startswith("Payment-Receipt:")
+    )
+    encoded = receipt_line.split(": ", 1)[1].strip()
+    import base64 as _b64
+
+    receipt = json.loads(_b64.b64decode(encoded).decode("utf-8"))
+    assert receipt["request_id"] == "req-200-receipt"
+    assert receipt["accepted_amount"] == "123"
+    assert receipt["settlement_status"] == "pending"
+    # ISO 8601 UTC with trailing Z. Loose check that it parses as a date.
+    from datetime import datetime as _dt
+
+    _dt.fromisoformat(receipt["accepted_at"].replace("Z", "+00:00"))
+
+
+def test_200_body_unchanged_for_legacy_clients(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """200 body shape is unchanged. Receipt only goes in the header."""
+    mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=10)
+    resp = _send_signed_request(mh, http_dialogue, request_id="req-200-body")
+
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload == {"request_id": "req-200-body"}
+
+
+def test_offchain_request_buffered_in_memory_not_in_ipfs_tasks(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The offchain handler buffers metadata in-memory and skips ipfs_tasks."""
+    # Locks in Piece 1's behavioural contract: the legacy IPFS upload queue is
+    # no longer written from the offchain path. A future refactor that flipped
+    # the flag back without us noticing would fail this test.
+    mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=10)
+    _send_signed_request(mh, http_dialogue, request_id="req-in-mem")
+
+    assert handler_context.shared_state["ipfs_tasks"] == []
+    assert handler_context.shared_state["in_memory_requests"] == {
+        "req-in-mem": '{"foo":"bar"}'
+    }
 
 
 def test_fetch_offchain_request_info_found(

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -1908,3 +1908,112 @@ def test_signed_requests_accepts_zero_delivery_rate(
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.OK_CODE.value
     assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+# --- guard tests for the defensive paths added in the remediation -----------
+
+
+def _http_handler(handler_context: Any, monkeypatch: Any) -> MechHttpHandler:
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    return mh
+
+
+def test_build_402_challenge_raises_without_balance_tracker_address(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """The 402 builder refuses to emit zero-address deposit instructions."""
+    mh = _http_handler(handler_context, monkeypatch)
+    with pytest.raises(ValueError, match="balance_tracker_address"):
+        mh._build_402_challenge(
+            {hmod.ResponseKey.PAYMENT_TYPE.value: "0x01"},
+            error_msg="insufficient balance",
+        )
+
+
+def test_build_402_challenge_payment_type_case_insensitive(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """A checksummed payment_type resolves against the lower-cased asset map."""
+    handler_context.params.payment_type_to_asset_address = {"0xabc": "0xAssetAddr"}
+    mh = _http_handler(handler_context, monkeypatch)
+    challenge = mh._build_402_challenge(
+        {
+            hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+            hmod.ResponseKey.PAYMENT_TYPE.value: "0xABC",
+        },
+        error_msg="insufficient balance",
+    )
+    assert challenge["asset"] == "0xAssetAddr"
+
+
+def test_build_402_challenge_none_payment_type_is_safe(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """A present-but-None payment_type must not AttributeError on .lower()."""
+    mh = _http_handler(handler_context, monkeypatch)
+    challenge = mh._build_402_challenge(
+        {
+            hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+            hmod.ResponseKey.PAYMENT_TYPE.value: None,
+        },
+        error_msg="insufficient balance",
+    )
+    assert challenge["asset"] == hmod.ZERO_ADDRESS
+
+
+def test_send_ok_response_rejects_non_newline_extra_headers(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A non-newline-terminated header block is rejected (can't merge body)."""
+    mh = _http_handler(handler_context, monkeypatch)
+    http_msg: Any = make_http_msg({"request_id": "req-x"})
+    with pytest.raises(ValueError, match="newline-terminated"):
+        mh._send_ok_response(
+            http_msg=http_msg,
+            http_dialogue=http_dialogue,
+            data={"request_id": "req-x"},
+            extra_headers="X-No-Newline: y",
+        )
+
+
+def test_send_rejection_response_rejects_non_newline_extra_headers(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Same newline guard on the rejection sender."""
+    mh = _http_handler(handler_context, monkeypatch)
+    http_msg: Any = make_http_msg({"request_id": "req-x"})
+    with pytest.raises(ValueError, match="newline-terminated"):
+        mh._send_rejection_response(
+            http_msg,
+            http_dialogue,
+            "req-x",
+            reason="r",
+            status_code=HttpCode.PAYMENT_REQUIRED_CODE.value,
+            status_text="t",
+            extra_headers="X-No-Newline: y",
+        )
+
+
+def test_handler_replies_500_when_402_build_fails(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """If the 402 builder raises, the handler replies 500 instead of hanging."""
+    monkeypatch.setattr(
+        MechHttpHandler,
+        "_check_offchain_requester_balance",
+        lambda self, sender, delivery_rate: {
+            hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+            hmod.ResponseKey.AVAILABLE_AMOUNT.value: 0,
+            hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
+        },
+    )
+    mh = _http_handler(handler_context, monkeypatch)
+    http_msg: Any = make_http_msg(
+        _make_signed_request_body(delivery_rate="1", request_id="req-500")
+    )
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.INTERNAL_SERVER_ERROR_CODE.value

--- a/packages/valory/skills/task_execution/tests/utils/test_local_cid.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_local_cid.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the local CID helper.
+
+The fixtures pair each input byte-string with the CID a real ``ipfs add
+--cid-version=1 --raw-leaves=false`` produced on the same input. Keeping those
+pairs as a hardcoded table makes the contract explicit: if a future refactor
+changes the encoding in a way that breaks parity with go-ipfs, these tests
+fail loudly rather than silently producing CIDs the on-chain commitment side
+no longer accepts.
+"""
+
+import pytest
+
+from packages.valory.skills.task_execution.utils.local_cid import compute_cidv1
+
+
+# Tuples of (label, content, expected_cid_from_real_ipfs_add).
+_FIXTURES = [
+    (
+        "empty",
+        b"",
+        "bafybeif7ztnhq65lumvvtr4ekcwd2ifwgm3awq4zfr3srh462rwyinlb4y",
+    ),
+    (
+        "small_text",
+        b"hello",
+        "bafybeid3weurg3gvyoi7nisadzolomlvoxoppe2sesktnpvdve3256n5tq",
+    ),
+    (
+        "small_json",
+        b'{"requestId":"42","result":"ok"}',
+        "bafybeihjg4w34tu2zmlriemthl24wdynhfx2rpsiflv7wxmb4lsk34etlu",
+    ),
+    (
+        "100k_repeated",
+        b"x" * 100000,
+        "bafybeiay23kics7rguz4kaxxmyz7d6bciozygbi27wllerri6dpqenuifi",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,content,expected",
+    _FIXTURES,
+    ids=[fx[0] for fx in _FIXTURES],
+)
+def test_compute_cidv1_matches_real_ipfs_output(
+    label: str, content: bytes, expected: str
+) -> None:
+    """Local CIDv1 matches ``ipfs add --cid-version=1 --raw-leaves=false`` byte-for-byte."""
+    assert compute_cidv1(content) == expected
+
+
+def test_compute_cidv1_oversize_raises() -> None:
+    """Content beyond the single-block bound fails loudly rather than silently."""
+    oversized = b"a" * (1024 * 1024 + 1)
+    with pytest.raises(ValueError, match="exceeds single-block bound"):
+        compute_cidv1(oversized)
+
+
+def test_compute_cidv1_is_deterministic() -> None:
+    """Identical input always produces the same CID — no hidden state."""
+    content = b'{"different":"payload"}'
+    assert compute_cidv1(content) == compute_cidv1(content)

--- a/packages/valory/skills/task_execution/tests/utils/test_local_cid.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_local_cid.py
@@ -31,7 +31,6 @@ import pytest
 
 from packages.valory.skills.task_execution.utils.local_cid import compute_cidv1
 
-
 # Tuples of (label, content, expected_cid_from_real_ipfs_add).
 _FIXTURES = [
     (
@@ -70,10 +69,21 @@ def test_compute_cidv1_matches_real_ipfs_output(
 
 
 def test_compute_cidv1_oversize_raises() -> None:
-    """Content beyond the single-block bound fails loudly rather than silently."""
-    oversized = b"a" * (1024 * 1024 + 1)
+    """Content one byte past the 256 KiB single-block bound fails loudly."""
+    oversized = b"a" * (256 * 1024 + 1)
     with pytest.raises(ValueError, match="exceeds single-block bound"):
         compute_cidv1(oversized)
+
+
+def test_compute_cidv1_accepts_exactly_one_block() -> None:
+    """Content of exactly 256 KiB is a single block and must be accepted."""
+    # No real-ipfs golden at this exact boundary (the test env has no ipfs
+    # binary); the parametrized fixtures pin go-ipfs parity for representative
+    # sizes, and this guards the off-by-one at the chunk boundary.
+    exactly_one_block = b"a" * (256 * 1024)
+    cid = compute_cidv1(exactly_one_block)
+    assert cid.startswith("bafy")
+    assert cid == compute_cidv1(exactly_one_block)
 
 
 def test_compute_cidv1_is_deterministic() -> None:

--- a/packages/valory/skills/task_execution/utils/local_cid.py
+++ b/packages/valory/skills/task_execution/utils/local_cid.py
@@ -23,15 +23,26 @@ would for the same bytes. Intended for the offchain delivery path where we put t
 content commitment on chain without publishing the content to public IPFS.
 
 Single-block only: content must fit in one IPFS block. IPFS chunks at 256 KiB by
-default; payloads above that bound need a chunked / linked DAG and are not handled
-here. Hash sanity asserts the bound at runtime so a future oversized response fails
-loudly rather than silently producing a CID a real IPFS upload would not match.
+default, so the single-block bound is exactly 256 KiB; payloads above it need a
+chunked / linked DAG and are not handled here. ``compute_cidv1`` raises
+``ValueError`` (not ``assert``, which ``python -O`` would strip) above the bound,
+so a future oversized response fails loudly rather than silently producing a CID
+a real IPFS upload would not match.
+
+Shape note: this is a *bare* single-block file CID, matching ``ipfs add`` without
+``-w``. The mech's on-chain delivery path instead uploads via the IPFS connection
+with ``wrap_with_directory=True``, committing the *directory* CID. The two paths
+therefore commit structurally different CIDs for the same content — intentional:
+offchain content is never published, so its commitment is verified by re-hashing
+the raw bytes as a bare file, not by resolving ``ipfs://<cid>/<req_id>``.
 """
 
 import base64
 import hashlib
 
-_MAX_BLOCK_BYTES = 1024 * 1024  # IPFS default chunker is 256 KiB; one MiB is plenty.
+_MAX_BLOCK_BYTES = (
+    256 * 1024
+)  # IPFS default chunk size; above this needs a multi-block DAG.
 
 # Multicodec / multihash / multibase prefix bytes.
 _CIDV1_VERSION = 0x01

--- a/packages/valory/skills/task_execution/utils/local_cid.py
+++ b/packages/valory/skills/task_execution/utils/local_cid.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Pure-Python local CIDv1 computation matching IPFS UnixFS + DAG-PB single-block output.
+
+Produces the same CIDv1 string that ``ipfs add --cid-version=1 --raw-leaves=false``
+would for the same bytes. Intended for the offchain delivery path where we put the
+content commitment on chain without publishing the content to public IPFS.
+
+Single-block only: content must fit in one IPFS block. IPFS chunks at 256 KiB by
+default; payloads above that bound need a chunked / linked DAG and are not handled
+here. Hash sanity asserts the bound at runtime so a future oversized response fails
+loudly rather than silently producing a CID a real IPFS upload would not match.
+"""
+
+import base64
+import hashlib
+
+_MAX_BLOCK_BYTES = 1024 * 1024  # IPFS default chunker is 256 KiB; one MiB is plenty.
+
+# Multicodec / multihash / multibase prefix bytes.
+_CIDV1_VERSION = 0x01
+_DAG_PB_CODEC = 0x70
+_SHA256_MULTIHASH_CODE = 0x12
+_SHA256_DIGEST_LEN = 0x20
+
+# UnixFS data type enum: File = 2.
+_UNIXFS_TYPE_FILE = 2
+
+
+def _varint(value: int) -> bytes:
+    """Encode an unsigned integer as a protobuf varint.
+
+    :param value: the non-negative integer to encode.
+    :return: the encoded varint bytes.
+    :raises ValueError: if ``value`` is negative.
+    """
+    if value < 0:
+        raise ValueError("varint requires non-negative value")
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def _length_delimited(field_number: int, payload: bytes) -> bytes:
+    """Encode a protobuf length-delimited field (wire type 2).
+
+    :param field_number: the protobuf field number.
+    :param payload: the field payload bytes.
+    :return: the encoded tag + length + payload.
+    """
+    tag = (field_number << 3) | 2
+    return _varint(tag) + _varint(len(payload)) + payload
+
+
+def _varint_field(field_number: int, value: int) -> bytes:
+    """Encode a protobuf varint field (wire type 0).
+
+    :param field_number: the protobuf field number.
+    :param value: the field value.
+    :return: the encoded tag + value.
+    """
+    tag = (field_number << 3) | 0
+    return _varint(tag) + _varint(value)
+
+
+def _encode_unixfs_file(content: bytes) -> bytes:
+    """Encode a UnixFS ``Type=File`` Data message for the given content.
+
+    Mirrors the canonical encoding go-ipfs produces for a single-block file: a
+    Type varint (field 1), optional Data bytes (field 2), and the filesize
+    varint (field 3). The Data field is omitted entirely for empty content,
+    matching go-ipfs' behaviour.
+
+    :param content: the raw file content.
+    :return: the serialized UnixFS message bytes.
+    """
+    out = bytearray()
+    out += _varint_field(1, _UNIXFS_TYPE_FILE)
+    if content:
+        out += _length_delimited(2, content)
+    out += _varint_field(3, len(content))
+    return bytes(out)
+
+
+def _encode_dag_pb_node(data: bytes) -> bytes:
+    """Wrap ``data`` in a DAG-PB ``PBNode`` with no links.
+
+    The DAG-PB ``PBNode`` schema has ``Data`` as field 1 and ``Links`` as field 2.
+    For a single-block file we have no links, only the Data field carrying the
+    serialized UnixFS message.
+
+    :param data: the serialized UnixFS bytes to wrap.
+    :return: the serialized DAG-PB node bytes.
+    """
+    return _length_delimited(1, data)
+
+
+def _multibase_base32_lower(payload: bytes) -> str:
+    """Encode bytes as RFC 4648 base32 lowercase without padding, prefixed with 'b'.
+
+    Multibase prefix ``b`` selects base32-lower; this is the encoding ``ipfs add
+    --cid-version=1`` emits by default (CIDs starting with ``bafy...`` for
+    DAG-PB).
+
+    :param payload: the bytes to multibase-encode.
+    :return: the multibase string with the ``b`` prefix.
+    """
+    encoded = base64.b32encode(payload).decode("ascii").rstrip("=").lower()
+    return "b" + encoded
+
+
+def compute_cidv1(content: bytes) -> str:
+    """Compute the CIDv1 string a real ``ipfs add`` would produce for ``content``.
+
+    The output is byte-for-byte equivalent to running
+    ``ipfs add --cid-version=1 --raw-leaves=false`` on the same content. The
+    returned string is a multibase base32-lower (``bafy...``) DAG-PB CIDv1 over
+    a SHA-256 multihash of the UnixFS-wrapped content.
+
+    :param content: the content bytes to commit to.
+    :return: the multibase-encoded CIDv1 string.
+    :raises ValueError: if ``content`` exceeds the single-block bound; chunked
+        DAGs are intentionally unsupported (offchain payloads in the mech are
+        well under 256 KiB today and the unbounded path needs a different DAG
+        shape).
+    """
+    if len(content) > _MAX_BLOCK_BYTES:
+        raise ValueError(
+            f"content size {len(content)} exceeds single-block bound "
+            f"{_MAX_BLOCK_BYTES}; chunked DAG encoding is not supported"
+        )
+
+    unixfs_bytes = _encode_unixfs_file(content)
+    dag_pb_bytes = _encode_dag_pb_node(unixfs_bytes)
+
+    digest = hashlib.sha256(dag_pb_bytes).digest()
+    multihash = bytes([_SHA256_MULTIHASH_CODE, _SHA256_DIGEST_LEN]) + digest
+    cid_bytes = bytes([_CIDV1_VERSION, _DAG_PB_CODEC]) + multihash
+
+    return _multibase_base32_lower(cid_bytes)

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu
+- valory/task_execution:0.1.0:bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeihfbafxwxfs63rb7svio3dif55bvvqtzl2fer6ssc5mda4n2jbwii
+- valory/task_execution:0.1.0:bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
+- valory/task_execution:0.1.0:bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeiahxtwdmlhixhy3y2x3zrtyzpnte7xnojqywvflxtgtfuuhgzgt6y
+- valory/task_execution:0.1.0:bafybeidkspdeqk2weqn5g6g6msrn2oqmun4d2jpbzswilufejhgl3w7dlu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeicbeiihrbw2ffhi5vnk2d6cxt3mfmuhjyru6ymdzxtrg4agocgptm
+- valory/task_execution:0.1.0:bafybeidqtcpqhhl5uefh4jijevvnhjbxaqgputyvvewx3zcscktyapg2eu
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Summary

PR 1 of 3 for the mech prepay migration (see `docs/mech_prepay_spec.md`). Two additive changes to the off-chain HTTP path. Contracts unchanged. On-chain (autonomous polling) behaviour is bit-for-bit identical (regression-tested below).

## PR series (how the three connect)

- **PR 1/3 — this PR:** mech server off-chain path. In off-chain mode, skip the IPFS upload of the response (keep it private) and commit a locally-computed **bare-file** CIDv1 instead, plus the structured 402 challenge + `Payment-Receipt` header. The off-chain return channel persists the result under `offchain_request_responses` so `/fetch_offchain_info` can serve it (the response never hits public IPFS). Ships dark behind `use_offchain=false`.
- **PR 2/3 — `valory-xyz/kv-store#16`:** adds `DELETE_REQUEST` / `LIST_REQUEST` performatives to the `valory/kv_store` protocol. Pure enabler — no mech wiring.
- **PR 3/3 — `#455`:** operator-side **preimage retention buffer** — mirrors each off-chain `(request, response)` into the `kv_store` connection keyed by `request_id`, with a background sweeper that LISTs by prefix + DELETEs entries past a retention window (uses PR 2's performatives). Ships dark behind `preimage_retention_enabled=false`. Draft, blocked on PR 2 publishing.

So: PR 1 makes off-chain private, PR 2 gives `kv_store` the delete/list verbs, PR 3 uses them for durable retention.

### Piece 1: skip IPFS upload on the off-chain path, compute CID locally

- New `packages/valory/skills/task_execution/utils/local_cid.py` with `compute_cidv1(content)` that produces the exact CID a real `ipfs add --cid-version=1 --raw-leaves=false` would for the same bytes. Pure-Python UnixFS + DAG-PB encoder, sha256, multibase base32-lower. No new top-level dependencies. Single-block only (raises if content exceeds 1 MiB).
- `_enqueue_offchain_request` no longer pushes to `ipfs_tasks`; it buffers the request JSON in a new `shared_state[in_memory_requests]` dict keyed by `request_id`.
- `_handle_done_task` gates the IPFS store upload on `is_offchain`. When `True` it computes the CID locally and finalizes the done_task synchronously via the new extracted `_finalize_done_task` helper. When `False` (on-chain autonomous-polling tasks) the existing IPFS flow runs unchanged.
- `task_result` (multihash hex passed as on-chain `delivery_data`) is unchanged across both paths.

### Piece 2: structured 402 + Payment-Receipt header

- 402 body now includes `scheme, payTo, asset, chainId, currentBalance, required, depositInstructions, error` alongside the existing `{request_id, status, reason}` keys. Legacy clients reading only `reason` keep working.
- 402 emits `WWW-Authenticate: Payment scheme="olas-prepay" realm="<mech_address>"`.
- 200 emits `Payment-Receipt: <base64 JSON>` carrying `{request_id, accepted_at, accepted_amount, settlement_status: "pending"}`. Header is intentionally a snapshot at HTTP-accept time, NOT a settlement confirmation.
- Adds `payment_type_to_asset_address: Dict[str, str]` skill param. Empty by default; payment types not in the mapping surface the zero address as `asset` so clients can detect native-asset deposits.

## Review updates

- **Off-chain return channel.** The success path now persists the result under `offchain_request_responses[request_id]` so `/fetch_offchain_info` serves the actual `result`/`prompt`/`cost_dict`; previously it fell back to the `done_task`, which carries the CID but not the content (which is no longer on public IPFS).
- **Verifiable commitment.** The committed object is served verbatim under a dedicated `response` field, with the envelope (`request_id`/`status`/`content_cid`) kept outside it, so a consumer re-derives `compute_cidv1(json.dumps(stored["response"])) == content_cid` byte-for-byte (mirrors the on-chain path, which content-addresses `json.dumps(response)`).
- **Fail-honest status.** A task that ran but failed (`_invalid_request`) is now routed through the terminal rejection channel (`status: "rejected"` + reason), not served as `status: "ok"` with an error string — a prepaid requester keys refund/retry/dispute on `status`.

## Tests

- `tests/utils/test_local_cid.py`: 4 fixtures compare the local CID against real `ipfs add` output for known content (empty, small text, small JSON, 100 KiB repeated). Plus oversize rejection + determinism.
- `tests/test_handlers.py`: 5 new tests covering 402 body schema, `WWW-Authenticate` header, `Payment-Receipt` header valid base64-JSON, 200 body shape unchanged for legacy clients, off-chain buffer goes to memory and not to `ipfs_tasks`. Existing balance-scenarios and rollback tests updated to reflect the new flow.
- `tests/test_behaviours.py`: off-chain `_handle_done_task` skips the IPFS store call and finalizes with a local CID (asserting the `content_cid` round-trip); a failed off-chain task is recorded as a rejection, never `status: "ok"`; on-chain path still fires the IPFS upload (regression for the gate).

Local results: full `common_checks.yaml` suite green (lock_check, copyright/deps, third-party + doc hashes, linters, abci specs, handlers, bandit, liccheck, gitleaks); 569 skill tests pass. `safety` reports two pre-existing transitive CVE warnings that also fail on `main`.

## Out of scope

- kv_store-backed preimage buffer + background sweeper. Lands in PR 3 after `kv_store` gains `DELETE_REQUEST` and `LIST_REQUEST` performatives (PR 2 against `valory-xyz/kv-store`).
- mech-side write to wildcard, mech-client, mech-interact, 503 backpressure: separate workstreams.

## Test plan

- [ ] CI green on all `tomte tox` envs that run in `common_checks.yaml`
- [ ] Manual: drive a signed off-chain request against a running mech, confirm the response carries the new `Payment-Receipt` header
- [ ] Manual: drive an insufficient-balance request, confirm 402 body has the structured fields and the `WWW-Authenticate` header is set
- [ ] Manual: confirm the on-chain `delivery_data` written at settlement equals `to_multihash(compute_cidv1(response_json))` for the off-chain path
- [ ] Manual: confirm an on-chain (autonomous-polling) request still uploads to IPFS and behaves exactly as on `main`
- [ ] Manual: poll `/fetch_offchain_info` after an off-chain delivery, confirm `compute_cidv1(json.dumps(body["response"]))` equals the served `content_cid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
