### PR TITLE
fix(token-prices): add gpt-4.1-mini-2025-04-14 to TOKEN_PRICES

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde",
-        "skill/valory/task_execution/0.1.0": "bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja",
+        "skill/valory/mech_abci/0.1.0": "bafybeicvdhsjd26jkfvfqjvzl3muv46bdhi2xgwbe2qps3qcfy7pc6f4ia",
+        "skill/valory/task_execution/0.1.0": "bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicwnwhffu6oeyhbkfdda6rkapip44crbdbty642d3vapci7hbpgae",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeicdamiszm56bgq2x7q7r2c5ie3rg6tpkwdq4o6knqegk6vydqtn5u",
-        "service/valory/mech/0.1.0": "bafybeibsm7xb7bbjwkruk7hixdoeal34pkuv6p2fn4rv5qa6kgn2s7t3je"
+        "agent/valory/mech/0.1.0": "bafybeidggko4gtq5pqqrx52i4k7f7wndwwuwnphsslhkqixwyry5mjbswm",
+        "service/valory/mech/0.1.0": "bafybeigkljjcjgtk7r7exxre7kgxcxf4tfvdo4jzfq7axhmp45wd5dedem"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeicvdhsjd26jkfvfqjvzl3muv46bdhi2xgwbe2qps3qcfy7pc6f4ia",
-        "skill/valory/task_execution/0.1.0": "bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicwnwhffu6oeyhbkfdda6rkapip44crbdbty642d3vapci7hbpgae",
+        "skill/valory/mech_abci/0.1.0": "bafybeidjjknxrn4ldakdeq7azuffe4a76oi2vladmjkb57z3fmeg3z5g6a",
+        "skill/valory/task_execution/0.1.0": "bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidggko4gtq5pqqrx52i4k7f7wndwwuwnphsslhkqixwyry5mjbswm",
-        "service/valory/mech/0.1.0": "bafybeigkljjcjgtk7r7exxre7kgxcxf4tfvdo4jzfq7axhmp45wd5dedem"
+        "agent/valory/mech/0.1.0": "bafybeicr4x5x4xlaryx3zqbkhbvfr5jqzrxrpkecz7kld24crk4jgpg3zu",
+        "service/valory/mech/0.1.0": "bafybeiahgqyegqmukcgtnwv5yh7eqfnb5xwmmxiyockrf3jkrtlu5dcszq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde
+- valory/mech_abci:0.1.0:bafybeicvdhsjd26jkfvfqjvzl3muv46bdhi2xgwbe2qps3qcfy7pc6f4ia
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
-- valory/task_submission_abci:0.1.0:bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja
+- valory/task_execution:0.1.0:bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44
+- valory/task_submission_abci:0.1.0:bafybeicwnwhffu6oeyhbkfdda6rkapip44crbdbty642d3vapci7hbpgae
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicvdhsjd26jkfvfqjvzl3muv46bdhi2xgwbe2qps3qcfy7pc6f4ia
+- valory/mech_abci:0.1.0:bafybeidjjknxrn4ldakdeq7azuffe4a76oi2vladmjkb57z3fmeg3z5g6a
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44
-- valory/task_submission_abci:0.1.0:bafybeicwnwhffu6oeyhbkfdda6rkapip44crbdbty642d3vapci7hbpgae
+- valory/task_execution:0.1.0:bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe
+- valory/task_submission_abci:0.1.0:bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidggko4gtq5pqqrx52i4k7f7wndwwuwnphsslhkqixwyry5mjbswm
+agent: valory/mech:0.1.0:bafybeicr4x5x4xlaryx3zqbkhbvfr5jqzrxrpkecz7kld24crk4jgpg3zu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeicdamiszm56bgq2x7q7r2c5ie3rg6tpkwdq4o6knqegk6vydqtn5u
+agent: valory/mech:0.1.0:bafybeidggko4gtq5pqqrx52i4k7f7wndwwuwnphsslhkqixwyry5mjbswm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja
+- valory/task_submission_abci:0.1.0:bafybeicwnwhffu6oeyhbkfdda6rkapip44crbdbty642d3vapci7hbpgae
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
+- valory/task_execution:0.1.0:bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeicwnwhffu6oeyhbkfdda6rkapip44crbdbty642d3vapci7hbpgae
+- valory/task_submission_abci:0.1.0:bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44
+- valory/task_execution:0.1.0:bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -25,25 +25,25 @@ fingerprint:
   tests/utils/test_task.py: bafybeigdfi37m5taw6jecd7t2bg54ctcv4u3js5u3xd2lyckoazy4efpv4
   utils/__init__.py: bafybeiccdijaigu6e5p2iruwo5mkk224o7ywedc7nr6xeu5fpmhjqgk24e
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
-  utils/benchmarks.py: bafybeicbidcifpfgr7q7q2qihud4hdplsoijukagbtcsnw7qjy5vob7sni
+  utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:
-- valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
 - valory/ipfs:0.1.0:bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta
+- valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 contracts:
-- valory/olas_mech:0.1.0:bafybeifvxzldiclpk7ztinivtjaf3y7yfrkw677y73tb2cukkywbagawc4
-- valory/mech_marketplace:0.1.0:bafybeifwx6owth25ud4pknu2s2vcxitt3w2eotjkavmwksdhmur2xd5qgy
 - valory/balance_tracker:0.1.0:bafybeibb7bzedhht262sn2t4vklcjcaa5fibermmcepnqi2wrcorkyz4qa
+- valory/mech_marketplace:0.1.0:bafybeifwx6owth25ud4pknu2s2vcxitt3w2eotjkavmwksdhmur2xd5qgy
+- valory/olas_mech:0.1.0:bafybeifvxzldiclpk7ztinivtjaf3y7yfrkw677y73tb2cukkywbagawc4
 protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
-- valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
-- valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
+- valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
+- valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 behaviours:
@@ -86,35 +86,36 @@ models:
     args:
       agent_index: 0
       api_keys: {}
-      tools_to_package_hash: {}
+      base_ledger_rpc: http://localhost:8545
+      default_chain_id: gnosis
       from_block_range: 50000
-      num_agents: 4
-      mech_to_config: {}
-      tools_to_pricing: {}
-      polling_interval: 30.0
-      step_in_list_size: 20
-      mech_to_max_delivery_rate: {}
-      task_deadline: 240.0
+      gnosis_ledger_rpc: http://localhost:8545
+      light_slash_unit_amount: 5000000000000000
       max_block_window: 500
-      use_slashing: false
-      timeout_limit: 3
+      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
+      mech_to_config: {}
+      mech_to_max_delivery_rate: {}
+      num_agents: 4
+      polling_interval: 30.0
+      polygon_ledger_rpc: http://localhost:8545
+      serious_slash_unit_amount: 8000000000000000
       slash_cooldown_hours: 3
       slash_threshold_amount: 10000000000000000
-      light_slash_unit_amount: 5000000000000000
-      serious_slash_unit_amount: 8000000000000000
-      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
-      default_chain_id: gnosis
-      gnosis_ledger_rpc: http://localhost:8545
-      polygon_ledger_rpc: http://localhost:8545
-      base_ledger_rpc: http://localhost:8545
+      step_in_list_size: 20
+      task_deadline: 240.0
+      timeout_limit: 3
+      tools_to_package_hash: {}
+      tools_to_pricing: {}
+      use_slashing: false
     class_name: Params
 dependencies:
-  open-aea-ledger-ethereum:
-    version: ==2.2.7
   PyYAML:
     version: ==6.0.1
-  prometheus_client:
-    version: ==0.23.1
+  open-aea-ledger-ethereum:
+    version: ==2.2.7
   pebble:
     version: ==5.1.3
+  prometheus_client:
+    version: ==0.23.1
 is_abstract: false
+customs: []

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -31,19 +31,19 @@ fingerprint:
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:
-- valory/ipfs:0.1.0:bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta
 - valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
+- valory/ipfs:0.1.0:bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 contracts:
-- valory/balance_tracker:0.1.0:bafybeibb7bzedhht262sn2t4vklcjcaa5fibermmcepnqi2wrcorkyz4qa
-- valory/mech_marketplace:0.1.0:bafybeifwx6owth25ud4pknu2s2vcxitt3w2eotjkavmwksdhmur2xd5qgy
 - valory/olas_mech:0.1.0:bafybeifvxzldiclpk7ztinivtjaf3y7yfrkw677y73tb2cukkywbagawc4
+- valory/mech_marketplace:0.1.0:bafybeifwx6owth25ud4pknu2s2vcxitt3w2eotjkavmwksdhmur2xd5qgy
+- valory/balance_tracker:0.1.0:bafybeibb7bzedhht262sn2t4vklcjcaa5fibermmcepnqi2wrcorkyz4qa
 protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
-- valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
-- valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
+- valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
+- valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 behaviours:
@@ -86,36 +86,35 @@ models:
     args:
       agent_index: 0
       api_keys: {}
-      base_ledger_rpc: http://localhost:8545
-      default_chain_id: gnosis
+      tools_to_package_hash: {}
       from_block_range: 50000
-      gnosis_ledger_rpc: http://localhost:8545
-      light_slash_unit_amount: 5000000000000000
-      max_block_window: 500
-      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
-      mech_to_config: {}
-      mech_to_max_delivery_rate: {}
       num_agents: 4
+      mech_to_config: {}
+      tools_to_pricing: {}
       polling_interval: 30.0
-      polygon_ledger_rpc: http://localhost:8545
-      serious_slash_unit_amount: 8000000000000000
+      step_in_list_size: 20
+      mech_to_max_delivery_rate: {}
+      task_deadline: 240.0
+      max_block_window: 500
+      use_slashing: false
+      timeout_limit: 3
       slash_cooldown_hours: 3
       slash_threshold_amount: 10000000000000000
-      step_in_list_size: 20
-      task_deadline: 240.0
-      timeout_limit: 3
-      tools_to_package_hash: {}
-      tools_to_pricing: {}
-      use_slashing: false
+      light_slash_unit_amount: 5000000000000000
+      serious_slash_unit_amount: 8000000000000000
+      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
+      default_chain_id: gnosis
+      gnosis_ledger_rpc: http://localhost:8545
+      polygon_ledger_rpc: http://localhost:8545
+      base_ledger_rpc: http://localhost:8545
     class_name: Params
 dependencies:
-  PyYAML:
-    version: ==6.0.1
   open-aea-ledger-ethereum:
     version: ==2.2.7
-  pebble:
-    version: ==5.1.3
+  PyYAML:
+    version: ==6.0.1
   prometheus_client:
     version: ==0.23.1
+  pebble:
+    version: ==5.1.3
 is_abstract: false
-customs: []

--- a/packages/valory/skills/task_execution/utils/benchmarks.py
+++ b/packages/valory/skills/task_execution/utils/benchmarks.py
@@ -37,6 +37,7 @@ class TokenCounterCallback:
         "gpt-4-1106-preview": {"input": 0.01, "output": 0.03},
         "gpt-4o-2024-08-06": {"input": 0.0025, "output": 0.01},
         "gpt-4.1-2025-04-14": {"input": 0.002, "output": 0.008},
+        "gpt-4.1-mini-2025-04-14": {"input": 0.0004, "output": 0.0016},
         "claude-2": {"input": 0.008, "output": 0.024},
         "claude-3-haiku-20240307": {"input": 0.00025, "output": 0.00125},
         "claude-3-5-sonnet-20240620": {"input": 0.003, "output": 0.015},

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44
+- valory/task_execution:0.1.0:bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -44,7 +44,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
+- valory/task_execution:0.1.0:bafybeielpodjoqkr2dlazsxrsdielcp7r5kbxarnvlgvrtkaxf64pqss44
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Summary

Adds `gpt-4.1-mini-2025-04-14` to `TokenCounterCallback.TOKEN_PRICES` (`packages/valory/skills/task_execution/utils/benchmarks.py`).

```python
"gpt-4.1-mini-2025-04-14": {"input": 0.0004, "output": 0.0016},
```

## Why

`TokenCounterCallback.__call__` raises `ValueError("Model <x> not supported.")` for any model not present as a literal key in `TOKEN_PRICES`. A new prediction-market tool being onboarded to the mech (`propose-question`) uses `gpt-4.1-mini-2025-04-14` as its lightweight model for query generation / source verification. Without this entry, every delivery for that tool fails server-side in the mech's own cost accounting (after the LLM call already succeeded) — the same failure class as the 2026-06-11 `claude-fable-5` incident.

A local executor smoke test confirmed the tool runs end-to-end and generates questions **once this price is present**; without it the run aborts with `Model gpt-4.1-mini-2025-04-14 not supported.`

## Pricing — verified online (2026-06-17)

Units are USD per 1k tokens (`PRICE_NUM_TOKENS = 1000`). GPT-4.1-mini list price is **$0.40 / 1M input** and **$1.60 / 1M output** → `input: 0.0004`, `output: 0.0016` per 1k.

Source (triple-checked against the official OpenAI pricing): https://developers.openai.com/api/docs/models/gpt-4.1-mini — also listed at https://openai.com/api/pricing/

## Cascade

Re-locked: `task_execution` → `task_submission_abci` → `mech_abci` → `agent/mech` → `service/mech`. No third-party CIDs touched.

## Test plan

- [x] `tomte tox -e check-hash` / `check-packages` pass
- [x] `black-check` / `flake8` pass
- [x] Local executor test: tool generates questions with this price patched in
- [x] Pricing verified against the official OpenAI pricing page
- [ ] Merge + release → mech-predict re-pins `task_execution`/`mech_abci`/`task_submission_abci` → mech-predict release → agent-deployments mech service bump
