### PR TITLE
fix(task_execution): skip IPFS on offchain task fetch + canonical Z timestamps

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidwlmkoiu2xdhmajkfo7pmm6ykgwny3leruhwcybr652tj7v2itlq",
-        "skill/valory/task_execution/0.1.0": "bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihg7hybolac4ct3pooxtj4l5roqnkh2mot6em65hcxxrbxuz22qdm",
+        "skill/valory/mech_abci/0.1.0": "bafybeiaqmsp63ood6f2rnsvt73yhzlbiekzbx3qa6ehrczgsadefwwfsxi",
+        "skill/valory/task_execution/0.1.0": "bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeie32pbzhtrxd6saskth4nbqh646nu2knnpdeeo3clpevz6ugm4tja",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeif2xgkt6727ndycgqdbz5ruvqpjmtlsyutoc37qpvhh2bvtvd5zoe",
-        "service/valory/mech/0.1.0": "bafybeiez3abzjh2qm77lza5oyqqdidjatr5rxa5ynjevpcffajtmo7dbtq"
+        "agent/valory/mech/0.1.0": "bafybeiabbs2q5hvp5wqwgjawlzihfpuemazzus4vhbt62kyf4kdt3v64fi",
+        "service/valory/mech/0.1.0": "bafybeibmrooeb5abx5ng4zb57ubni7pun7sztk2h2mqmistudu3lardsiy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeiaqmsp63ood6f2rnsvt73yhzlbiekzbx3qa6ehrczgsadefwwfsxi",
-        "skill/valory/task_execution/0.1.0": "bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeie32pbzhtrxd6saskth4nbqh646nu2knnpdeeo3clpevz6ugm4tja",
+        "skill/valory/mech_abci/0.1.0": "bafybeiacjlrmkviwfvqomeauilz4xqfvjnjvkrt6wc2xzfxkjm5yqwbama",
+        "skill/valory/task_execution/0.1.0": "bafybeiciivrvfhdcmamgoj5h2bso3mm5kswe6glw2tptrvhcb2cogtuxgu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeigkgvy3wiqvbrmuwh4av5t7mwaxa3l3bor3wz4sje6kzg3mwbksse",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiabbs2q5hvp5wqwgjawlzihfpuemazzus4vhbt62kyf4kdt3v64fi",
-        "service/valory/mech/0.1.0": "bafybeibmrooeb5abx5ng4zb57ubni7pun7sztk2h2mqmistudu3lardsiy"
+        "agent/valory/mech/0.1.0": "bafybeidu2vxm6xuybrk6gfspzg4al2ntokwcxulvoqitlyy3knieo46rua",
+        "service/valory/mech/0.1.0": "bafybeicqe6idexc34vwaqd6gdartlxt2mbxxpw4hjwhndmq64huj2oauyy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeibnkzgufwtlbec2ezhqip3gnzroaje3g5tlwh5rmwldztyzudfrvi",
-        "skill/valory/task_execution/0.1.0": "bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeif7zlablq5ex2owczqn3pu67lmtt4o3ok3gdunee753j6waxmv7au",
+        "skill/valory/mech_abci/0.1.0": "bafybeigw3whzy7xzz4xkx4yamyylkghy5uzrmhlnsjiiiinkpfkgx63hdq",
+        "skill/valory/task_execution/0.1.0": "bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihosewaqg6islk5n2odzf4p7yxf7rgl5soilodkamosjjgy34fu24",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeihsneb3zmw6o472bqa3znmizv3fit5bu7cyycfgfjge7skibew7x4",
-        "service/valory/mech/0.1.0": "bafybeigavceprrnxnt3euybapzg466trbsjbinhwzra3uap37golr4wiwm"
+        "agent/valory/mech/0.1.0": "bafybeigl7meg3aukwf3aeevcgzvdczni4dmrr5sgknssxizh7lj6yybady",
+        "service/valory/mech/0.1.0": "bafybeibderbhvnokzntnwfnpsic6mq7uzjik7r4zyk4wsdk366uxl3vddy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeigowcxpxsgnbqrmvzltg6sfpimigw5uw6r3vw5bvuedq3s2m3ea6e",
-        "skill/valory/task_execution/0.1.0": "bafybeieyjv272dp4tyok57nt4rzt762n3wbog5h3fr3ohata3tw73gfqsa",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeif4ijmkzpilgezw3w5ol5k5d2l4r5mqqhkoo3ot7llgzxd3xe7fcy",
+        "skill/valory/mech_abci/0.1.0": "bafybeibnkzgufwtlbec2ezhqip3gnzroaje3g5tlwh5rmwldztyzudfrvi",
+        "skill/valory/task_execution/0.1.0": "bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeif7zlablq5ex2owczqn3pu67lmtt4o3ok3gdunee753j6waxmv7au",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeibj5jfnqgza4owscefghhsifkylaggebr6jgqcl7ynvghbcns6oba",
-        "service/valory/mech/0.1.0": "bafybeifxt5pa7e54frclzhzoirramwuf4wlxxg723cckyshepmb5uwmlya"
+        "agent/valory/mech/0.1.0": "bafybeihsneb3zmw6o472bqa3znmizv3fit5bu7cyycfgfjge7skibew7x4",
+        "service/valory/mech/0.1.0": "bafybeigavceprrnxnt3euybapzg466trbsjbinhwzra3uap37golr4wiwm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeigw3whzy7xzz4xkx4yamyylkghy5uzrmhlnsjiiiinkpfkgx63hdq",
-        "skill/valory/task_execution/0.1.0": "bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihosewaqg6islk5n2odzf4p7yxf7rgl5soilodkamosjjgy34fu24",
+        "skill/valory/mech_abci/0.1.0": "bafybeidwlmkoiu2xdhmajkfo7pmm6ykgwny3leruhwcybr652tj7v2itlq",
+        "skill/valory/task_execution/0.1.0": "bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihg7hybolac4ct3pooxtj4l5roqnkh2mot6em65hcxxrbxuz22qdm",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeigl7meg3aukwf3aeevcgzvdczni4dmrr5sgknssxizh7lj6yybady",
-        "service/valory/mech/0.1.0": "bafybeibderbhvnokzntnwfnpsic6mq7uzjik7r4zyk4wsdk366uxl3vddy"
+        "agent/valory/mech/0.1.0": "bafybeif2xgkt6727ndycgqdbz5ruvqpjmtlsyutoc37qpvhh2bvtvd5zoe",
+        "service/valory/mech/0.1.0": "bafybeiez3abzjh2qm77lza5oyqqdidjatr5rxa5ynjevpcffajtmo7dbtq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigowcxpxsgnbqrmvzltg6sfpimigw5uw6r3vw5bvuedq3s2m3ea6e
+- valory/mech_abci:0.1.0:bafybeibnkzgufwtlbec2ezhqip3gnzroaje3g5tlwh5rmwldztyzudfrvi
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeieyjv272dp4tyok57nt4rzt762n3wbog5h3fr3ohata3tw73gfqsa
-- valory/task_submission_abci:0.1.0:bafybeif4ijmkzpilgezw3w5ol5k5d2l4r5mqqhkoo3ot7llgzxd3xe7fcy
+- valory/task_execution:0.1.0:bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq
+- valory/task_submission_abci:0.1.0:bafybeif7zlablq5ex2owczqn3pu67lmtt4o3ok3gdunee753j6waxmv7au
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiaqmsp63ood6f2rnsvt73yhzlbiekzbx3qa6ehrczgsadefwwfsxi
+- valory/mech_abci:0.1.0:bafybeiacjlrmkviwfvqomeauilz4xqfvjnjvkrt6wc2xzfxkjm5yqwbama
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi
-- valory/task_submission_abci:0.1.0:bafybeie32pbzhtrxd6saskth4nbqh646nu2knnpdeeo3clpevz6ugm4tja
+- valory/task_execution:0.1.0:bafybeiciivrvfhdcmamgoj5h2bso3mm5kswe6glw2tptrvhcb2cogtuxgu
+- valory/task_submission_abci:0.1.0:bafybeigkgvy3wiqvbrmuwh4av5t7mwaxa3l3bor3wz4sje6kzg3mwbksse
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeibnkzgufwtlbec2ezhqip3gnzroaje3g5tlwh5rmwldztyzudfrvi
+- valory/mech_abci:0.1.0:bafybeigw3whzy7xzz4xkx4yamyylkghy5uzrmhlnsjiiiinkpfkgx63hdq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq
-- valory/task_submission_abci:0.1.0:bafybeif7zlablq5ex2owczqn3pu67lmtt4o3ok3gdunee753j6waxmv7au
+- valory/task_execution:0.1.0:bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y
+- valory/task_submission_abci:0.1.0:bafybeihosewaqg6islk5n2odzf4p7yxf7rgl5soilodkamosjjgy34fu24
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidwlmkoiu2xdhmajkfo7pmm6ykgwny3leruhwcybr652tj7v2itlq
+- valory/mech_abci:0.1.0:bafybeiaqmsp63ood6f2rnsvt73yhzlbiekzbx3qa6ehrczgsadefwwfsxi
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe
-- valory/task_submission_abci:0.1.0:bafybeihg7hybolac4ct3pooxtj4l5roqnkh2mot6em65hcxxrbxuz22qdm
+- valory/task_execution:0.1.0:bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi
+- valory/task_submission_abci:0.1.0:bafybeie32pbzhtrxd6saskth4nbqh646nu2knnpdeeo3clpevz6ugm4tja
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigw3whzy7xzz4xkx4yamyylkghy5uzrmhlnsjiiiinkpfkgx63hdq
+- valory/mech_abci:0.1.0:bafybeidwlmkoiu2xdhmajkfo7pmm6ykgwny3leruhwcybr652tj7v2itlq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y
-- valory/task_submission_abci:0.1.0:bafybeihosewaqg6islk5n2odzf4p7yxf7rgl5soilodkamosjjgy34fu24
+- valory/task_execution:0.1.0:bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe
+- valory/task_submission_abci:0.1.0:bafybeihg7hybolac4ct3pooxtj4l5roqnkh2mot6em65hcxxrbxuz22qdm
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihsneb3zmw6o472bqa3znmizv3fit5bu7cyycfgfjge7skibew7x4
+agent: valory/mech:0.1.0:bafybeigl7meg3aukwf3aeevcgzvdczni4dmrr5sgknssxizh7lj6yybady
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeibj5jfnqgza4owscefghhsifkylaggebr6jgqcl7ynvghbcns6oba
+agent: valory/mech:0.1.0:bafybeihsneb3zmw6o472bqa3znmizv3fit5bu7cyycfgfjge7skibew7x4
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiabbs2q5hvp5wqwgjawlzihfpuemazzus4vhbt62kyf4kdt3v64fi
+agent: valory/mech:0.1.0:bafybeidu2vxm6xuybrk6gfspzg4al2ntokwcxulvoqitlyy3knieo46rua
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigl7meg3aukwf3aeevcgzvdczni4dmrr5sgknssxizh7lj6yybady
+agent: valory/mech:0.1.0:bafybeif2xgkt6727ndycgqdbz5ruvqpjmtlsyutoc37qpvhh2bvtvd5zoe
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeif2xgkt6727ndycgqdbz5ruvqpjmtlsyutoc37qpvhh2bvtvd5zoe
+agent: valory/mech:0.1.0:bafybeiabbs2q5hvp5wqwgjawlzihfpuemazzus4vhbt62kyf4kdt3v64fi
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeie32pbzhtrxd6saskth4nbqh646nu2knnpdeeo3clpevz6ugm4tja
+- valory/task_submission_abci:0.1.0:bafybeigkgvy3wiqvbrmuwh4av5t7mwaxa3l3bor3wz4sje6kzg3mwbksse
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi
+- valory/task_execution:0.1.0:bafybeiciivrvfhdcmamgoj5h2bso3mm5kswe6glw2tptrvhcb2cogtuxgu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeif4ijmkzpilgezw3w5ol5k5d2l4r5mqqhkoo3ot7llgzxd3xe7fcy
+- valory/task_submission_abci:0.1.0:bafybeif7zlablq5ex2owczqn3pu67lmtt4o3ok3gdunee753j6waxmv7au
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeieyjv272dp4tyok57nt4rzt762n3wbog5h3fr3ohata3tw73gfqsa
+- valory/task_execution:0.1.0:bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq
 behaviours:
   main:
     args: {}
@@ -171,6 +171,9 @@ models:
       tools_to_pricing: {}
       service_endpoint_base: https://dummy_service.autonolas.tech/
       default_chain_id: gnosis
+      mech_events_enabled: false
+      wildcard_events_url: ''
+      wildcard_events_timeout_seconds: 5.0
     class_name: Params
   randomness_api:
     args:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeihosewaqg6islk5n2odzf4p7yxf7rgl5soilodkamosjjgy34fu24
+- valory/task_submission_abci:0.1.0:bafybeihg7hybolac4ct3pooxtj4l5roqnkh2mot6em65hcxxrbxuz22qdm
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y
+- valory/task_execution:0.1.0:bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeif7zlablq5ex2owczqn3pu67lmtt4o3ok3gdunee753j6waxmv7au
+- valory/task_submission_abci:0.1.0:bafybeihosewaqg6islk5n2odzf4p7yxf7rgl5soilodkamosjjgy34fu24
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq
+- valory/task_execution:0.1.0:bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeihg7hybolac4ct3pooxtj4l5roqnkh2mot6em65hcxxrbxuz22qdm
+- valory/task_submission_abci:0.1.0:bafybeie32pbzhtrxd6saskth4nbqh646nu2knnpdeeo3clpevz6ugm4tja
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe
+- valory/task_execution:0.1.0:bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1680,8 +1680,18 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             # untouched and reintroduce the ``batch_hash`` mismatch the
             # canonicalisation is meant to close. Malformed strings fall
             # through to ``now_iso`` rather than crashing the FSM round.
+            #
+            # The trailing-``Z`` rewrite is needed because
+            # ``datetime.fromisoformat`` rejects ``…Z`` on Python 3.10;
+            # the canonical-``Z`` form is what the server emits and what
+            # JavaScript's ``Date.prototype.toISOString()`` produces, so
+            # a requester re-using the server's own timestamp shape
+            # would otherwise silently fall back to ``executed_at`` and
+            # lose the real request time.
             try:
-                requested_at_iso = _iso_z(datetime.fromisoformat(requested_at_raw))
+                requested_at_iso = _iso_z(
+                    datetime.fromisoformat(requested_at_raw.replace("Z", "+00:00"))
+                )
             except ValueError:
                 self.context.logger.warning(
                     "requested_at=%r for req_id=%s is not parsable ISO 8601; "

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1652,12 +1652,28 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # All three timestamps go through ``_iso_z`` so the canonical-JSON
         # bytes match the server's Pydantic round-trip (see helper docstring).
         now_iso = _iso_z(datetime.now(timezone.utc))
+        # ``datetime.fromtimestamp`` raises ``OverflowError`` (and on some
+        # libcs ``OSError``) for values past the platform's representable
+        # range, plus ``ValueError`` for NaN. The ``executed_at`` field
+        # comes from tool plumbing on the mech itself, but it still rides
+        # the FSM consensus channel and a buggy tool returning a wild
+        # value would otherwise crash the round; fall back to ``now_iso``.
         executed_at_unix = response_data.get("executed_at")
-        executed_at_iso = (
-            _iso_z(datetime.fromtimestamp(executed_at_unix, tz=timezone.utc))
-            if isinstance(executed_at_unix, (int, float))
-            else now_iso
-        )
+        if isinstance(executed_at_unix, (int, float)):
+            try:
+                executed_at_iso = _iso_z(
+                    datetime.fromtimestamp(executed_at_unix, tz=timezone.utc)
+                )
+            except (ValueError, OverflowError, OSError):
+                self.context.logger.warning(
+                    "executed_at=%r for req_id=%s is out of range; "
+                    "falling back to now_iso.",
+                    executed_at_unix,
+                    req_id,
+                )
+                executed_at_iso = now_iso
+        else:
+            executed_at_iso = now_iso
         # Requested_at: prefer the signed timestamp on the buffered request;
         # the handler validates and stores it before enqueueing. Fall back to
         # the executed_at on the response so the time-leading index entry is
@@ -1669,9 +1685,24 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             "requested_at"
         )
         if isinstance(requested_at_raw, (int, float)):
-            requested_at_iso = _iso_z(
-                datetime.fromtimestamp(requested_at_raw, tz=timezone.utc)
-            )
+            # ``datetime.fromtimestamp`` raises ``OverflowError`` /
+            # ``OSError`` for values past the platform's representable
+            # range and ``ValueError`` for NaN. ``requested_at`` comes
+            # from a requester-controlled field, so the fallback closes
+            # the round-crash path on a malformed integer the same way
+            # the string branch handles a malformed ISO 8601 string.
+            try:
+                requested_at_iso = _iso_z(
+                    datetime.fromtimestamp(requested_at_raw, tz=timezone.utc)
+                )
+            except (ValueError, OverflowError, OSError):
+                self.context.logger.warning(
+                    "requested_at=%r for req_id=%s is out of range; "
+                    "falling back to executed_at.",
+                    requested_at_raw,
+                    req_id,
+                )
+                requested_at_iso = executed_at_iso
         elif isinstance(requested_at_raw, str) and requested_at_raw:
             # Parse the requester-provided ISO 8601 string and re-emit via
             # ``_iso_z`` so a non-UTC offset (``…+05:30``, ``…-08:00``) gets

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -97,6 +97,36 @@ RESPONSE_SCHEMA_VERSION = "2.0"
 IPFS_MAX_TASK_BYTES = 1_048_576  # 1MB cap on attacker-controlled task payload
 MAX_PROMPT_BYTES = 100_000  # 100KB cap on the prompt field
 
+
+def _iso_z(dt: datetime) -> str:
+    """Render a timezone-aware datetime as ISO 8601 with the ``Z`` suffix.
+
+    Normalises through ``astimezone(timezone.utc)`` so a datetime with any
+    UTC offset (``+00:00``, ``+05:30``, ``-08:00``) emits the same canonical
+    string for the same wall-clock instant. The wildcard server's Pydantic
+    ``AwareDatetime`` round-trips through ``model_dump(mode="json")`` which
+    emits ``...Z`` for UTC; the mech's ``batch_hash`` recompute on the
+    server side compares byte-for-byte against ours, so leaving the offset
+    unconverted breaks the equality at the canonical-JSON layer (this was
+    the original ``+00:00`` → ``Z`` mismatch that dropped every offchain
+    delivery with ``400 BATCH_HASH_MISMATCH``).
+
+    Naive datetimes are rejected. Python 3.6+'s ``astimezone`` silently
+    coerces a naive value to the system's local timezone, which would
+    swap the canonical byte string between dev machines and CI without a
+    clear failure signal. The caller must attach a tz explicitly (always
+    ``timezone.utc`` in this module).
+
+    :param dt: a timezone-aware ``datetime``.
+    :return: ISO 8601 string of the same instant in UTC, suffixed with ``Z``.
+    :raises ValueError: if ``dt.tzinfo`` is None (naive datetime).
+    """
+    if dt.tzinfo is None:
+        raise ValueError(
+            "_iso_z requires a timezone-aware datetime; got a naive value"
+        )
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
 # Cap on the JSON-serialised size of each ``raw_content`` blob attached to
 # a wildcard event. The blob rides Tendermint consensus replication into
 # ``synchronized_data`` on every agent and the field is requester-influenced
@@ -876,7 +906,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
 
     def _handle_done_task(self, task_result: Any) -> None:
         """Handle done tasks"""
-        executed_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        executed_at = _iso_z(datetime.now(timezone.utc))
         executing_task = cast(Dict[str, Any], self._executing_task)
         self.context.logger.info(f"Handling done task {executing_task}.")
         req_id = executing_task.get("requestId", None)
@@ -1620,18 +1650,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # not suitable as a delivered_at timestamp. Use the current wall-clock
         # at finalize as the best-effort delivered_at; the analytics ETL can
         # cross-correlate against the on-chain block timestamp if needed.
-        # Emit UTC instants with the ``Z`` suffix to match the canonical
-        # form Pydantic's ``AwareDatetime`` round-trips through
-        # ``model_dump(mode="json")`` on the wildcard server side. A
-        # ``+00:00`` suffix represents the same moment but hashes to a
-        # different canonical-JSON byte string, breaking ``batch_hash``
-        # equality on the recompute step.
-        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        # All three timestamps go through ``_iso_z`` so the canonical-JSON
+        # bytes match the server's Pydantic round-trip (see helper docstring).
+        now_iso = _iso_z(datetime.now(timezone.utc))
         executed_at_unix = response_data.get("executed_at")
         executed_at_iso = (
-            datetime.fromtimestamp(executed_at_unix, tz=timezone.utc)
-            .isoformat()
-            .replace("+00:00", "Z")
+            _iso_z(datetime.fromtimestamp(executed_at_unix, tz=timezone.utc))
             if isinstance(executed_at_unix, (int, float))
             else now_iso
         )
@@ -1646,16 +1670,29 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             "requested_at"
         )
         if isinstance(requested_at_raw, (int, float)):
-            requested_at_iso = (
+            requested_at_iso = _iso_z(
                 datetime.fromtimestamp(requested_at_raw, tz=timezone.utc)
-                .isoformat()
-                .replace("+00:00", "Z")
             )
         elif isinstance(requested_at_raw, str) and requested_at_raw:
-            # Normalise an explicit ``+00:00`` to ``Z`` so a requester-
-            # provided ISO 8601 string canonicalises the same way the
-            # server's Pydantic round-trip emits it.
-            requested_at_iso = requested_at_raw.replace("+00:00", "Z")
+            # Parse the requester-provided ISO 8601 string and re-emit via
+            # ``_iso_z`` so a non-UTC offset (``…+05:30``, ``…-08:00``) gets
+            # converted to the canonical UTC ``Z`` form. A plain
+            # ``.replace("+00:00", "Z")`` would leave non-UTC offsets
+            # untouched and reintroduce the ``batch_hash`` mismatch the
+            # canonicalisation is meant to close. Malformed strings fall
+            # through to ``now_iso`` rather than crashing the FSM round.
+            try:
+                requested_at_iso = _iso_z(
+                    datetime.fromisoformat(requested_at_raw)
+                )
+            except ValueError:
+                self.context.logger.warning(
+                    "requested_at=%r for req_id=%s is not parsable ISO 8601; "
+                    "falling back to executed_at.",
+                    requested_at_raw,
+                    req_id,
+                )
+                requested_at_iso = executed_at_iso
         else:
             requested_at_iso = executed_at_iso
 

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -26,6 +26,7 @@ from asyncio import Future
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, cast
 
 from aea.helpers.cid import to_v1
@@ -733,6 +734,29 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         self.request_id_to_delivery_rate_info[request_id] = delivery_rate
         self._executing_task = task_data
         self._request_handling_deadline = None
+
+        # Off-chain path: prompt JSON is already inline in ``task_data["ipfs_data"]``
+        # (set by the handler in ``_enqueue_offchain_request`` and mirrored to
+        # ``in_memory_requests``). Skip the IPFS GET round-trip entirely and feed
+        # a synthetic message straight to ``_handle_get_task`` so the rest of the
+        # pipeline (validation + pebble dispatch) is unchanged. Matches the design
+        # intent of #457 ("off-chain path skips the IPFS upload"); the GET half
+        # was left in place by oversight.
+        if task_data.get("is_offchain"):
+            inline_payload = task_data.get("ipfs_data")
+            if not isinstance(inline_payload, str):
+                self.context.logger.warning(
+                    f"Off-chain request {request_id} missing inline ipfs_data; "
+                    f"skipping."
+                )
+                self._invalid_request = True
+                return
+            self._handle_get_task(
+                cast(Any, SimpleNamespace(files={"metadata.json": inline_payload})),
+                cast(Any, None),
+            )
+            return
+
         try:
             ipfs_hash = get_ipfs_file_hash(task_data["data"])
         except Exception as e:  # pylint: disable=W0718
@@ -1596,10 +1620,18 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # not suitable as a delivered_at timestamp. Use the current wall-clock
         # at finalize as the best-effort delivered_at; the analytics ETL can
         # cross-correlate against the on-chain block timestamp if needed.
-        now_iso = datetime.now(timezone.utc).isoformat()
+        # Emit UTC instants with the ``Z`` suffix to match the canonical
+        # form Pydantic's ``AwareDatetime`` round-trips through
+        # ``model_dump(mode="json")`` on the wildcard server side. A
+        # ``+00:00`` suffix represents the same moment but hashes to a
+        # different canonical-JSON byte string, breaking ``batch_hash``
+        # equality on the recompute step.
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         executed_at_unix = response_data.get("executed_at")
         executed_at_iso = (
-            datetime.fromtimestamp(executed_at_unix, tz=timezone.utc).isoformat()
+            datetime.fromtimestamp(executed_at_unix, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
             if isinstance(executed_at_unix, (int, float))
             else now_iso
         )
@@ -1614,11 +1646,16 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             "requested_at"
         )
         if isinstance(requested_at_raw, (int, float)):
-            requested_at_iso = datetime.fromtimestamp(
-                requested_at_raw, tz=timezone.utc
-            ).isoformat()
+            requested_at_iso = (
+                datetime.fromtimestamp(requested_at_raw, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
         elif isinstance(requested_at_raw, str) and requested_at_raw:
-            requested_at_iso = requested_at_raw
+            # Normalise an explicit ``+00:00`` to ``Z`` so a requester-
+            # provided ISO 8601 string canonicalises the same way the
+            # server's Pydantic round-trip emits it.
+            requested_at_iso = requested_at_raw.replace("+00:00", "Z")
         else:
             requested_at_iso = executed_at_iso
 

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -122,10 +122,9 @@ def _iso_z(dt: datetime) -> str:
     :raises ValueError: if ``dt.tzinfo`` is None (naive datetime).
     """
     if dt.tzinfo is None:
-        raise ValueError(
-            "_iso_z requires a timezone-aware datetime; got a naive value"
-        )
+        raise ValueError("_iso_z requires a timezone-aware datetime; got a naive value")
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
 
 # Cap on the JSON-serialised size of each ``raw_content`` blob attached to
 # a wildcard event. The blob rides Tendermint consensus replication into
@@ -1682,9 +1681,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             # canonicalisation is meant to close. Malformed strings fall
             # through to ``now_iso`` rather than crashing the FSM round.
             try:
-                requested_at_iso = _iso_z(
-                    datetime.fromisoformat(requested_at_raw)
-                )
+                requested_at_iso = _iso_z(datetime.fromisoformat(requested_at_raw))
             except ValueError:
                 self.context.logger.warning(
                     "requested_at=%r for req_id=%s is not parsable ISO 8601; "

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeignd3ojufyamjpzghncfpqqqvzcb2e2sp233a63kzg7nsgdijazpq
+  behaviours.py: bafybeieifpkhm4osmvig2r2khuqlglpxxgsm7i7bmutrtxg6lu5pzosmbu
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeigtaswgs7z47gncb7qysqhccgwbnfe4u37qr5s6zcwgkzapyewe7u
   models.py: bafybeigsjfnridhcwbon3tlbvpdzm6wi7kgleioze3cor5e4wnvdsl7hf4
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeidqewe7oirdf54f4rjp56jszi45wca6cdhqfrkx5zgns3mtbcrjim
+  tests/test_behaviours.py: bafybeigxibopqs55tlprsmylsrnd3r7jx4wanaiz4a632h2jhx3butmode
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeieldbamzx7ik7sgw4wos6biacenbagcde3xndszn5bkskwd4c3u2m
+  behaviours.py: bafybeic4pc77wwe3bns24muul4nhqhm75ehvyzc62odmz7xrb4bzblfktq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeigtaswgs7z47gncb7qysqhccgwbnfe4u37qr5s6zcwgkzapyewe7u
   models.py: bafybeigsjfnridhcwbon3tlbvpdzm6wi7kgleioze3cor5e4wnvdsl7hf4

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeieifpkhm4osmvig2r2khuqlglpxxgsm7i7bmutrtxg6lu5pzosmbu
+  behaviours.py: bafybeicl5ga3mhv7co3qzllk7l4cmnz2enqlctwy4z2zv72oafmkh4peda
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeigtaswgs7z47gncb7qysqhccgwbnfe4u37qr5s6zcwgkzapyewe7u
   models.py: bafybeigsjfnridhcwbon3tlbvpdzm6wi7kgleioze3cor5e4wnvdsl7hf4
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeigxibopqs55tlprsmylsrnd3r7jx4wanaiz4a632h2jhx3butmode
+  tests/test_behaviours.py: bafybeica2lyinv26al2fekg6i2n4qowp3qbroandxdwnzpdwn53oivrgnq
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeic4pc77wwe3bns24muul4nhqhm75ehvyzc62odmz7xrb4bzblfktq
+  behaviours.py: bafybeifpuyxjlx5wegfhfnfmssfrwtjmsfvnzvdrjdgq2rbrxzichruzku
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeigtaswgs7z47gncb7qysqhccgwbnfe4u37qr5s6zcwgkzapyewe7u
   models.py: bafybeigsjfnridhcwbon3tlbvpdzm6wi7kgleioze3cor5e4wnvdsl7hf4
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeifo25uodji5alqwldgv2wf2g5warrh4dqwww5mm6vgshdi7l452gm
+  tests/test_behaviours.py: bafybeihod5k7i3wiuaj77wvvstp3soqfcnq6xi7vwlem3hgslupzmcevwq
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifpuyxjlx5wegfhfnfmssfrwtjmsfvnzvdrjdgq2rbrxzichruzku
+  behaviours.py: bafybeignd3ojufyamjpzghncfpqqqvzcb2e2sp233a63kzg7nsgdijazpq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeigtaswgs7z47gncb7qysqhccgwbnfe4u37qr5s6zcwgkzapyewe7u
   models.py: bafybeigsjfnridhcwbon3tlbvpdzm6wi7kgleioze3cor5e4wnvdsl7hf4
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeihod5k7i3wiuaj77wvvstp3soqfcnq6xi7vwlem3hgslupzmcevwq
+  tests/test_behaviours.py: bafybeidqewe7oirdf54f4rjp56jszi45wca6cdhqfrkx5zgns3mtbcrjim
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3178,6 +3178,31 @@ def test_build_wildcard_event_unix_requested_at_is_z(
     assert event["request"]["requested_at"] == "2026-06-25T13:19:06Z"
 
 
+def test_build_wildcard_event_z_suffix_requested_at_is_parsed(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A ``…Z`` requested_at parses on Python 3.10 (the version-dependent case)."""
+    # datetime.fromisoformat rejects a trailing Z until Python 3.11; the
+    # canonical Z form is what the server emits and what JS toISOString()
+    # produces, so a requester re-using the server's timestamp shape would
+    # otherwise silently fall back to executed_at and lose the real
+    # request time. The .replace("Z", "+00:00") guards that.
+    request_data = {
+        "prompt": "trailing Z",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    assert event["request"]["requested_at"] == "2026-06-25T13:19:06.651013Z"
+
+
 def test_build_wildcard_event_malformed_requested_at_falls_back(
     behaviour: Any,
     params_stub: Any,

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3017,3 +3017,299 @@ def test_ensure_payment_model_does_not_reset_inflight_from_other_flow(
 
     assert result is False
     assert params_stub.in_flight_req is True
+
+
+# ---------------------------------------------------------------------------
+# _iso_z + _build_wildcard_event timestamp normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_iso_z_emits_z_suffix_on_utc_datetime() -> None:
+    """``_iso_z`` renders a UTC instant with the ``Z`` suffix.
+
+    Pinning the canonical form because the server's Pydantic
+    ``AwareDatetime`` round-trip emits exactly this shape; a drift back to
+    ``+00:00`` (the Python default for ``isoformat``) reintroduces the
+    ``batch_hash`` mismatch that dropped every offchain delivery before
+    this fix landed.
+    """
+    from datetime import datetime, timezone
+
+    dt = datetime(2026, 6, 25, 13, 19, 6, 651013, tzinfo=timezone.utc)
+    assert beh_mod._iso_z(dt) == "2026-06-25T13:19:06.651013Z"
+
+
+def test_iso_z_converts_non_utc_offset_to_utc_z() -> None:
+    """A non-UTC offset is rotated to UTC, then emitted with ``Z``.
+
+    Plain ``.replace("+00:00", "Z")`` would leave ``+05:30`` untouched and
+    the canonical-JSON bytes wouldn't match the server's UTC-normalised
+    re-emit. ``_iso_z`` goes through ``astimezone(utc)`` to close that gap.
+    """
+    from datetime import datetime, timezone, timedelta
+
+    ist = timezone(timedelta(hours=5, minutes=30))
+    dt = datetime(2026, 6, 25, 18, 49, 6, 651013, tzinfo=ist)
+    # Same wall-clock instant in UTC: 18:49 IST == 13:19 UTC.
+    assert beh_mod._iso_z(dt) == "2026-06-25T13:19:06.651013Z"
+
+
+def test_iso_z_naive_datetime_raises() -> None:
+    """A naive datetime is a programming bug; surface it loudly.
+
+    ``astimezone`` on a naive value raises ``ValueError`` in modern Python.
+    The helper is documented as taking a tz-aware value; verifying the
+    raise here pins the contract so a future refactor that swaps the
+    helper out doesn't silently coerce naive values to local time.
+    """
+    from datetime import datetime
+
+    with pytest.raises((ValueError, OSError)):
+        beh_mod._iso_z(datetime(2026, 6, 25, 13, 19, 6))
+
+
+def _wildcard_event_setup(
+    behaviour: Any,
+    shared_state: Dict[str, Any],
+    request_data: Dict[str, Any],
+    response_data: Optional[Dict[str, Any]] = None,
+    req_id: str = "req-z",
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Wire ``shared_state`` so ``_build_wildcard_event`` sees the inputs.
+
+    Returns the ``done_task`` and ``executing_task`` shaped for the call
+    so each test can vary fields without re-deriving the dict shape.
+    """
+    if response_data is None:
+        response_data = {
+            "result": "p_yes=0.7",
+            "schema_version": "2.0",
+            "executed_at": "2026-06-25T13:19:06.953661Z",
+        }
+    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {req_id: json.dumps(request_data)}
+    shared_state.setdefault(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})[
+        req_id
+    ] = {"response": response_data}
+    done_task = {
+        "request_id": req_id,
+        "is_offchain": True,
+        "tool": request_data.get("tool", "prediction-offline"),
+    }
+    executing_task = {
+        "requestId": req_id,
+        "request_delivery_rate": 10**16,
+        "is_offchain": True,
+        "sender": "0xrequester",
+    }
+    return done_task, executing_task
+
+
+def test_build_wildcard_event_emits_z_on_all_timestamps(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """All three timestamps end in ``Z`` (not ``+00:00``) on the happy path.
+
+    Regression guard for the production-silent ``BATCH_HASH_MISMATCH`` bug:
+    the mech hashed events with ``+00:00``, the server's Pydantic
+    re-emit normalised to ``Z``, and every offchain delivery was rejected
+    at the last auth-chain step.
+    """
+    request_data = {
+        "prompt": "Will BTC reach $100k?",
+        "tool": "prediction-offline",
+        "nonce": "uuid-1",
+        "requested_at": "2026-06-25T13:19:06.651013+00:00",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    assert event["request"]["requested_at"].endswith("Z")
+    assert "+00:00" not in event["request"]["requested_at"]
+    assert event["response"]["executed_at"].endswith("Z")
+    assert "+00:00" not in event["response"]["executed_at"]
+    assert event["response"]["delivered_at"].endswith("Z")
+    assert "+00:00" not in event["response"]["delivered_at"]
+
+
+def test_build_wildcard_event_normalises_non_utc_requested_at(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A requester-supplied non-UTC offset rotates to UTC, then emits ``Z``.
+
+    The advisory case OjusWiZard flagged: ``.replace("+00:00", "Z")`` only
+    handles UTC; a ``+05:30`` offset would have passed through unchanged
+    and the canonical-JSON bytes wouldn't have matched the server's UTC
+    re-emit. The fix is ``datetime.fromisoformat(...).astimezone(utc)``.
+    """
+    request_data = {
+        "prompt": "noon in Mumbai",
+        "tool": "prediction-offline",
+        # 18:49:06 IST == 13:19:06 UTC.
+        "requested_at": "2026-06-25T18:49:06.651013+05:30",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    assert event["request"]["requested_at"] == "2026-06-25T13:19:06.651013Z"
+
+
+def test_build_wildcard_event_unix_requested_at_is_z(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A Unix-int ``requested_at`` round-trips through UTC + ``Z``."""
+    request_data = {
+        "prompt": "via integer",
+        "tool": "prediction-offline",
+        # 2026-06-25T13:19:06Z
+        "requested_at": 1782393546,
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    assert event["request"]["requested_at"] == "2026-06-25T13:19:06Z"
+
+
+def test_build_wildcard_event_malformed_requested_at_falls_back(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A non-ISO ``requested_at`` falls back to ``executed_at`` without crashing.
+
+    Catches a malformed requester payload (manual curl, a stale client) so
+    the FSM round doesn't die on a ``ValueError`` from ``fromisoformat``.
+    The fallback ends in ``Z`` because ``executed_at`` does.
+    """
+    request_data = {
+        "prompt": "garbled",
+        "tool": "prediction-offline",
+        "requested_at": "not-a-timestamp",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    assert event["request"]["requested_at"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# _execute_task offchain-skip branch
+# ---------------------------------------------------------------------------
+
+
+def test_execute_task_offchain_dispatches_via_handle_get_task_no_ipfs_get(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """Off-chain pending task → ``_handle_get_task`` called inline, no IPFS GET.
+
+    The handler short-circuits the IPFS upload but #457 left the symmetric
+    short-circuit on the get-side missing. This patch feeds a synthetic
+    ``IpfsMessage`` (the inline ``ipfs_data`` wrapped in
+    ``SimpleNamespace(files={"metadata.json": ...})``) straight into
+    ``_handle_get_task`` instead. Asserting both halves: the synthetic
+    message reaches ``_handle_get_task``, and ``send_message`` is never
+    called (which would be the IPFS GET).
+    """
+    params_stub.in_flight_req = False
+    behaviour._executing_task = None
+    behaviour._invalid_request = False
+    inline_payload = json.dumps(
+        {"prompt": "What is 2+2?", "tool": "prediction-offline", "nonce": "u-1"}
+    )
+    shared_state[beh_mod.PENDING_TASKS].append(
+        {
+            "requestId": "req-off-1",
+            "request_delivery_rate": 10**16,
+            "is_offchain": True,
+            "data": b"\x00" * 32,
+            "ipfs_data": inline_payload,
+            "sender": "0xrequester",
+        }
+    )
+    handle_calls: list = []
+    monkeypatch.setattr(
+        behaviour,
+        "_handle_get_task",
+        lambda msg, dlg: handle_calls.append((msg, dlg)),
+    )
+    send_calls: list = []
+    monkeypatch.setattr(
+        behaviour,
+        "send_message",
+        lambda *a, **k: send_calls.append((a, k)),
+    )
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+
+    behaviour._execute_task()
+
+    assert len(handle_calls) == 1, "offchain branch must call _handle_get_task once"
+    msg, _ = handle_calls[0]
+    # Synthetic SimpleNamespace carries the inline payload under
+    # metadata.json so _handle_get_task's downstream parse runs unchanged.
+    assert msg.files == {"metadata.json": inline_payload}
+    assert send_calls == [], "offchain branch must NOT issue an IPFS GET"
+
+
+def test_execute_task_offchain_missing_ipfs_data_sets_invalid_request(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """Off-chain task with no inline payload → invalid request, no dispatch.
+
+    Defensive guard: a buffered off-chain task without ``ipfs_data`` is a
+    handler bug; the patch sets ``_invalid_request=True`` so the FSM
+    cleans up rather than dispatching ``_handle_get_task(SimpleNamespace(
+    files={"metadata.json": None}))`` which would crash deeper in the
+    pipeline.
+    """
+    params_stub.in_flight_req = False
+    behaviour._executing_task = None
+    behaviour._invalid_request = False
+    shared_state[beh_mod.PENDING_TASKS].append(
+        {
+            "requestId": "req-off-bad",
+            "request_delivery_rate": 10**16,
+            "is_offchain": True,
+            "data": b"\x00" * 32,
+            # No ``ipfs_data`` field at all — the off-chain handler should
+            # never produce this, but defend against it anyway.
+            "sender": "0xrequester",
+        }
+    )
+    handle_calls: list = []
+    monkeypatch.setattr(
+        behaviour, "_handle_get_task", lambda msg, dlg: handle_calls.append(1)
+    )
+    send_calls: list = []
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: send_calls.append(1))
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+
+    behaviour._execute_task()
+
+    assert behaviour._invalid_request is True
+    assert handle_calls == []
+    assert send_calls == []

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3046,7 +3046,7 @@ def test_iso_z_converts_non_utc_offset_to_utc_z() -> None:
     the canonical-JSON bytes wouldn't match the server's UTC-normalised
     re-emit. ``_iso_z`` goes through ``astimezone(utc)`` to close that gap.
     """
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     ist = timezone(timedelta(hours=5, minutes=30))
     dt = datetime(2026, 6, 25, 18, 49, 6, 651013, tzinfo=ist)
@@ -3075,11 +3075,10 @@ def _wildcard_event_setup(
     response_data: Optional[Dict[str, Any]] = None,
     req_id: str = "req-z",
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """Wire ``shared_state`` so ``_build_wildcard_event`` sees the inputs.
-
-    Returns the ``done_task`` and ``executing_task`` shaped for the call
-    so each test can vary fields without re-deriving the dict shape.
-    """
+    """Wire shared_state and return the done_task and executing_task dicts."""
+    # Each test varies the request/response fields without re-deriving
+    # the dict shape; this helper centralises the IN_MEMORY_REQUESTS +
+    # OFFCHAIN_REQUEST_RESPONSES seeding that _build_wildcard_event reads.
     if response_data is None:
         response_data = {
             "result": "p_yes=0.7",
@@ -3087,9 +3086,9 @@ def _wildcard_event_setup(
             "executed_at": "2026-06-25T13:19:06.953661Z",
         }
     shared_state[beh_mod.IN_MEMORY_REQUESTS] = {req_id: json.dumps(request_data)}
-    shared_state.setdefault(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})[
-        req_id
-    ] = {"response": response_data}
+    shared_state.setdefault(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})[req_id] = {
+        "response": response_data
+    }
     done_task = {
         "request_id": req_id,
         "is_offchain": True,
@@ -3109,13 +3108,11 @@ def test_build_wildcard_event_emits_z_on_all_timestamps(
     params_stub: Any,
     shared_state: Dict[str, Any],
 ) -> None:
-    """All three timestamps end in ``Z`` (not ``+00:00``) on the happy path.
-
-    Regression guard for the production-silent ``BATCH_HASH_MISMATCH`` bug:
-    the mech hashed events with ``+00:00``, the server's Pydantic
-    re-emit normalised to ``Z``, and every offchain delivery was rejected
-    at the last auth-chain step.
-    """
+    """All three timestamps end in Z (not +00:00) on the happy path."""
+    # Regression guard for the production-silent BATCH_HASH_MISMATCH bug:
+    # the mech hashed events with +00:00, the server's Pydantic re-emit
+    # normalised to Z, and every offchain delivery was rejected at the
+    # last auth-chain step.
     request_data = {
         "prompt": "Will BTC reach $100k?",
         "tool": "prediction-offline",
@@ -3141,13 +3138,10 @@ def test_build_wildcard_event_normalises_non_utc_requested_at(
     params_stub: Any,
     shared_state: Dict[str, Any],
 ) -> None:
-    """A requester-supplied non-UTC offset rotates to UTC, then emits ``Z``.
-
-    The advisory case OjusWiZard flagged: ``.replace("+00:00", "Z")`` only
-    handles UTC; a ``+05:30`` offset would have passed through unchanged
-    and the canonical-JSON bytes wouldn't have matched the server's UTC
-    re-emit. The fix is ``datetime.fromisoformat(...).astimezone(utc)``.
-    """
+    """A non-UTC offset on requested_at rotates to UTC, then emits Z."""
+    # Plain .replace("+00:00", "Z") would leave +05:30 untouched and the
+    # canonical-JSON bytes wouldn't match the server's UTC re-emit. The
+    # fix routes through datetime.fromisoformat(...).astimezone(utc).
     request_data = {
         "prompt": "noon in Mumbai",
         "tool": "prediction-offline",
@@ -3189,12 +3183,10 @@ def test_build_wildcard_event_malformed_requested_at_falls_back(
     params_stub: Any,
     shared_state: Dict[str, Any],
 ) -> None:
-    """A non-ISO ``requested_at`` falls back to ``executed_at`` without crashing.
-
-    Catches a malformed requester payload (manual curl, a stale client) so
-    the FSM round doesn't die on a ``ValueError`` from ``fromisoformat``.
-    The fallback ends in ``Z`` because ``executed_at`` does.
-    """
+    """A non-ISO requested_at falls back to executed_at without crashing."""
+    # Catches a malformed requester payload (manual curl, a stale client)
+    # so the FSM round doesn't die on a ValueError from fromisoformat.
+    # The fallback ends in Z because executed_at does.
     request_data = {
         "prompt": "garbled",
         "tool": "prediction-offline",
@@ -3220,16 +3212,14 @@ def test_execute_task_offchain_dispatches_via_handle_get_task_no_ipfs_get(
     shared_state: Dict[str, Any],
     monkeypatch: Any,
 ) -> None:
-    """Off-chain pending task → ``_handle_get_task`` called inline, no IPFS GET.
-
-    The handler short-circuits the IPFS upload but #457 left the symmetric
-    short-circuit on the get-side missing. This patch feeds a synthetic
-    ``IpfsMessage`` (the inline ``ipfs_data`` wrapped in
-    ``SimpleNamespace(files={"metadata.json": ...})``) straight into
-    ``_handle_get_task`` instead. Asserting both halves: the synthetic
-    message reaches ``_handle_get_task``, and ``send_message`` is never
-    called (which would be the IPFS GET).
-    """
+    """Offchain pending task dispatches via _handle_get_task with no IPFS GET."""
+    # The handler short-circuits the IPFS upload but #457 left the
+    # symmetric short-circuit on the get-side missing. This patch feeds a
+    # synthetic IpfsMessage (the inline ipfs_data wrapped in
+    # SimpleNamespace(files={"metadata.json": ...})) straight into
+    # _handle_get_task instead. Asserting both halves: the synthetic
+    # message reaches _handle_get_task, and send_message is never called
+    # (which would be the IPFS GET).
     params_stub.in_flight_req = False
     behaviour._executing_task = None
     behaviour._invalid_request = False
@@ -3277,14 +3267,11 @@ def test_execute_task_offchain_missing_ipfs_data_sets_invalid_request(
     shared_state: Dict[str, Any],
     monkeypatch: Any,
 ) -> None:
-    """Off-chain task with no inline payload → invalid request, no dispatch.
-
-    Defensive guard: a buffered off-chain task without ``ipfs_data`` is a
-    handler bug; the patch sets ``_invalid_request=True`` so the FSM
-    cleans up rather than dispatching ``_handle_get_task(SimpleNamespace(
-    files={"metadata.json": None}))`` which would crash deeper in the
-    pipeline.
-    """
+    """Offchain task without inline ipfs_data sets _invalid_request, no dispatch."""
+    # Defensive guard: a buffered offchain task without ipfs_data is a
+    # handler bug; the patch sets _invalid_request=True so the FSM cleans
+    # up rather than dispatching with a None payload that would crash
+    # deeper in the pipeline.
     params_stub.in_flight_req = False
     behaviour._executing_task = None
     behaviour._invalid_request = False

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3203,6 +3203,61 @@ def test_build_wildcard_event_z_suffix_requested_at_is_parsed(
     assert event["request"]["requested_at"] == "2026-06-25T13:19:06.651013Z"
 
 
+def test_build_wildcard_event_unix_requested_at_out_of_range_falls_back(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """An out-of-range Unix requested_at falls back to executed_at."""
+    # ``datetime.fromtimestamp`` raises ``OverflowError`` (or ``OSError``
+    # on some libcs) for values past the platform's representable range.
+    # The Unix branch catches it the same way the string branch catches
+    # malformed ISO 8601, so a malformed integer can't drop the delivery.
+    request_data = {
+        "prompt": "wild number",
+        "tool": "prediction-offline",
+        # 99,999,999,999,999 seconds since epoch ≈ year 5138 — past the
+        # range Python's datetime can represent on a 64-bit platform.
+        "requested_at": 99_999_999_999_999,
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    # Fallback ends in Z because executed_at does.
+    assert event["request"]["requested_at"].endswith("Z")
+
+
+def test_build_wildcard_event_unix_executed_at_out_of_range_falls_back(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """An out-of-range Unix executed_at falls back to now_iso."""
+    # Same defensive shape on the response side. ``executed_at`` comes
+    # from tool plumbing, but it still rides FSM consensus so a buggy
+    # tool returning a wild value can't take the round down with it.
+    request_data = {
+        "prompt": "wild executed",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06Z",
+    }
+    response_data = {
+        "result": "p_yes=0.7",
+        "schema_version": "2.0",
+        "executed_at": 99_999_999_999_999,  # past representable range
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data, response_data=response_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy-cid", executing_task=executing_task
+    )
+    assert event["response"]["executed_at"].endswith("Z")
+
+
 def test_build_wildcard_event_malformed_requested_at_falls_back(
     behaviour: Any,
     params_stub: Any,

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi
+- valory/task_execution:0.1.0:bafybeiciivrvfhdcmamgoj5h2bso3mm5kswe6glw2tptrvhcb2cogtuxgu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe
+- valory/task_execution:0.1.0:bafybeia6ufvehw5guk5xrpnysno6ibq4kycqlwooiif5vcsckcrhgdgfqi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeieyjv272dp4tyok57nt4rzt762n3wbog5h3fr3ohata3tw73gfqsa
+- valory/task_execution:0.1.0:bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeig4zholwyep76sapo2q4pgnr5mozdbz7s24u6uo2vqlg5jjikn7jq
+- valory/task_execution:0.1.0:bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeibmjjonv2f5n3a4jado5lfxxew76kbys2npvryvvaifnqs26jap5y
+- valory/task_execution:0.1.0:bafybeiepiugelvwth5uknhwjzji7i7xeb3n7twuvh3ks7gckelopvwlfoe
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Summary

Two follow-ups to #457 surfaced while running the offchain path end-to-end against staging (`mpp.staging.autonolas.tech`). With either gap in place, no offchain delivery ever reaches the wildcard data lake.

### 1. Bypass IPFS for the offchain task fetch

`_execute_task` was unconditionally fetching the request body via `_build_ipfs_get_file_req(ipfs_hash)` — even on the offchain path, where `in_memory_requests[request_id]` already has the prompt JSON in process memory. The handler short-circuits the IPFS *upload* (per #457's design intent) but the symmetric short-circuit on the *get* side was missing.

On a slow / unreachable IPFS endpoint the fetch ate the full 60s timeout and the offchain task never reached pebble. Branches on `is_offchain` now and feeds a synthetic `IpfsMessage` (the inline payload wrapped in `SimpleNamespace(files={\"metadata.json\": ...})`) straight into `_handle_get_task` so the rest of the validation + pebble dispatch stays unchanged.

### 2. Canonical timestamp form (Z, not +00:00)

`_build_wildcard_event` was emitting `requested_at` / `executed_at` / `delivered_at` with the `+00:00` UTC offset suffix:

```
\"requested_at\": \"2026-06-25T13:19:06.651013+00:00\"
```

The wildcard server reparses through Pydantic's `AwareDatetime` and re-emits via `model_dump(mode=\"json\")` which normalises to:

```
\"requested_at\": \"2026-06-25T13:19:06.651013Z\"
```

Same instant, different bytes. The mech's canonical-JSON `batch_hash` then disagreed with the server's recompute, dropping every offchain delivery with `400 BATCH_HASH_MISMATCH` at the very last auth-chain step (after `checkMech` + `getOwners` + owner verification had already passed). All three timestamps now `.replace(\"+00:00\", \"Z\")` to match the canonical form the server hashes.

### 3. Declare new params in `mech_abci`'s args allowlist

`mech_abci.Params` inherits from `TaskExecutionParams` (composition skill), so the three new fields (`mech_events_enabled`, `wildcard_events_url`, `wildcard_events_timeout_seconds`) are *read* via the inherited `kwargs.get`. But `mech_abci`'s own `skill.yaml` `args:` block didn't declare them, so AEA's strict-mode arg allowlist *rejected* any override block trying to flip them on. Result: the feature stayed dark even with the env vars set.

Adds the three fields with the same defaults as `task_submission_abci/skill.yaml` (off by default, empty URL, 5s timeout) so operators can override per deployment.

## E2E verification

Single-agent local run via `aea-helpers run-agent` against this PR's source + the predict-api staging server:

- mech-client sends offchain request → mech returns 200 with `Payment-Receipt` (#457 unchanged)
- Tool runs in pebble (`prediction-offline`)
- Done task with `wildcard_event` payload attached
- On-chain settlement via `deliverMarketplaceWithSignatures`
- `PostTxSettlementBehaviour` fires, signs the batch with the operator EOA
- POST to `https://mpp.staging.autonolas.tech/mech/events` returns **200**
- Mech log: `Wildcard batch POST OK (status=200 batch_size=1 signer-eoa=0x53B6c51B…)`

Before the timestamp fix, the same flow consistently returned `400 BATCH_HASH_MISMATCH` on the recompute step. After the fix the server accepts and inserts the `mech_requests` / `mech_responses` row pair.

## Test plan

- [ ] CI passes (lock + lint + tests)
- [ ] Existing unit tests for `_build_wildcard_event` still pass with the Z-normalised timestamps
- [ ] Add a unit test that asserts `_build_wildcard_event` emits `…Z` suffix on all three timestamp fields
- [ ] Confirm staging DB row landed via production team running the verification queries against `mech_requests` / `mech_responses`

🤖 Generated with [Claude Code](https://claude.com/claude-code)