### PR TITLE
feat(mech): on-chain write path — PostTxSettlement sweep + source field

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidjwhmd6rfacb3ckzfwpvjdrf7acubetxnxdfts6uu7r2zd3hampy",
+        "skill/valory/mech_abci/0.1.0": "bafybeifeoruubqscokp2dt7jwzbrh5gbpahcbpcvtoq6lwkh5fy2hlirja",
         "skill/valory/task_execution/0.1.0": "bafybeiedozhs2h3jwfbcr2e43hkyde3mqtxy236ztvtf73vlhyqumdey2i",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiaiwd5nvyb2zae2xjv3x43w3almckpmqw25g7wflz7nyt7ztxqq2a",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifccxpzjsec67h73kmcc2wlgtpbfunhh3zkq7wyixyiukesnl7upe",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeigv3fransj6e7boll6gwovk5qvio52xnuwrt4cpwrye5zis4d4inq",
-        "service/valory/mech/0.1.0": "bafybeibzvf6maa3ajxrkenpwepo2rbojsropyl5ngw6scissr5cb2a3l2q"
+        "agent/valory/mech/0.1.0": "bafybeib4dubnj7r7gwqkn4afpozsnogzkrbbswzutotoe2wboitxuc5f7u",
+        "service/valory/mech/0.1.0": "bafybeic3mcpl4a3qylwl5h5nncmkcn635wa3zrqw4ma6odjuvx62fad2pa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeid7z4cilmrtntmp2ownrsxwg3y6lwztfqabawcv2f7thosfvvftmq",
-        "skill/valory/task_execution/0.1.0": "bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeianxzhfz5geky2pjvryfbmpr6pgj2ov4qim5i4oqqd3xhgvufqery",
+        "skill/valory/mech_abci/0.1.0": "bafybeidjwhmd6rfacb3ckzfwpvjdrf7acubetxnxdfts6uu7r2zd3hampy",
+        "skill/valory/task_execution/0.1.0": "bafybeiedozhs2h3jwfbcr2e43hkyde3mqtxy236ztvtf73vlhyqumdey2i",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiaiwd5nvyb2zae2xjv3x43w3almckpmqw25g7wflz7nyt7ztxqq2a",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeif5ifgjaqswpdywlfaum4nloiwfnwvzudtn2nu4c2pt43gstxde54",
-        "service/valory/mech/0.1.0": "bafybeifvzinixdgke7er5hvmjtr5o5nxbtbgov52kqkfshf6or4m25eauy"
+        "agent/valory/mech/0.1.0": "bafybeigv3fransj6e7boll6gwovk5qvio52xnuwrt4cpwrye5zis4d4inq",
+        "service/valory/mech/0.1.0": "bafybeibzvf6maa3ajxrkenpwepo2rbojsropyl5ngw6scissr5cb2a3l2q"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeif53f4msnjk4njizkgovzp2sz7xbhuhsbyk3pvqdaooxopq2idlie",
-        "skill/valory/task_execution/0.1.0": "bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeia75r5rxneuff64e4xdejju3mtvgk44bj5nhz5sc4btiblytutyoe",
+        "skill/valory/mech_abci/0.1.0": "bafybeid7z4cilmrtntmp2ownrsxwg3y6lwztfqabawcv2f7thosfvvftmq",
+        "skill/valory/task_execution/0.1.0": "bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeianxzhfz5geky2pjvryfbmpr6pgj2ov4qim5i4oqqd3xhgvufqery",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiamh5bmd6arllvxtac7dtdjo763qahpya2buo63bhzbhnmro7n76a",
-        "service/valory/mech/0.1.0": "bafybeiaohk6t4ns2vfsb2aftacqqx6x67pklb7e4ipk72uyyebyujbl7iu"
+        "agent/valory/mech/0.1.0": "bafybeif5ifgjaqswpdywlfaum4nloiwfnwvzudtn2nu4c2pt43gstxde54",
+        "service/valory/mech/0.1.0": "bafybeifvzinixdgke7er5hvmjtr5o5nxbtbgov52kqkfshf6or4m25eauy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeia3fbmx6j6pcn5kky4eonsa5yvk64pl5vgunlmzd36wyzzparuoci",
-        "skill/valory/task_execution/0.1.0": "bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidqxjjxxf6ixvpjs2x45qtslcmzcrrhsixli4o7dtd7wcy6xi6qku",
+        "skill/valory/mech_abci/0.1.0": "bafybeidaprtiwozar37cnu2bgpngvuwnvyi2ljpkgo6eq3bf5gi6uzhki4",
+        "skill/valory/task_execution/0.1.0": "bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiap6pnh4kogzzmdy73jndofhvxcpp2rytktj2malhik4lyip5bgly",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeic53y5lkq7rksqczelrshkqegoskiqpbvsdfx4x433kpvmcrjasfe",
-        "service/valory/mech/0.1.0": "bafybeic36zvdzmifeub3tt22sv2ubsmclssrucvuthbjrzablcpkjbuv5e"
+        "agent/valory/mech/0.1.0": "bafybeid7burybe4v46hjm3ubaxvbhmykjdg6h4czhgu7br57ag56cdzcry",
+        "service/valory/mech/0.1.0": "bafybeigudzbw5sfetbhdbq667vmwwbszgumoxuhdssvy55diirojloeuuq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidaprtiwozar37cnu2bgpngvuwnvyi2ljpkgo6eq3bf5gi6uzhki4",
+        "skill/valory/mech_abci/0.1.0": "bafybeif53f4msnjk4njizkgovzp2sz7xbhuhsbyk3pvqdaooxopq2idlie",
         "skill/valory/task_execution/0.1.0": "bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiap6pnh4kogzzmdy73jndofhvxcpp2rytktj2malhik4lyip5bgly",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeia75r5rxneuff64e4xdejju3mtvgk44bj5nhz5sc4btiblytutyoe",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeid7burybe4v46hjm3ubaxvbhmykjdg6h4czhgu7br57ag56cdzcry",
-        "service/valory/mech/0.1.0": "bafybeigudzbw5sfetbhdbq667vmwwbszgumoxuhdssvy55diirojloeuuq"
+        "agent/valory/mech/0.1.0": "bafybeiamh5bmd6arllvxtac7dtdjo763qahpya2buo63bhzbhnmro7n76a",
+        "service/valory/mech/0.1.0": "bafybeiaohk6t4ns2vfsb2aftacqqx6x67pklb7e4ipk72uyyebyujbl7iu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu",
-        "skill/valory/task_execution/0.1.0": "bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4",
+        "skill/valory/mech_abci/0.1.0": "bafybeia3fbmx6j6pcn5kky4eonsa5yvk64pl5vgunlmzd36wyzzparuoci",
+        "skill/valory/task_execution/0.1.0": "bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidqxjjxxf6ixvpjs2x45qtslcmzcrrhsixli4o7dtd7wcy6xi6qku",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiet4mcpr36cm6wuprswfrxgibr5ob5rii277ynx65gl7a27qpekcm",
-        "service/valory/mech/0.1.0": "bafybeifpdygfygghydm7i3xfsnjbshdoyluq4dtu2izhit6utc43herg2u"
+        "agent/valory/mech/0.1.0": "bafybeic53y5lkq7rksqczelrshkqegoskiqpbvsdfx4x433kpvmcrjasfe",
+        "service/valory/mech/0.1.0": "bafybeic36zvdzmifeub3tt22sv2ubsmclssrucvuthbjrzablcpkjbuv5e"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeid7z4cilmrtntmp2ownrsxwg3y6lwztfqabawcv2f7thosfvvftmq
+- valory/mech_abci:0.1.0:bafybeidjwhmd6rfacb3ckzfwpvjdrf7acubetxnxdfts6uu7r2zd3hampy
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi
-- valory/task_submission_abci:0.1.0:bafybeianxzhfz5geky2pjvryfbmpr6pgj2ov4qim5i4oqqd3xhgvufqery
+- valory/task_execution:0.1.0:bafybeiedozhs2h3jwfbcr2e43hkyde3mqtxy236ztvtf73vlhyqumdey2i
+- valory/task_submission_abci:0.1.0:bafybeiaiwd5nvyb2zae2xjv3x43w3almckpmqw25g7wflz7nyt7ztxqq2a
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeif53f4msnjk4njizkgovzp2sz7xbhuhsbyk3pvqdaooxopq2idlie
+- valory/mech_abci:0.1.0:bafybeid7z4cilmrtntmp2ownrsxwg3y6lwztfqabawcv2f7thosfvvftmq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
-- valory/task_submission_abci:0.1.0:bafybeia75r5rxneuff64e4xdejju3mtvgk44bj5nhz5sc4btiblytutyoe
+- valory/task_execution:0.1.0:bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi
+- valory/task_submission_abci:0.1.0:bafybeianxzhfz5geky2pjvryfbmpr6pgj2ov4qim5i4oqqd3xhgvufqery
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeia3fbmx6j6pcn5kky4eonsa5yvk64pl5vgunlmzd36wyzzparuoci
+- valory/mech_abci:0.1.0:bafybeidaprtiwozar37cnu2bgpngvuwnvyi2ljpkgo6eq3bf5gi6uzhki4
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4
-- valory/task_submission_abci:0.1.0:bafybeidqxjjxxf6ixvpjs2x45qtslcmzcrrhsixli4o7dtd7wcy6xi6qku
+- valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
+- valory/task_submission_abci:0.1.0:bafybeiap6pnh4kogzzmdy73jndofhvxcpp2rytktj2malhik4lyip5bgly
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidjwhmd6rfacb3ckzfwpvjdrf7acubetxnxdfts6uu7r2zd3hampy
+- valory/mech_abci:0.1.0:bafybeifeoruubqscokp2dt7jwzbrh5gbpahcbpcvtoq6lwkh5fy2hlirja
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
 - valory/task_execution:0.1.0:bafybeiedozhs2h3jwfbcr2e43hkyde3mqtxy236ztvtf73vlhyqumdey2i
-- valory/task_submission_abci:0.1.0:bafybeiaiwd5nvyb2zae2xjv3x43w3almckpmqw25g7wflz7nyt7ztxqq2a
+- valory/task_submission_abci:0.1.0:bafybeifccxpzjsec67h73kmcc2wlgtpbfunhh3zkq7wyixyiukesnl7upe
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu
+- valory/mech_abci:0.1.0:bafybeia3fbmx6j6pcn5kky4eonsa5yvk64pl5vgunlmzd36wyzzparuoci
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq
-- valory/task_submission_abci:0.1.0:bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4
+- valory/task_execution:0.1.0:bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4
+- valory/task_submission_abci:0.1.0:bafybeidqxjjxxf6ixvpjs2x45qtslcmzcrrhsixli4o7dtd7wcy6xi6qku
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidaprtiwozar37cnu2bgpngvuwnvyi2ljpkgo6eq3bf5gi6uzhki4
+- valory/mech_abci:0.1.0:bafybeif53f4msnjk4njizkgovzp2sz7xbhuhsbyk3pvqdaooxopq2idlie
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
 - valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
-- valory/task_submission_abci:0.1.0:bafybeiap6pnh4kogzzmdy73jndofhvxcpp2rytktj2malhik4lyip5bgly
+- valory/task_submission_abci:0.1.0:bafybeia75r5rxneuff64e4xdejju3mtvgk44bj5nhz5sc4btiblytutyoe
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiamh5bmd6arllvxtac7dtdjo763qahpya2buo63bhzbhnmro7n76a
+agent: valory/mech:0.1.0:bafybeif5ifgjaqswpdywlfaum4nloiwfnwvzudtn2nu4c2pt43gstxde54
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeif5ifgjaqswpdywlfaum4nloiwfnwvzudtn2nu4c2pt43gstxde54
+agent: valory/mech:0.1.0:bafybeigv3fransj6e7boll6gwovk5qvio52xnuwrt4cpwrye5zis4d4inq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiet4mcpr36cm6wuprswfrxgibr5ob5rii277ynx65gl7a27qpekcm
+agent: valory/mech:0.1.0:bafybeic53y5lkq7rksqczelrshkqegoskiqpbvsdfx4x433kpvmcrjasfe
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigv3fransj6e7boll6gwovk5qvio52xnuwrt4cpwrye5zis4d4inq
+agent: valory/mech:0.1.0:bafybeib4dubnj7r7gwqkn4afpozsnogzkrbbswzutotoe2wboitxuc5f7u
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeic53y5lkq7rksqczelrshkqegoskiqpbvsdfx4x433kpvmcrjasfe
+agent: valory/mech:0.1.0:bafybeid7burybe4v46hjm3ubaxvbhmykjdg6h4czhgu7br57ag56cdzcry
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeid7burybe4v46hjm3ubaxvbhmykjdg6h4czhgu7br57ag56cdzcry
+agent: valory/mech:0.1.0:bafybeiamh5bmd6arllvxtac7dtdjo763qahpya2buo63bhzbhnmro7n76a
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -176,6 +176,7 @@ models:
       wildcard_events_timeout_seconds: 5.0
       mech_events_sweep_pending_enabled: false
       mech_events_sweep_max_age_seconds: 3600.0
+      mech_events_chain_id: 0
     class_name: Params
   randomness_api:
     args:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4
+- valory/task_submission_abci:0.1.0:bafybeidqxjjxxf6ixvpjs2x45qtslcmzcrrhsixli4o7dtd7wcy6xi6qku
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq
+- valory/task_execution:0.1.0:bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4
 behaviours:
   main:
     args: {}
@@ -174,6 +174,8 @@ models:
       mech_events_enabled: false
       wildcard_events_url: ''
       wildcard_events_timeout_seconds: 5.0
+      mech_events_sweep_pending_enabled: false
+      mech_events_sweep_max_age_seconds: 3600.0
     class_name: Params
   randomness_api:
     args:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeia75r5rxneuff64e4xdejju3mtvgk44bj5nhz5sc4btiblytutyoe
+- valory/task_submission_abci:0.1.0:bafybeianxzhfz5geky2pjvryfbmpr6pgj2ov4qim5i4oqqd3xhgvufqery
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
+- valory/task_execution:0.1.0:bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,7 +30,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeiaiwd5nvyb2zae2xjv3x43w3almckpmqw25g7wflz7nyt7ztxqq2a
+- valory/task_submission_abci:0.1.0:bafybeifccxpzjsec67h73kmcc2wlgtpbfunhh3zkq7wyixyiukesnl7upe
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeidqxjjxxf6ixvpjs2x45qtslcmzcrrhsixli4o7dtd7wcy6xi6qku
+- valory/task_submission_abci:0.1.0:bafybeiap6pnh4kogzzmdy73jndofhvxcpp2rytktj2malhik4lyip5bgly
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4
+- valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeianxzhfz5geky2pjvryfbmpr6pgj2ov4qim5i4oqqd3xhgvufqery
+- valory/task_submission_abci:0.1.0:bafybeiaiwd5nvyb2zae2xjv3x43w3almckpmqw25g7wflz7nyt7ztxqq2a
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi
+- valory/task_execution:0.1.0:bafybeiedozhs2h3jwfbcr2e43hkyde3mqtxy236ztvtf73vlhyqumdey2i
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,7 +30,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeiap6pnh4kogzzmdy73jndofhvxcpp2rytktj2malhik4lyip5bgly
+- valory/task_submission_abci:0.1.0:bafybeia75r5rxneuff64e4xdejju3mtvgk44bj5nhz5sc4btiblytutyoe
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1545,7 +1545,17 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # built and nothing rides Tendermint consensus replication. The flag
         # check lives here as well as in the post-settlement behaviour so
         # the consensus-state cost is gated, not just the HTTP write.
-        if is_offchain and getattr(self.params, "mech_events_enabled", False):
+        # Build the wildcard event for both off-chain HTTP deliveries
+        # (is_offchain=True) and on-chain marketplace deliveries
+        # (is_offchain=False AND is_marketplace_mech). The ``source`` field
+        # on the event (set by ``_build_wildcard_event``) is what
+        # disambiguates the two paths on the wildcard side: ``mech_offchain``
+        # for the paid HTTP path, ``mech_onchain`` for the on-chain rails.
+        # See ``autonolas-marketplace/docs/onchain_write_path_scope.md`` for
+        # the agreed shape.
+        wildcard_mode_enabled = getattr(self.params, "mech_events_enabled", False)
+        is_marketplace_delivery = bool(done_task.get("is_marketplace_mech"))
+        if wildcard_mode_enabled and (is_offchain or is_marketplace_delivery):
             done_task["wildcard_event"] = self._build_wildcard_event(
                 done_task=done_task,
                 cid=cid,
@@ -1643,6 +1653,17 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         tool = str(done_task.get("tool") or "unknown")
         delivery_mech = str(
             done_task.get("mech_address") or self.params.mech_marketplace_address or ""
+        )
+        # Wildcard ``source`` derives from the per-task ``is_offchain``
+        # flag: True → ``mech_offchain`` (paid HTTP path); False →
+        # ``mech_onchain`` (the on-chain marketplace rails). This is the
+        # only field that disambiguates the two paths on the wildcard
+        # side; the per-row ``is_offchain`` boolean stays on the
+        # response payload as well (the lake keeps both because the
+        # ipfs_historical backfill describes either path).
+        is_offchain_task = bool(executing_task.get("is_offchain", False))
+        wildcard_source = (
+            "mech_offchain" if is_offchain_task else "mech_onchain"
         )
 
         # `start_time` is a perf_counter() value (monotonic, not wall-clock),
@@ -1829,7 +1850,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "error": error_text,
                 "executed_at": executed_at_iso,
                 "cost_dict": cost_dict,
-                "is_offchain": True,
+                "is_offchain": is_offchain_task,
                 "tool_hash": tool_hash,
                 "execution_latency_ms": None,
                 "params_used": (
@@ -1845,6 +1866,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "response_cid": None,
                 "delivered_at": now_iso,
             },
+            "source": wildcard_source,
         }
 
     def _reset_executing_task(self) -> None:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1662,9 +1662,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # response payload as well (the lake keeps both because the
         # ipfs_historical backfill describes either path).
         is_offchain_task = bool(executing_task.get("is_offchain", False))
-        wildcard_source = (
-            "mech_offchain" if is_offchain_task else "mech_onchain"
-        )
+        wildcard_source = "mech_offchain" if is_offchain_task else "mech_onchain"
 
         # `start_time` is a perf_counter() value (monotonic, not wall-clock),
         # not suitable as a delivered_at timestamp. Use the current wall-clock

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1813,7 +1813,21 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "marketplace_address": str(
                     getattr(self.params, "mech_marketplace_address", "") or ""
                 ),
-                "requester": str(executing_task.get("sender") or ""),
+                # ``sender`` is the off-chain HTTP path's requester key
+                # (set from the signed request body in
+                # ``task_execution.handlers._enqueue_offchain_request``).
+                # Marketplace pending tasks come from
+                # ``MechMarketplaceContract.get_marketplace_undelivered_reqs``
+                # which keys the requester as ``requester`` and carries no
+                # ``sender`` field. This block now runs for on-chain
+                # marketplace deliveries too, so falling back to
+                # ``requester`` keeps the wildcard row correctly populated
+                # instead of writing an empty ``requester``.
+                "requester": str(
+                    executing_task.get("sender")
+                    or executing_task.get("requester")
+                    or ""
+                ),
                 "priority_mech": str(
                     executing_task.get("priority_mech") or delivery_mech
                 ),

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -461,6 +461,18 @@ class ContractHandler(BaseHandler):
                 priority_mech.lower() == self.mech_address.lower()
                 and status != DELIVERED_STATUS
             ):
+                # Stamp the local enqueue time so PostTxSettlement's
+                # undelivered-sweep (see task_submission_abci.behaviours
+                # ``_sweep_pending_undelivered``) can detect tasks that
+                # have sat in the pending queue past the operator-configured
+                # sweep window without paying a per-task RPC at sweep time.
+                # The contract's RequestInfo.responseTimeout is the
+                # authoritative timeout; this local stamp is the proxy the
+                # mech uses to decide when to emit a request-only event
+                # to the wildcard data lake. See
+                # ``autonolas-marketplace/docs/onchain_write_path_scope.md``
+                # §3.2 for the design.
+                req.setdefault("enqueued_at_local", time.time())
                 self.context.logger.info(
                     f"Adding request with id {rid} to pending_tasks."
                 )

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeicl5ga3mhv7co3qzllk7l4cmnz2enqlctwy4z2zv72oafmkh4peda
+  behaviours.py: bafybeia3xhmqepaupddtvmbhg7i57sh4mex5k5btbe5gtz7tpsx4crr3ym
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeieac6pch7j4v5tn7vwo4fcgkq5egi3kxv2qyus2egqeofsspowdem
+  handlers.py: bafybeicj6x3dsm4bk25n4n3pxmm6ioturmopztqfywcehaajjfcawcr4hm
   models.py: bafybeieuhchssbazb4f3nnvjex6trifp4kxse4lh6ihenmeemq36zhws7i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeica2lyinv26al2fekg6i2n4qowp3qbroandxdwnzpdwn53oivrgnq
+  tests/test_behaviours.py: bafybeicsreztkd7niqs3rrpregt5ckfpeciatcgghmthaggosc7s4deixa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   models.py: bafybeieuhchssbazb4f3nnvjex6trifp4kxse4lh6ihenmeemq36zhws7i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeifwo2lfowzt2gogr6bhsva7zbrsig6ry5fs5uzun2s7qh7rropmoe
+  tests/test_behaviours.py: bafybeib5ivnfbc7unufy5jde3hv7wvzrgpj7e7pz2ulj25kfjqqdu4gmti
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifay6kt6rpmgm5yzcrbtutdsxpfdzq4h2tqbco2g3fxcqongyk5ay
+  behaviours.py: bafybeifg7hk64avhvsdtlf63lzunhrsoijxovtdb7bxq2wz5ymojxlm23a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeicj6x3dsm4bk25n4n3pxmm6ioturmopztqfywcehaajjfcawcr4hm
   models.py: bafybeieuhchssbazb4f3nnvjex6trifp4kxse4lh6ihenmeemq36zhws7i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeicsreztkd7niqs3rrpregt5ckfpeciatcgghmthaggosc7s4deixa
+  tests/test_behaviours.py: bafybeifwo2lfowzt2gogr6bhsva7zbrsig6ry5fs5uzun2s7qh7rropmoe
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeia3xhmqepaupddtvmbhg7i57sh4mex5k5btbe5gtz7tpsx4crr3ym
+  behaviours.py: bafybeifay6kt6rpmgm5yzcrbtutdsxpfdzq4h2tqbco2g3fxcqongyk5ay
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeicj6x3dsm4bk25n4n3pxmm6ioturmopztqfywcehaajjfcawcr4hm
   models.py: bafybeieuhchssbazb4f3nnvjex6trifp4kxse4lh6ihenmeemq36zhws7i

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3380,3 +3380,71 @@ def test_execute_task_offchain_missing_ipfs_data_sets_invalid_request(
     assert behaviour._invalid_request is True
     assert handle_calls == []
     assert send_calls == []
+
+
+# ---------------------------------------------------------------------------
+# On-chain write path: source field on _build_wildcard_event
+# ---------------------------------------------------------------------------
+#
+# After the on-chain write path lands, _build_wildcard_event sets a
+# top-level ``source`` field on the returned event dict based on the
+# task's ``is_offchain`` flag:
+#   - is_offchain=True  → source="mech_offchain" (the paid HTTP path).
+#   - is_offchain=False → source="mech_onchain"  (the on-chain rails).
+# The wildcard server uses this field to tag both mech_requests and
+# mech_responses rows for the analytics ETL. See
+# ``autonolas-marketplace/docs/onchain_write_path_scope.md`` §3.
+
+
+def test_build_wildcard_event_offchain_task_carries_mech_offchain_source(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A task with ``is_offchain=True`` produces ``source='mech_offchain'``."""
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["source"] == "mech_offchain"
+    # Response payload's is_offchain field still reflects the underlying
+    # delivery path (kept in lock-step with the source for clarity).
+    assert event["response"]["is_offchain"] is True
+
+
+def test_build_wildcard_event_onchain_task_carries_mech_onchain_source(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A task with ``is_offchain=False`` produces ``source='mech_onchain'``.
+
+    The on-chain marketplace path lands here when the mech delivers an
+    on-chain request via ``deliverMarketplaceWithSignatures``. The
+    per-row response.is_offchain flag also flips false to keep the
+    analytics lake's two signals (which path + which source) consistent.
+    """
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    # Flip the flags on both halves: the source decision keys on the
+    # executing_task; the response payload's is_offchain mirrors it.
+    executing_task["is_offchain"] = False
+    done_task["is_offchain"] = False
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["source"] == "mech_onchain"
+    assert event["response"]["is_offchain"] is False

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3454,3 +3454,49 @@ def test_build_wildcard_event_onchain_task_carries_mech_onchain_source(
     )
     assert event["source"] == "mech_onchain"
     assert event["response"]["is_offchain"] is False
+
+
+def test_build_wildcard_event_marketplace_task_falls_back_to_requester_key(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """Marketplace-delivered tasks carry `requester` (not `sender`); requester still populates.
+
+    Pending marketplace tasks come from
+    ``MechMarketplaceContract.get_marketplace_undelivered_reqs``, which
+    keys the requester as ``requester`` and carries no ``sender`` field.
+    The delivered wildcard row must still populate ``request.requester``
+    or the analytics-side join breaks.
+
+    The shared ``_wildcard_event_setup`` fixture always stamps
+    ``sender`` on ``executing_task`` (that's the off-chain HTTP shape).
+    This test deletes it and injects ``requester`` alone, exercising the
+    ``sender or requester`` fallback added in ``_build_wildcard_event``.
+
+    :param behaviour: task_execution behaviour under test.
+    :param params_stub: params fixture — consumed by
+        ``_wildcard_event_setup`` to populate ``self.params`` bits.
+    :param shared_state: shared_state fixture used by
+        ``_wildcard_event_setup`` for ``IN_MEMORY_REQUESTS`` /
+        ``OFFCHAIN_REQUEST_RESPONSES`` seeding.
+    """
+    request_data = {
+        "prompt": "on-chain marketplace delivery",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _wildcard_event_setup(
+        behaviour, shared_state, request_data
+    )
+    # Marketplace shape: only ``requester``, no ``sender``. Also flip the
+    # per-row provenance so this is the on-chain path.
+    del executing_task["sender"]
+    executing_task["requester"] = "0xMARKETPLACE_REQUESTER"
+    executing_task["is_offchain"] = False
+    done_task["is_offchain"] = False
+    event = behaviour._build_wildcard_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["requester"] == "0xMARKETPLACE_REQUESTER"
+    assert event["source"] == "mech_onchain"

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3430,6 +3430,12 @@ def test_build_wildcard_event_onchain_task_carries_mech_onchain_source(
     on-chain request via ``deliverMarketplaceWithSignatures``. The
     per-row response.is_offchain flag also flips false to keep the
     analytics lake's two signals (which path + which source) consistent.
+
+    :param behaviour: the wired ``task_execution`` behaviour under test.
+    :param params_stub: params fixture — indirectly consumed by
+        ``_wildcard_event_setup`` to populate ``self.params`` bits.
+    :param shared_state: shared_state fixture used by
+        ``_wildcard_event_setup`` to build ``done_task`` / ``executing_task``.
     """
     request_data = {
         "prompt": "p",

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -1866,7 +1866,8 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             1. The feature flag is off (the default during Phase 1).
             2. The skill has no wildcard URL configured.
             3. The round's done_tasks carry no offchain wildcard_event
-               entries (the on-chain path doesn't populate these).
+               entries and the pending-task sweep produced no
+               request-only events (a truly quiet round).
 
         :yield: AEA protocol messages (signing dialogue, HTTP request) via
             the underlying generator-based helpers; this method does not
@@ -1887,7 +1888,12 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # have sat in the queue past the operator's max age. Appended to
         # the same batch as delivered events so the signing round-trip
         # costs one signature per settlement, not one per event class.
-        request_only_events = self._sweep_pending_undelivered()
+        # ``_sweep_pending_undelivered`` returns the swept ``request_id``s
+        # alongside the events but does NOT mutate the pending queue: any
+        # guard-skip or POST failure below would otherwise drop the tasks
+        # with no re-queue and no written row. The queue is only mutated
+        # once the wildcard POST has confirmed a 2xx below.
+        request_only_events, swept_request_ids = self._sweep_pending_undelivered()
         if request_only_events:
             events = events + request_only_events
         if not events:
@@ -2064,6 +2070,15 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             len(events),
             self.context.agent_address,
         )
+        # Wildcard confirmed the batch; drop the swept undelivered tasks
+        # from the pending queue now. Deferring to this point (rather than
+        # inside ``_sweep_pending_undelivered``) ensures that any early
+        # return above — missing mech address, missing marketplace, mixed
+        # chains, unconfigured chain_id, digest build, signing, JSON
+        # serialisation, POST timeout, or non-2xx status — leaves the
+        # sweep at-least-once: the tasks stay on the queue and the next
+        # FSM cycle re-attempts the write.
+        self._drop_swept_from_pending(swept_request_ids)
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
         """Return the ``wildcard_event`` payload from every done_task that
@@ -2090,11 +2105,26 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             events.append(event)
         return events
 
-    def _sweep_pending_undelivered(self) -> List[Dict[str, Any]]:
-        """Walk the on-chain pending-tasks queue, emit request-only
+    def _sweep_pending_undelivered(
+        self,
+    ) -> Tuple[List[Dict[str, Any]], List[str]]:
+        """Walk the on-chain pending-tasks queue and return request-only
         events for any task that has sat in the queue past the
-        operator-configured sweep window, and remove those tasks from
-        the queue.
+        operator-configured sweep window, alongside the ``request_id``s
+        of the swept tasks so the caller can remove them from the queue
+        AFTER the wildcard POST confirms success.
+
+        The sweep does NOT mutate ``PENDING_TASKS``. Dropping tasks here
+        (as an earlier revision of this PR did) would lose the
+        undelivered signal on any of the six early-return paths below
+        the caller — missing mech address, missing marketplace, mixed
+        chains, unconfigured chain id, digest-build failure, or the POST
+        itself failing — because ``PENDING_TASKS`` is the only record
+        the mech has for a task that never got delivered (unlike a
+        delivered event, which is anchored on-chain). Deferring the
+        queue mutation to a confirmed 2xx keeps the sweep at-least-once
+        rather than at-most-once and lets a transient POST failure
+        recover on the next FSM cycle.
 
         The sweep is the mech side of the on-chain write path's
         undelivered-request capture. Local-clock comparison only: the
@@ -2116,63 +2146,83 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         request-only event always carries ``source='mech_onchain'``;
         the off-chain path doesn't produce them by construction.
 
-        :return: an ordered list of request-only event dicts ready to
-            append to the batch.
+        :return: a ``(events, swept_request_ids)`` tuple. ``events`` is
+            an ordered list of request-only event dicts ready to append
+            to the batch; ``swept_request_ids`` is the ordered list of
+            ``request_id`` strings the caller should drop from
+            ``PENDING_TASKS`` if the wildcard POST returns 2xx. Empty
+            lists on any short-circuit or when nothing timed out.
         """
         if not getattr(self.params, "mech_events_enabled", False):
-            return []
+            return [], []
         if not getattr(self.params, "mech_events_sweep_pending_enabled", False):
-            return []
+            return [], []
         max_age = float(
             getattr(self.params, "mech_events_sweep_max_age_seconds", 3600.0)
         )
         if max_age <= 0:
-            return []
+            return [], []
         pending = self.context.shared_state.get(PENDING_TASKS)
         if not isinstance(pending, list) or not pending:
-            return []
+            return [], []
 
         now_ts = time.time()
-        kept: List[Dict[str, Any]] = []
         request_only_events: List[Dict[str, Any]] = []
+        swept_request_ids: List[str] = []
         for task in pending:
             if not isinstance(task, dict):
                 # Anything that isn't a dict shouldn't be in
-                # pending_tasks. Keep it as-is rather than dropping —
-                # whatever bug put it there is not this sweep's
-                # problem.
-                kept.append(task)
+                # pending_tasks. Leave it alone — whatever bug put it
+                # there is not this sweep's problem.
                 continue
             enqueued_at = task.get("enqueued_at_local")
             if not isinstance(enqueued_at, (int, float)):
                 # Older entries (pre-sweep deployment) won't carry the
                 # stamp. Leave them alone; they'll be picked up on the
                 # next enqueue or when the handler stamps fresh.
-                kept.append(task)
                 continue
             if now_ts - float(enqueued_at) < max_age:
-                kept.append(task)
                 continue
             event = self._build_request_only_event(task, now_ts)
             if event is None:
                 # If we can't build a valid event from a stale task,
-                # keep it on the queue rather than silently dropping —
+                # leave it on the queue rather than silently dropping —
                 # better a re-attempted sweep than a lost write.
-                kept.append(task)
                 continue
             request_only_events.append(event)
+            swept_request_ids.append(str(event["request"].get("request_id")))
             self.context.logger.info(
-                "Wildcard sweep: emitting request-only event for "
-                "timed-out task request_id=%s, age=%.0fs",
+                "Wildcard sweep: staging request-only event for "
+                "timed-out task request_id=%s, age=%.0fs "
+                "(queue not mutated until POST succeeds)",
                 event["request"].get("request_id"),
                 now_ts - float(enqueued_at),
             )
 
-        # Mutate the shared list in place: other consumers (the task
-        # picker in task_execution) hold the same reference and would
-        # not see a rebinding.
-        pending[:] = kept
-        return request_only_events
+        return request_only_events, swept_request_ids
+
+    def _drop_swept_from_pending(self, swept_request_ids: List[str]) -> None:
+        """Remove the swept tasks from ``PENDING_TASKS`` after a
+        confirmed wildcard write.
+
+        Mutates the shared list in place: other consumers (the task
+        picker in task_execution) hold the same reference and would not
+        see a rebinding.
+        """
+        if not swept_request_ids:
+            return
+        pending = self.context.shared_state.get(PENDING_TASKS)
+        if not isinstance(pending, list) or not pending:
+            return
+        drop_set = set(swept_request_ids)
+        pending[:] = [
+            task
+            for task in pending
+            if not (
+                isinstance(task, dict)
+                and str(task.get("requestId") or "") in drop_set
+            )
+        ]
 
     def _build_request_only_event(
         self, task: Dict[str, Any], now_ts: float

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -2081,8 +2081,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         self._drop_swept_from_pending(swept_request_ids)
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
-        """Return the ``wildcard_event`` payload from every done_task that
-        carries one.
+        """Return the ``wildcard_event`` payload from every done_task that carries one.
 
         Both off-chain HTTP deliveries (``source = 'mech_offchain'``) and
         on-chain marketplace deliveries (``source = 'mech_onchain'``) now
@@ -2108,11 +2107,12 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     def _sweep_pending_undelivered(
         self,
     ) -> Tuple[List[Dict[str, Any]], List[str]]:
-        """Walk the on-chain pending-tasks queue and return request-only
-        events for any task that has sat in the queue past the
-        operator-configured sweep window, alongside the ``request_id``s
-        of the swept tasks so the caller can remove them from the queue
-        AFTER the wildcard POST confirms success.
+        """Walk the on-chain pending-tasks queue and stage request-only events for stale tasks.
+
+        Returns request-only events for any task that has sat in the
+        queue past the operator-configured sweep window, alongside the
+        ``request_id``s of the swept tasks so the caller can remove them
+        from the queue AFTER the wildcard POST confirms success.
 
         The sweep does NOT mutate ``PENDING_TASKS``. Dropping tasks here
         (as an earlier revision of this PR did) would lose the
@@ -2202,12 +2202,15 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         return request_only_events, swept_request_ids
 
     def _drop_swept_from_pending(self, swept_request_ids: List[str]) -> None:
-        """Remove the swept tasks from ``PENDING_TASKS`` after a
-        confirmed wildcard write.
+        """Remove the swept tasks from ``PENDING_TASKS`` after a confirmed wildcard write.
 
         Mutates the shared list in place: other consumers (the task
         picker in task_execution) hold the same reference and would not
         see a rebinding.
+
+        :param swept_request_ids: ``request_id`` strings returned by
+            :py:meth:`_sweep_pending_undelivered` alongside the
+            request-only events; empty list = no-op.
         """
         if not swept_request_ids:
             return
@@ -2219,16 +2222,14 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             task
             for task in pending
             if not (
-                isinstance(task, dict)
-                and str(task.get("requestId") or "") in drop_set
+                isinstance(task, dict) and str(task.get("requestId") or "") in drop_set
             )
         ]
 
     def _build_request_only_event(
         self, task: Dict[str, Any], now_ts: float
     ) -> Optional[Dict[str, Any]]:
-        """Build a request-only ``MechEvent``-shaped dict for a timed-out
-        pending task.
+        """Build a request-only ``MechEvent``-shaped dict for a timed-out pending task.
 
         The pending-task dict carries the on-chain bits the marketplace
         knows (request_id, requester, priority_mech, delivery_rate,
@@ -2313,9 +2314,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # so a reader can spot a sweep-emitted row from the value.
         prompt = "[onchain undelivered]"
         tool = "unknown"
-        chain_id = int(
-            getattr(self.params, "mech_events_chain_id", 0) or 0
-        )
+        chain_id = int(getattr(self.params, "mech_events_chain_id", 0) or 0)
         marketplace_address = str(
             getattr(self.params, "mech_marketplace_address", "") or ""
         )

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -25,6 +25,7 @@ import time
 from abc import ABC
 from collections import defaultdict
 from copy import deepcopy
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Type, cast
 
@@ -113,6 +114,12 @@ SENDER = "sender"
 REQUESTER_KEY = "requester"
 MECH_ADDRESS = "mech_address"
 LAST_TX = "last_tx"
+
+# Shared-state key under which task_execution.handlers stores the
+# mech's on-chain pending-task queue. Imported by reference rather than
+# from task_execution to keep the dependency direction one-way (the
+# post-tx behaviour reads, never writes).
+PENDING_TASKS = "pending_tasks"
 PAYMENT_MODEL = "payment_model"
 
 
@@ -1876,10 +1883,18 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             return
 
         events = self._extract_offchain_events()
+        # On-chain pending-task sweep: request-only events for tasks that
+        # have sat in the queue past the operator's max age. Appended to
+        # the same batch as delivered events so the signing round-trip
+        # costs one signature per settlement, not one per event class.
+        request_only_events = self._sweep_pending_undelivered()
+        if request_only_events:
+            events = events + request_only_events
         if not events:
             self.context.logger.debug(
-                "No offchain wildcard_event entries in done_tasks; "
-                "post-tx wildcard write is a no-op for this round."
+                "No wildcard_event entries in done_tasks and no swept "
+                "pending tasks; post-tx wildcard write is a no-op for "
+                "this round."
             )
             return
 
@@ -2051,26 +2066,239 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         )
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
-        """Return the ``wildcard_event`` payload from every offchain done_task.
+        """Return the ``wildcard_event`` payload from every done_task that
+        carries one.
 
-        Only tasks with ``is_offchain=True`` AND a non-empty
-        ``wildcard_event`` field are included: on-chain tasks (where the
-        old IPFS publication path still runs) do not need a separate
-        analytics write, and an offchain task without a wildcard_event
-        attached is a finalize-time bug that we'd rather skip than crash.
+        Both off-chain HTTP deliveries (``source = 'mech_offchain'``) and
+        on-chain marketplace deliveries (``source = 'mech_onchain'``) now
+        ride the same wildcard write path; the per-event ``source`` field
+        set inside :py:meth:`task_execution.behaviours._build_wildcard_event`
+        is what disambiguates the two on the wildcard side. The filter
+        here keys on the presence of a ``wildcard_event`` field — built
+        only when both ``mech_events_enabled`` is set AND the task is a
+        marketplace task — so on-chain non-marketplace tasks (legacy
+        mech contract) stay out of the lake by construction.
 
-        :return: an ordered list of ``MechSettlementEvent``-shaped dicts.
+        :return: an ordered list of ``MechEvent``-shaped dicts.
         """
         done_tasks = cast(List[Dict[str, Any]], self.synchronized_data.done_tasks)
         events: List[Dict[str, Any]] = []
         for task in done_tasks:
-            if not task.get("is_offchain"):
-                continue
             event = task.get("wildcard_event")
             if not isinstance(event, dict):
                 continue
             events.append(event)
         return events
+
+    def _sweep_pending_undelivered(self) -> List[Dict[str, Any]]:
+        """Walk the on-chain pending-tasks queue, emit request-only
+        events for any task that has sat in the queue past the
+        operator-configured sweep window, and remove those tasks from
+        the queue.
+
+        The sweep is the mech side of the on-chain write path's
+        undelivered-request capture. Local-clock comparison only: the
+        contract's ``mapRequestIdInfos.responseTimeout`` is the
+        authoritative timeout, but reading it per task is one RPC per
+        sweep that we explicitly want to avoid (see
+        ``autonolas-marketplace/docs/onchain_write_path_scope.md`` §3.2).
+        Instead, ``filter_requests`` in task_execution.handlers stamps
+        ``enqueued_at_local`` at enqueue time, and the sweep here treats
+        any pending task older than ``mech_events_sweep_max_age_seconds``
+        as undelivered. The DB's race-safe ``ON CONFLICT (request_id)
+        DO UPDATE ... WHERE delivery_mech IS NULL`` clause (predict-api
+        side) reconciles the lake to the right row if step-in delivers
+        the request after the sweep — see §3.4.
+
+        Gated on ``mech_events_sweep_pending_enabled`` so operators can
+        roll this out independently from the delivered-event write
+        (which is what ``mech_events_enabled`` already gates). A
+        request-only event always carries ``source='mech_onchain'``;
+        the off-chain path doesn't produce them by construction.
+
+        :return: an ordered list of request-only event dicts ready to
+            append to the batch.
+        """
+        if not getattr(self.params, "mech_events_enabled", False):
+            return []
+        if not getattr(self.params, "mech_events_sweep_pending_enabled", False):
+            return []
+        max_age = float(
+            getattr(self.params, "mech_events_sweep_max_age_seconds", 3600.0)
+        )
+        if max_age <= 0:
+            return []
+        pending = self.context.shared_state.get(PENDING_TASKS)
+        if not isinstance(pending, list) or not pending:
+            return []
+
+        now_ts = time.time()
+        kept: List[Dict[str, Any]] = []
+        request_only_events: List[Dict[str, Any]] = []
+        for task in pending:
+            if not isinstance(task, dict):
+                # Anything that isn't a dict shouldn't be in
+                # pending_tasks. Keep it as-is rather than dropping —
+                # whatever bug put it there is not this sweep's
+                # problem.
+                kept.append(task)
+                continue
+            enqueued_at = task.get("enqueued_at_local")
+            if not isinstance(enqueued_at, (int, float)):
+                # Older entries (pre-sweep deployment) won't carry the
+                # stamp. Leave them alone; they'll be picked up on the
+                # next enqueue or when the handler stamps fresh.
+                kept.append(task)
+                continue
+            if now_ts - float(enqueued_at) < max_age:
+                kept.append(task)
+                continue
+            event = self._build_request_only_event(task, now_ts)
+            if event is None:
+                # If we can't build a valid event from a stale task,
+                # keep it on the queue rather than silently dropping —
+                # better a re-attempted sweep than a lost write.
+                kept.append(task)
+                continue
+            request_only_events.append(event)
+            self.context.logger.info(
+                "Wildcard sweep: emitting request-only event for "
+                "timed-out task request_id=%s, age=%.0fs",
+                event["request"].get("request_id"),
+                now_ts - float(enqueued_at),
+            )
+
+        # Mutate the shared list in place: other consumers (the task
+        # picker in task_execution) hold the same reference and would
+        # not see a rebinding.
+        pending[:] = kept
+        return request_only_events
+
+    def _build_request_only_event(
+        self, task: Dict[str, Any], now_ts: float
+    ) -> Optional[Dict[str, Any]]:
+        """Build a request-only ``MechEvent``-shaped dict for a timed-out
+        pending task.
+
+        The pending-task dict carries the on-chain bits the marketplace
+        knows (request_id, requester, priority_mech, delivery_rate,
+        content_cid) but not the IPFS-resolved fields (prompt, tool,
+        model). Those would require an IPFS fetch at sweep time, which
+        we explicitly do not do; placeholders keep the wildcard schema
+        happy. The lake's analytics-side undelivered signal — the
+        absence of a ``mech_responses`` row — does not depend on those
+        fields, so the placeholder values do not corrupt downstream
+        analytics. If a richer fill-in becomes load-bearing later, the
+        sweep can lazily resolve IPFS at sweep time; v1 trades fidelity
+        for predictability.
+
+        :param task: one entry from ``shared_state[PENDING_TASKS]``.
+        :param now_ts: ``time.time()`` value captured by the caller so
+            every event in the sweep shares the same ``requested_at``
+            fallback if the task carries no local timestamp.
+        :return: a dict with the same shape as the off-chain
+            ``_build_wildcard_event`` return, but with ``response: None``
+            and ``source: 'mech_onchain'``; or ``None`` if the task
+            doesn't have the minimum fields the wildcard server
+            requires.
+        """
+        request_id = task.get("requestId")
+        if not request_id:
+            self.context.logger.warning(
+                "Pending sweep: skipping task with no requestId: %s", task
+            )
+            return None
+        request_id_str = str(request_id)
+        priority_mech = str(task.get("priorityMech") or "")
+        requester = str(task.get("requester") or "")
+        if not priority_mech or not requester:
+            self.context.logger.warning(
+                "Pending sweep: skipping task with missing priority_mech "
+                "or requester: %s",
+                request_id_str,
+            )
+            return None
+        # ``data`` on the pending-task dict is the IPFS CID for the
+        # request body (raw bytes from the contract event). Surface it
+        # as ``content_cid`` for the lake; downstream consumers can
+        # resolve later if they need the body, but the lake row itself
+        # doesn't need it.
+        content_cid_raw = task.get("data")
+        if isinstance(content_cid_raw, (bytes, bytearray)):
+            content_cid = "0x" + content_cid_raw.hex()
+        elif isinstance(content_cid_raw, str):
+            content_cid = content_cid_raw
+        else:
+            content_cid = None
+
+        # ``enqueued_at_local`` is monotonic-ish ``time.time()`` from
+        # the handler; the wildcard ``requested_at`` is the requester's
+        # signed-header timestamp on the off-chain path. The on-chain
+        # path's request timestamp is the block.timestamp, which we
+        # don't have here without a contract read; use the local stamp
+        # as a stand-in. Skew is bounded by the gap between request
+        # submission and the mech seeing the event (typically seconds).
+        enqueued_at_raw = task.get("enqueued_at_local") or now_ts
+        try:
+            requested_at_iso = (
+                datetime.fromtimestamp(float(enqueued_at_raw), tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+        except (TypeError, ValueError, OverflowError, OSError):
+            requested_at_iso = (
+                datetime.fromtimestamp(now_ts, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+
+        delivery_rate_raw = task.get("request_delivery_rate")
+        delivery_rate_str = (
+            str(delivery_rate_raw) if delivery_rate_raw is not None else None
+        )
+
+        # The wildcard server requires ``prompt`` to be a non-empty
+        # string and ``tool`` to be a non-empty string. Placeholders
+        # match the off-chain build's pattern ("[offchain request]")
+        # so a reader can spot a sweep-emitted row from the value.
+        prompt = "[onchain undelivered]"
+        tool = "unknown"
+        chain_id = int(
+            getattr(self.params, "mech_events_chain_id", 0) or 0
+        )
+        marketplace_address = str(
+            getattr(self.params, "mech_marketplace_address", "") or ""
+        )
+
+        return {
+            "request": {
+                "request_id": request_id_str,
+                "chain_id": chain_id,
+                "marketplace_address": marketplace_address,
+                "requester": requester,
+                "priority_mech": priority_mech,
+                # Request-only events carry no delivery_mech: no one
+                # delivered. The lake column stays NULL until a stepper
+                # writes the delivered event, at which point the
+                # ON CONFLICT DO UPDATE fills it in.
+                "delivery_mech": None,
+                "payment_type": None,
+                "delivery_rate": delivery_rate_str,
+                "nonce": None,
+                "content_cid": content_cid,
+                "prompt": prompt,
+                "tool": tool,
+                "model": None,
+                "tool_params": None,
+                "raw_content": {
+                    "note": "request-only event; IPFS body not resolved",
+                    "request_id": request_id_str,
+                },
+                "requested_at": requested_at_iso,
+            },
+            "response": None,
+            "source": "mech_onchain",
+        }
 
 
 class TaskSubmissionRoundBehaviour(AbstractRoundBehaviour):

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -1845,9 +1845,15 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
 
     matching_round: Type[AbstractRound] = PostTxSettlementRound
 
+    # Set to True after we've logged the mech_events_chain_id divergence
+    # once, so ``_check_mech_events_chain_id_consistency`` doesn't spam
+    # the same warning every settlement round on a persistent config drift.
+    _chain_id_divergence_logged: bool = False
+
     def async_act(self) -> Generator:
         """Build, sign, and POST the offchain-events batch, then advance."""
         with self.context.benchmark_tool.measure(self.behaviour_id).local():
+            self._check_mech_events_chain_id_consistency()
             yield from self._do_wildcard_write_best_effort()
             payload = PostTxSettlementPayload(
                 sender=self.context.agent_address, content="done"
@@ -1857,6 +1863,61 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             yield from self.send_a2a_transaction(payload)
             yield from self.wait_until_round_end()
             self.set_done()
+
+    def _check_mech_events_chain_id_consistency(self) -> None:
+        """Warn once if task_execution and task_submission_abci disagree on chain id.
+
+        ``mech_events_chain_id`` now lives on both
+        :class:`task_execution.models.Params` and
+        :class:`task_submission_abci.models.Params` because a pure-sweep
+        round has no delivered event to fall back to for the EIP-712
+        ``domain.chainId`` and the two skills each own their own event
+        builder. That gives operators two knobs where they had one, and
+        forgetting the newer knob silently split the batch chain-id
+        across delivered and sweep events.
+
+        The split-batch design in :py:meth:`_post_wildcard_batch` already
+        limits the blast radius (the two batches are independent, so a
+        misconfigured sweep chain id short-circuits the sweep batch
+        without touching delivered), but a drift is still a config bug
+        worth surfacing.
+
+        Rather than crash at startup on a mismatch (this behaviour is
+        fail-soft by design and a config check that hard-blocks the FSM
+        would be worse than the drift it protects against), we log a
+        single WARNING the first time we notice, and rely on operators
+        picking it up in the logs. The flag is instance-scoped so it
+        also self-resets on a mech restart.
+        """
+        if self._chain_id_divergence_logged:
+            return
+        submission_chain_id = int(getattr(self.params, "mech_events_chain_id", 0) or 0)
+        # ``task_execution.Params`` is the same object graph — the
+        # PostTxSettlement behaviour extends TaskExecutionBaseBehaviour
+        # which composes both skills' params under ``self.params``. Pull
+        # the task_execution copy directly from the skill context so the
+        # comparison isn't tautological.
+        task_exec_params = getattr(
+            self.context.skills.task_execution.models, "params", None
+        )
+        task_exec_chain_id = int(
+            getattr(task_exec_params, "mech_events_chain_id", 0) or 0
+        )
+        if submission_chain_id != task_exec_chain_id:
+            self.context.logger.warning(
+                "mech_events_chain_id drift detected: task_execution has "
+                "%s but task_submission_abci has %s. A pure-sweep round "
+                "will use the task_submission value; a delivered-only "
+                "round will use the task_execution value. Under the "
+                "split-batch flow the sweep batch may short-circuit at "
+                "the chain_id=0 guard while the delivered batch still "
+                "lands, so operators can miss this silently — check the "
+                "``mech_events_chain_id`` field on both skill.yaml / "
+                "aea-config overrides.",
+                task_exec_chain_id,
+                submission_chain_id,
+            )
+            self._chain_id_divergence_logged = True
 
     def _do_wildcard_write_best_effort(self) -> Generator:
         """Best-effort wildcard write. Never raises; logs failure paths.
@@ -1883,20 +1944,17 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             )
             return
 
-        events = self._extract_offchain_events()
+        delivered_events = self._extract_offchain_events()
         # On-chain pending-task sweep: request-only events for tasks that
-        # have sat in the queue past the operator's max age. Appended to
-        # the same batch as delivered events so the signing round-trip
-        # costs one signature per settlement, not one per event class.
+        # have sat in the queue past the operator's max age.
         # ``_sweep_pending_undelivered`` returns the swept ``request_id``s
         # alongside the events but does NOT mutate the pending queue: any
         # guard-skip or POST failure below would otherwise drop the tasks
         # with no re-queue and no written row. The queue is only mutated
-        # once the wildcard POST has confirmed a 2xx below.
+        # once the wildcard POST has confirmed a 2xx (or a terminal 4xx —
+        # see ``_post_wildcard_batch`` for the poison-drop rationale).
         request_only_events, swept_request_ids = self._sweep_pending_undelivered()
-        if request_only_events:
-            events = events + request_only_events
-        if not events:
+        if not delivered_events and not request_only_events:
             self.context.logger.debug(
                 "No wildcard_event entries in done_tasks and no swept "
                 "pending tasks; post-tx wildcard write is a no-op for "
@@ -1918,7 +1976,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         mech_address = getattr(self.params, "agent_mech_contract_address", "") or ""
         if not mech_address:
             self.context.logger.warning(
-                "No agent_mech_contract_address available; " "skipping wildcard write."
+                "No agent_mech_contract_address available; skipping wildcard write."
             )
             return
 
@@ -1929,30 +1987,121 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             )
             return
 
-        # The EIP-712 domain.chainId binds the signature to one chain. Every
-        # event in the batch was built by ``task_execution._build_wildcard_event``
-        # against the same ``mech_events_chain_id`` param, so we can read
-        # the int from the first event rather than duplicating the param
-        # across two skills (and the value-by-construction check below
-        # rejects a heterogeneous batch defensively).
+        # Delivered and sweep events are posted as TWO INDEPENDENT batches
+        # rather than merged into one. A permanently-rejected sweep event
+        # would otherwise kill the whole atomic batch (server 4xx or a
+        # digest/JSON-build failure on requester-influenced content) and
+        # take real delivered events down with it. Because delivered
+        # events are NOT retried across rounds (they come from this
+        # round's ``synchronized_data.done_tasks``), those already-settled
+        # deliveries would be silently and permanently lost, and every
+        # round the same poison sweep task would repeat the drain. Two
+        # batches isolate the failure modes: a bad sweep can never cost
+        # us a real delivered row.
+        if delivered_events:
+            yield from self._post_wildcard_batch(
+                events=delivered_events,
+                mech_address=mech_address,
+                verifying_contract=verifying_contract,
+                wildcard_url=wildcard_url,
+                batch_label="delivered",
+                swept_request_ids=None,  # delivered has no queue-side state
+            )
+        if request_only_events:
+            yield from self._post_wildcard_batch(
+                events=request_only_events,
+                mech_address=mech_address,
+                verifying_contract=verifying_contract,
+                wildcard_url=wildcard_url,
+                batch_label="sweep",
+                swept_request_ids=swept_request_ids,
+            )
+
+    def _post_wildcard_batch(  # noqa: C901
+        self,
+        events: List[Dict[str, Any]],
+        mech_address: str,
+        verifying_contract: str,
+        wildcard_url: str,
+        batch_label: str,
+        swept_request_ids: Optional[List[str]],
+    ) -> Generator:
+        """Hash, sign, and POST one wildcard batch. Post-write side effects vary by outcome.
+
+        Called separately for the delivered-events batch and the
+        sweep-events batch so a poison sweep event can't take real
+        delivered rows down with it.
+
+        Post-batch side effects, when ``swept_request_ids`` is not None
+        (i.e. this is a sweep batch):
+
+          * On 2xx — the server accepted the batch and wrote every row;
+            drop the swept tasks from ``PENDING_TASKS``.
+          * On terminal 4xx (or a 3xx / signer-not-owner / allowlist miss)
+            — the server will keep rejecting these events on every retry.
+            Drop the swept tasks anyway to avoid a livelock where the
+            same poison event is re-swept + re-POSTed every settlement
+            round, spamming warnings and growing ``PENDING_TASKS``
+            unbounded. The undelivered signal is lost, but that beats a
+            self-reinforcing drain.
+          * On retryable 5xx / network / pre-sign failure — leave the
+            swept tasks on the queue so the next FSM cycle re-attempts.
+
+        For the delivered batch (``swept_request_ids is None``): the events
+        come from this round's ``synchronized_data.done_tasks`` and there is
+        no queue-side state to reconcile. We log the outcome and return.
+
+        :param events: the ordered event dicts for THIS batch (delivered
+            only, or sweep only — never mixed).
+        :param mech_address: on-chain mech contract for the signed typed-data.
+        :param verifying_contract: marketplace contract for the EIP-712 domain.
+        :param wildcard_url: server endpoint (``POST /mech/events``).
+        :param batch_label: ``"delivered"`` or ``"sweep"``, used in log lines.
+        :param swept_request_ids: request-ids to drop from ``PENDING_TASKS``
+            on outcome-appropriate paths. ``None`` for the delivered batch.
+        :yield: AEA protocol messages (signing dialogue, HTTP request).
+        """
+        # The EIP-712 domain.chainId binds the signature to one chain. Read
+        # it from the first event's ``request.chain_id`` — every event in
+        # the batch was built by either ``task_execution._build_wildcard_event``
+        # (delivered) or ``self._build_request_only_event`` (sweep) against
+        # the corresponding skill's ``mech_events_chain_id`` param. The
+        # value-by-construction check below rejects a heterogeneous batch
+        # defensively; the ``mech_events_chain_id`` param NOW lives on
+        # BOTH task_execution.Params and task_submission_abci.Params, so
+        # an operator that sets one but forgets the other would produce
+        # a chain-id split between the two batches (delivered would carry
+        # the real chain id, sweep would carry 0 and short-circuit at
+        # the ``chain_id == 0`` guard below with a clear log). See
+        # ``_check_mech_events_chain_id_consistency`` for the paired
+        # startup check.
         chain_id = int(events[0].get("request", {}).get("chain_id", 0) or 0)
         if any(
             int(e.get("request", {}).get("chain_id", 0) or 0) != chain_id
             for e in events
         ):
             self.context.logger.warning(
-                "Wildcard batch contains events from multiple chains; "
+                "Wildcard %s batch contains events from multiple chains; "
                 "skipping. A single Safe should only ever build events for "
-                "one chain — investigate task_execution."
+                "one chain — check the mech_events_chain_id param on both "
+                "task_execution and task_submission_abci.",
+                batch_label,
             )
             return
         # Short-circuit before the signing round-trip when the chain id is
         # unconfigured: chain_id=0 lands in no marketplace allowlist on the
         # server, so the batch is guaranteed to be rejected. Bail with a
         # clear log instead of spending a signing dialogue + HTTP POST.
+        # This is a config-driven fail; sweep tasks stay on the queue so
+        # a subsequent config fix picks them up.
         if chain_id == 0:
             self.context.logger.warning(
-                "mech_events_chain_id is 0 (unconfigured); " "skipping wildcard write."
+                "mech_events_chain_id is 0 (unconfigured) for the %s "
+                "batch; skipping wildcard write. If this is the sweep "
+                "batch, the task_submission_abci copy of the param is the "
+                "usual culprit — task_execution's copy fills the delivered "
+                "batch's chain id independently.",
+                batch_label,
             )
             return
 
@@ -1981,9 +2130,12 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             # response body), and any of them can raise ``ValueError`` /
             # ``KeyError`` / ``TypeError`` on a malformed payload. The
             # round is designed fail-soft (settlement already confirmed),
-            # so any pre-signing crash drops the batch with a log.
+            # so any pre-signing crash drops the batch with a log. Sweep
+            # tasks stay on the queue (retryable — a subsequent FSM cycle
+            # may see clean content).
             self.context.logger.warning(
-                "Wildcard EIP-712 digest build failed; dropping batch: %s",
+                "Wildcard %s EIP-712 digest build failed; dropping batch: %s",
+                batch_label,
                 exc,
             )
             return
@@ -1993,7 +2145,8 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             )
         except Exception as exc:
             self.context.logger.warning(
-                "Wildcard EIP-712 signing failed; dropping batch this round: %s",
+                "Wildcard %s EIP-712 signing failed; dropping batch this round: %s",
+                batch_label,
                 exc,
             )
             return
@@ -2009,11 +2162,18 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         except (TypeError, ValueError) as exc:
             # ``events`` carries requester-influenced content; a non-JSON-
             # serialisable value (leaked ``bytes``, ``float('inf')``, etc.)
-            # would otherwise escape ``async_act`` as a crash.
+            # would otherwise escape ``async_act`` as a crash. For a sweep
+            # batch this is effectively terminal (the same content would
+            # fail every subsequent round). Drop the swept tasks so a
+            # single poison event cannot livelock.
             self.context.logger.warning(
-                "Wildcard batch JSON serialisation failed; dropping batch: %s",
+                "Wildcard %s batch JSON serialisation failed; treating as "
+                "terminal (poison payload) and dropping: %s",
+                batch_label,
                 exc,
             )
+            if swept_request_ids:
+                self._drop_swept_from_pending(swept_request_ids)
             return
 
         # Build the request with an explicit short timeout. ``get_http_response``
@@ -2036,49 +2196,85 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 ),
             )
         except Exception as exc:
+            # Network-level failures are retryable — the server may come
+            # back, so leave sweep tasks on the queue for the next cycle.
             self.context.logger.warning(
-                "Wildcard POST raised; dropping batch this round "
+                "Wildcard %s POST raised; dropping batch this round "
                 "(follow-up PR adds kv_store replay buffer): %s",
+                batch_label,
                 exc,
             )
             return
 
         status = getattr(response, "status_code", None)
-        # Treat anything outside the 2xx success range as non-success. A 3xx
-        # redirect on a POST is never the right outcome here: the server
-        # never redirects ``/mech/events``, so a 3xx means a misconfigured
-        # proxy and we should not log it as ``POST OK``.
-        if status is None or status < 200 or status >= 300:
-            # 4xx is terminal (bad payload, allowlist miss, signer-not-owner);
-            # 5xx + network are retryable on the next FSM cycle once the
-            # replay buffer lands (mech#455 follow-up). 3xx redirects on a
-            # POST are a misconfigured proxy, treated the same as 4xx here.
-            self.context.logger.warning(
-                "Wildcard POST returned non-success (status=%s); dropping "
-                "batch this round (follow-up PR adds replay buffer). "
-                "batch_size=%d signer-eoa=%s body_preview=%s",
+        if status is not None and 200 <= status < 300:
+            self.context.logger.info(
+                "Wildcard %s batch POST OK (status=%s batch_size=%d signer-eoa=%s)",
+                batch_label,
+                status,
+                len(events),
+                self.context.agent_address,
+            )
+            if swept_request_ids:
+                # Server confirmed the batch; drop the swept undelivered
+                # tasks from the pending queue now. Deferring to a
+                # confirmed 2xx (rather than mutating inside
+                # ``_sweep_pending_undelivered``) ensures every early-
+                # return path above leaves the sweep at-least-once.
+                #
+                # Advisory: this drops the WHOLE swept set on any 2xx.
+                # If the server ever adopts a partial-upsert semantic
+                # (returns 200 but rejects a subset), we would need to
+                # parse a per-event ack out of ``response.body`` and only
+                # drop confirmed ids. Today the server writes all-or-
+                # nothing per batch, so this is exact.
+                self._drop_swept_from_pending(swept_request_ids)
+            return
+
+        # Non-2xx: distinguish terminal (4xx, 3xx) from retryable
+        # (5xx / undefined status / network-classified elsewhere).
+        # ``None`` here is a defensive undefined-status case, which the
+        # framework rarely surfaces; treat it as retryable so we don't
+        # silently poison-drop a healthy sweep on a bookkeeping edge.
+        is_terminal = status is not None and (
+            400 <= status < 500 or 300 <= status < 400
+        )
+        if is_terminal:
+            # 4xx = bad payload / allowlist miss / signer-not-owner /
+            # BATCH_HASH_MISMATCH. All are terminal: retrying the same
+            # bytes with the same signer keeps failing. If this is a
+            # sweep batch, dropping the swept tasks avoids the livelock
+            # bennyjo + OjusWiZard flagged (task re-sweeps + re-POSTs
+            # forever, ``PENDING_TASKS`` grows unbounded, warnings spam).
+            # The undelivered signal is lost but that beats a
+            # self-reinforcing drain.
+            self.context.logger.error(
+                "Wildcard %s POST returned terminal non-success "
+                "(status=%s); dropping batch AND swept tasks from queue "
+                "to avoid livelock. batch_size=%d signer-eoa=%s "
+                "body_preview=%s",
+                batch_label,
                 status,
                 len(events),
                 self.context.agent_address,
                 response.body[:512] if hasattr(response, "body") else "?",
             )
+            if swept_request_ids:
+                self._drop_swept_from_pending(swept_request_ids)
             return
 
-        self.context.logger.info(
-            "Wildcard batch POST OK (status=%s batch_size=%d signer-eoa=%s)",
+        # Retryable (5xx / undefined): the server may recover on the next
+        # cycle. Leave sweep tasks on the queue.
+        self.context.logger.warning(
+            "Wildcard %s POST returned retryable non-success (status=%s); "
+            "dropping batch this round (follow-up PR adds replay buffer). "
+            "batch_size=%d signer-eoa=%s body_preview=%s",
+            batch_label,
             status,
             len(events),
             self.context.agent_address,
+            response.body[:512] if hasattr(response, "body") else "?",
         )
-        # Wildcard confirmed the batch; drop the swept undelivered tasks
-        # from the pending queue now. Deferring to this point (rather than
-        # inside ``_sweep_pending_undelivered``) ensures that any early
-        # return above — missing mech address, missing marketplace, mixed
-        # chains, unconfigured chain_id, digest build, signing, JSON
-        # serialisation, POST timeout, or non-2xx status — leaves the
-        # sweep at-least-once: the tasks stay on the queue and the next
-        # FSM cycle re-attempts the write.
-        self._drop_swept_from_pending(swept_request_ids)
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
         """Return the ``wildcard_event`` payload from every done_task that carries one.

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -30,7 +30,7 @@ from enum import Enum
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Type, cast
 
 from aea.helpers.cid import CID, to_v1
-from prometheus_client import Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 from packages.valory.contracts.balance_tracker.contract import BalanceTrackerContract
 from packages.valory.contracts.complementary_service_metadata.contract import (
@@ -112,6 +112,29 @@ IS_OFFCHAIN = "is_offchain"
 NONCE = "nonce"
 SENDER = "sender"
 REQUESTER_KEY = "requester"
+
+# Wildcard analytics-write outcome counter. Labels:
+#
+# * ``batch_label``: ``"delivered"`` (this round's on-chain settled
+#   events, sourced from ``synchronized_data.done_tasks``) or ``"sweep"``
+#   (request-only events staged by the pending-task sweep).
+# * ``outcome``: ``"ok"`` (server 2xx), ``"http_error"`` (non-2xx status
+#   returned), ``"pre_flight_failed"`` (digest / signing / JSON build
+#   raised before we hit the wire), ``"network_error"`` (HTTP transport
+#   raised).
+#
+# Delivered events have no queue-side parking spot (they come from this
+# round's ``synchronized_data.done_tasks`` and are not re-queued across
+# rounds), so a transient wildcard failure silently discards the row —
+# the replay buffer that would recover it is a future PR. This counter
+# gives operators a signal before the buffer lands: sustained non-``ok``
+# on ``batch_label="delivered"`` means the analytics lake is missing
+# rows for that window.
+mech_wildcard_events_total = Counter(
+    "mech_wildcard_events_total",
+    "Wildcard analytics-write batch outcomes",
+    labelnames=["batch_label", "outcome"],
+)
 MECH_ADDRESS = "mech_address"
 LAST_TX = "last_tx"
 
@@ -1845,15 +1868,9 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
 
     matching_round: Type[AbstractRound] = PostTxSettlementRound
 
-    # Set to True after we've logged the mech_events_chain_id divergence
-    # once, so ``_check_mech_events_chain_id_consistency`` doesn't spam
-    # the same warning every settlement round on a persistent config drift.
-    _chain_id_divergence_logged: bool = False
-
     def async_act(self) -> Generator:
         """Build, sign, and POST the offchain-events batch, then advance."""
         with self.context.benchmark_tool.measure(self.behaviour_id).local():
-            self._check_mech_events_chain_id_consistency()
             yield from self._do_wildcard_write_best_effort()
             payload = PostTxSettlementPayload(
                 sender=self.context.agent_address, content="done"
@@ -1864,60 +1881,16 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             yield from self.wait_until_round_end()
             self.set_done()
 
-    def _check_mech_events_chain_id_consistency(self) -> None:
-        """Warn once if task_execution and task_submission_abci disagree on chain id.
-
-        ``mech_events_chain_id`` now lives on both
-        :class:`task_execution.models.Params` and
-        :class:`task_submission_abci.models.Params` because a pure-sweep
-        round has no delivered event to fall back to for the EIP-712
-        ``domain.chainId`` and the two skills each own their own event
-        builder. That gives operators two knobs where they had one, and
-        forgetting the newer knob silently split the batch chain-id
-        across delivered and sweep events.
-
-        The split-batch design in :py:meth:`_post_wildcard_batch` already
-        limits the blast radius (the two batches are independent, so a
-        misconfigured sweep chain id short-circuits the sweep batch
-        without touching delivered), but a drift is still a config bug
-        worth surfacing.
-
-        Rather than crash at startup on a mismatch (this behaviour is
-        fail-soft by design and a config check that hard-blocks the FSM
-        would be worse than the drift it protects against), we log a
-        single WARNING the first time we notice, and rely on operators
-        picking it up in the logs. The flag is instance-scoped so it
-        also self-resets on a mech restart.
-        """
-        if self._chain_id_divergence_logged:
-            return
-        submission_chain_id = int(getattr(self.params, "mech_events_chain_id", 0) or 0)
-        # ``task_execution.Params`` is the same object graph — the
-        # PostTxSettlement behaviour extends TaskExecutionBaseBehaviour
-        # which composes both skills' params under ``self.params``. Pull
-        # the task_execution copy directly from the skill context so the
-        # comparison isn't tautological.
-        task_exec_params = getattr(
-            self.context.skills.task_execution.models, "params", None
-        )
-        task_exec_chain_id = int(
-            getattr(task_exec_params, "mech_events_chain_id", 0) or 0
-        )
-        if submission_chain_id != task_exec_chain_id:
-            self.context.logger.warning(
-                "mech_events_chain_id drift detected: task_execution has "
-                "%s but task_submission_abci has %s. A pure-sweep round "
-                "will use the task_submission value; a delivered-only "
-                "round will use the task_execution value. Under the "
-                "split-batch flow the sweep batch may short-circuit at "
-                "the chain_id=0 guard while the delivered batch still "
-                "lands, so operators can miss this silently — check the "
-                "``mech_events_chain_id`` field on both skill.yaml / "
-                "aea-config overrides.",
-                task_exec_chain_id,
-                submission_chain_id,
-            )
-            self._chain_id_divergence_logged = True
+    # Note on the two ``mech_events_chain_id`` params: task_execution's
+    # copy powers delivered events; task_submission_abci's copy powers
+    # sweep events. A drift is visible in the sweep batch's chain_id=0
+    # short-circuit (WARNING log inside ``_post_wildcard_batch``) and
+    # does not affect delivered under the split-batch design. An earlier
+    # revision of this file also tried a cross-skill consistency check
+    # here via ``self.context.skills.task_execution.models.params``, but
+    # AEA's SkillContext does not expose sibling skills that way, so the
+    # check crashed PostTxSettlement on every round. Dropped in favour
+    # of the per-batch short-circuit log.
 
     def _do_wildcard_write_best_effort(self) -> Generator:
         """Best-effort wildcard write. Never raises; logs failure paths.
@@ -2069,12 +2042,11 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # value-by-construction check below rejects a heterogeneous batch
         # defensively; the ``mech_events_chain_id`` param NOW lives on
         # BOTH task_execution.Params and task_submission_abci.Params, so
-        # an operator that sets one but forgets the other would produce
-        # a chain-id split between the two batches (delivered would carry
+        # an operator that sets one but forgets the other produces a
+        # chain-id split between the two batches (delivered would carry
         # the real chain id, sweep would carry 0 and short-circuit at
-        # the ``chain_id == 0`` guard below with a clear log). See
-        # ``_check_mech_events_chain_id_consistency`` for the paired
-        # startup check.
+        # the ``chain_id == 0`` guard below with a clear log). See the
+        # class-level comment on the two-params trade-off.
         chain_id = int(events[0].get("request", {}).get("chain_id", 0) or 0)
         if any(
             int(e.get("request", {}).get("chain_id", 0) or 0) != chain_id
@@ -2138,6 +2110,9 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 batch_label,
                 exc,
             )
+            mech_wildcard_events_total.labels(
+                batch_label=batch_label, outcome="pre_flight_failed"
+            ).inc()
             return
         try:
             signature_hex = yield from self.get_signature(
@@ -2149,6 +2124,9 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 batch_label,
                 exc,
             )
+            mech_wildcard_events_total.labels(
+                batch_label=batch_label, outcome="pre_flight_failed"
+            ).inc()
             return
 
         try:
@@ -2162,18 +2140,23 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         except (TypeError, ValueError) as exc:
             # ``events`` carries requester-influenced content; a non-JSON-
             # serialisable value (leaked ``bytes``, ``float('inf')``, etc.)
-            # would otherwise escape ``async_act`` as a crash. For a sweep
-            # batch this is effectively terminal (the same content would
-            # fail every subsequent round). Drop the swept tasks so a
-            # single poison event cannot livelock.
+            # would otherwise escape ``async_act`` as a crash. Leave sweep
+            # tasks on the queue: silent eviction of the whole swept set
+            # over one poison event is strictly worse than the visible
+            # loop (see the class-level note on the queue-eviction
+            # trade-off). The next FSM cycle may see clean content, and
+            # ``PENDING_TASKS`` is task_execution's live work queue —
+            # analytics-side ergonomics should not delete rows that
+            # still need to run.
             self.context.logger.warning(
-                "Wildcard %s batch JSON serialisation failed; treating as "
-                "terminal (poison payload) and dropping: %s",
+                "Wildcard %s batch JSON serialisation failed; dropping this "
+                "round (sweep tasks stay on the queue for retry): %s",
                 batch_label,
                 exc,
             )
-            if swept_request_ids:
-                self._drop_swept_from_pending(swept_request_ids)
+            mech_wildcard_events_total.labels(
+                batch_label=batch_label, outcome="pre_flight_failed"
+            ).inc()
             return
 
         # Build the request with an explicit short timeout. ``get_http_response``
@@ -2204,6 +2187,9 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 batch_label,
                 exc,
             )
+            mech_wildcard_events_total.labels(
+                batch_label=batch_label, outcome="network_error"
+            ).inc()
             return
 
         status = getattr(response, "status_code", None)
@@ -2215,12 +2201,19 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 len(events),
                 self.context.agent_address,
             )
+            mech_wildcard_events_total.labels(
+                batch_label=batch_label, outcome="ok"
+            ).inc()
             if swept_request_ids:
                 # Server confirmed the batch; drop the swept undelivered
                 # tasks from the pending queue now. Deferring to a
                 # confirmed 2xx (rather than mutating inside
                 # ``_sweep_pending_undelivered``) ensures every early-
                 # return path above leaves the sweep at-least-once.
+                #
+                # 2xx is the ONLY path that mutates ``PENDING_TASKS``.
+                # Non-2xx (including 4xx) leaves the queue alone — see
+                # the block below for the trade-off rationale.
                 #
                 # Advisory: this drops the WHOLE swept set on any 2xx.
                 # If the server ever adopts a partial-upsert semantic
@@ -2231,43 +2224,34 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 self._drop_swept_from_pending(swept_request_ids)
             return
 
-        # Non-2xx: distinguish terminal (4xx, 3xx) from retryable
-        # (5xx / undefined status / network-classified elsewhere).
-        # ``None`` here is a defensive undefined-status case, which the
-        # framework rarely surfaces; treat it as retryable so we don't
-        # silently poison-drop a healthy sweep on a bookkeeping edge.
-        is_terminal = status is not None and (
-            400 <= status < 500 or 300 <= status < 400
-        )
-        if is_terminal:
-            # 4xx = bad payload / allowlist miss / signer-not-owner /
-            # BATCH_HASH_MISMATCH. All are terminal: retrying the same
-            # bytes with the same signer keeps failing. If this is a
-            # sweep batch, dropping the swept tasks avoids the livelock
-            # bennyjo + OjusWiZard flagged (task re-sweeps + re-POSTs
-            # forever, ``PENDING_TASKS`` grows unbounded, warnings spam).
-            # The undelivered signal is lost but that beats a
-            # self-reinforcing drain.
-            self.context.logger.error(
-                "Wildcard %s POST returned terminal non-success "
-                "(status=%s); dropping batch AND swept tasks from queue "
-                "to avoid livelock. batch_size=%d signer-eoa=%s "
-                "body_preview=%s",
-                batch_label,
-                status,
-                len(events),
-                self.context.agent_address,
-                response.body[:512] if hasattr(response, "body") else "?",
-            )
-            if swept_request_ids:
-                self._drop_swept_from_pending(swept_request_ids)
-            return
-
-        # Retryable (5xx / undefined): the server may recover on the next
-        # cycle. Leave sweep tasks on the queue.
+        # Non-2xx: NEVER mutate ``PENDING_TASKS``. An earlier revision
+        # narrowed "terminal" to 4xx / 3xx and dropped swept tasks on that
+        # path to break a livelock in which the same poison sweep event
+        # re-POSTed every settlement round. That was strictly worse than
+        # the loop:
+        #
+        # * ``PENDING_TASKS`` is task_execution's LIVE WORK QUEUE (same
+        #   shared_state key; the executor pops from the same list).
+        #   Evicting entries removes work the executor would run.
+        # * Because ``_handle_get_undelivered_reqs`` advances ``from_block``
+        #   past those requests, they're never re-scanned — the eviction
+        #   is silent and irreversible.
+        # * ``mech_events_sweep_max_age_seconds`` is a LOCAL proxy for the
+        #   contract's ``responseTimeout``; a mis-set value below the
+        #   real timeout would evict tasks the mech could still legally
+        #   deliver, discarding paid work.
+        # * The 4xx causes we care about — allowlist miss (401/403),
+        #   429 rate-limit, ``BATCH_HASH_MISMATCH`` — are SYSTEMIC, so
+        #   the drop policy would evict every sweep task every round for
+        #   the whole rollout window, not just individual poison rows.
+        #
+        # A visible livelock is better than a silent, irreversible drain.
+        # Sweep tasks stay on the queue on every non-2xx path; a genuine
+        # per-event terminal rejection (e.g. server 422 on a subset) is
+        # left as future work (needs a per-event ack from the server).
         self.context.logger.warning(
-            "Wildcard %s POST returned retryable non-success (status=%s); "
-            "dropping batch this round (follow-up PR adds replay buffer). "
+            "Wildcard %s POST returned non-success (status=%s); dropping "
+            "this round, sweep tasks stay on the queue for retry. "
             "batch_size=%d signer-eoa=%s body_preview=%s",
             batch_label,
             status,
@@ -2275,6 +2259,9 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             self.context.agent_address,
             response.body[:512] if hasattr(response, "body") else "?",
         )
+        mech_wildcard_events_total.labels(
+            batch_label=batch_label, outcome="http_error"
+        ).inc()
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
         """Return the ``wildcard_event`` payload from every done_task that carries one.
@@ -2455,7 +2442,18 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 "Pending sweep: skipping task with no requestId: %s", task
             )
             return None
-        request_id_str = str(request_id)
+        # Undelivered marketplace tasks hold ``requestId`` as raw bytes
+        # (the int conversion happens later, once the task actually runs
+        # in task_execution). A plain ``str(bytes)`` would produce
+        # ``"b'\\x12\\x34...'"`` — completely different from the decimal
+        # string the delivered event uses, so predict-api's ON CONFLICT
+        # would never reconcile the two rows and a request that later
+        # gets delivered would stay marked undelivered forever. Coerce
+        # bytes → int → str here to match the delivered shape.
+        if isinstance(request_id, (bytes, bytearray)):
+            request_id_str = str(int.from_bytes(request_id, "big"))
+        else:
+            request_id_str = str(request_id)
         priority_mech = str(task.get("priorityMech") or "")
         requester = str(task.get("requester") or "")
         if not priority_mech or not requester:

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -176,9 +176,7 @@ class Params(BaseParams):
         # whole batch (including any delivered events on a mixed round)
         # is silently dropped after the queue has already been mutated.
         # Same semantics and default as task_execution.
-        self.mech_events_chain_id: int = int(
-            kwargs.get("mech_events_chain_id", 0) or 0
-        )
+        self.mech_events_chain_id: int = int(kwargs.get("mech_events_chain_id", 0) or 0)
         super().__init__(*args, **kwargs)
 
     @classmethod

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -166,6 +166,19 @@ class Params(BaseParams):
         self.mech_events_sweep_max_age_seconds: float = float(
             kwargs.get("mech_events_sweep_max_age_seconds", 3600.0) or 3600.0
         )
+        # Chain id used to build request-only sweep events and to derive
+        # the EIP-712 domain when a pure-sweep round emits no delivered
+        # events. task_execution.models.Params carries the same param
+        # for delivered events; a pure-sweep round has no delivered
+        # events to read the chain id from, so this skill's Params must
+        # carry the field independently. Without it, ``mech_events_chain_id``
+        # falls back to 0, the batch-level chain-id guard fires, and the
+        # whole batch (including any delivered events on a mixed round)
+        # is silently dropped after the queue has already been mutated.
+        # Same semantics and default as task_execution.
+        self.mech_events_chain_id: int = int(
+            kwargs.get("mech_events_chain_id", 0) or 0
+        )
         super().__init__(*args, **kwargs)
 
     @classmethod

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -143,6 +143,29 @@ class Params(BaseParams):
         self.wildcard_events_timeout_seconds: float = float(
             kwargs.get("wildcard_events_timeout_seconds", 5.0) or 5.0
         )
+        # On-chain undelivered-request sweep. The PostTxSettlement
+        # behaviour walks ``shared_state[PENDING_TASKS]`` for tasks
+        # whose local enqueue stamp is older than
+        # ``mech_events_sweep_max_age_seconds`` and emits a request-only
+        # event for each (``MechEvent.response is None``,
+        # ``source='mech_onchain'``). Gated separately from
+        # ``mech_events_enabled`` so the delivered-event write can roll
+        # out before the sweep; default off until v1 lands and is
+        # validated against a live deployment. See
+        # ``autonolas-marketplace/docs/onchain_write_path_scope.md`` §3.2.
+        self.mech_events_sweep_pending_enabled: bool = bool(
+            kwargs.get("mech_events_sweep_pending_enabled", False)
+        )
+        # Max age in seconds before a pending task is treated as
+        # undelivered. The contract's ``RequestInfo.responseTimeout`` is
+        # the authoritative value but reading it per pending task at
+        # sweep time would cost one RPC per sweep — explicitly avoided
+        # per the design (see §3.2). Default 3600 (1 hour) is a
+        # conservative upper bound covering typical mech timeouts; tune
+        # per deployment if responseTimeout values differ.
+        self.mech_events_sweep_max_age_seconds: float = float(
+            kwargs.get("mech_events_sweep_max_age_seconds", 3600.0) or 3600.0
+        )
         super().__init__(*args, **kwargs)
 
     @classmethod

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,11 +8,11 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeifiek52rdzejdjur2yvou22ugxwkgbyneutmwdtaj6yzbbjff4ope
+  behaviours.py: bafybeiakztao6lbyjpk6hvs6ib4tz6br2yr7x7kxa2x6rso5t5cqqqeosi
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeicbsdo5aliovq6q7xrscpimklp7p7osoywg6amixpaepr7zembika
+  models.py: bafybeihnoessohxco55ikhem7mdzze2edscnptdfvwx66yyh4otuh4ogry
   payloads.py: bafybeif2gnz5k7eyb6of4iiisni426zscwanjfmtrr37f7ceu4cjqo2ob4
   rounds.py: bafybeiagfyc4lz5sda5gwux4jcld7io26n5d77tdmewcwcs6l63sobfvt4
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
@@ -22,7 +22,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeih6nrses6qmtgifzesm4vo42bqehqtds4ajaxwcjosaztfqszlqyi
+  tests/test_onchain_write_path.py: bafybeibmo2soytu62c3cpdxvdcydujrx3ruvsdmt6jbp6hbaxoop36h6li
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4
+- valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,11 +8,11 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiakztao6lbyjpk6hvs6ib4tz6br2yr7x7kxa2x6rso5t5cqqqeosi
+  behaviours.py: bafybeifo47f3ueldju6j5zve3yfzu3q4usxk2av364zwyeu52ydvowxita
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeihnoessohxco55ikhem7mdzze2edscnptdfvwx66yyh4otuh4ogry
+  models.py: bafybeih7end4mjslb3ebdqg77ljt3cphrgrd5eqyvklaf33e2mebws7afi
   payloads.py: bafybeif2gnz5k7eyb6of4iiisni426zscwanjfmtrr37f7ceu4cjqo2ob4
   rounds.py: bafybeiagfyc4lz5sda5gwux4jcld7io26n5d77tdmewcwcs6l63sobfvt4
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
@@ -22,7 +22,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeidbogednvaklqyzvcoj43mphhlwn3h7bboiuprhkdfztouzpuzawi
+  tests/test_onchain_write_path.py: bafybeictmxo46yefqbajhiugybopo6biapv7wsytgngk4yqb36mcstgl4i
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeieroj6hzyyz7qclfp3zmz4ynobhnm2btzs45efuzrjfvotov2sx64
+- valory/task_execution:0.1.0:bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiacply3zgdqran4p3lcpfmbjn5li6uw7hcxukjcpgpltq2n6bcyse
+  behaviours.py: bafybeibgtcqa7ur4qm643bhtochlz3ivdp5kqic4lqz7wxrtrmjumrw4nq
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -22,11 +22,11 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeictmxo46yefqbajhiugybopo6biapv7wsytgngk4yqb36mcstgl4i
+  tests/test_onchain_write_path.py: bafybeielblv3y7tuas4r2d2mpbw2hlfcjcfrrlod5amigplevluk3u4f4e
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
-  tests/test_wildcard_write_client.py: bafybeifqvm3fek6sex6yum47tvzvph3ntufmmwyc7ctpuoepjhm2jykhlu
+  tests/test_wildcard_write_client.py: bafybeibhjqhm62jcisp4p2qcpvwdzityfy2hlimwaihkjrffmp7j3w5jzi
   wildcard_write_client.py: bafybeia5mum3wwjnkyzhwcm4bsq2alqmczxttcuhzy532fsgjur6v4nc3e
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -22,7 +22,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeibmo2soytu62c3cpdxvdcydujrx3ruvsdmt6jbp6hbaxoop36h6li
+  tests/test_onchain_write_path.py: bafybeidbogednvaklqyzvcoj43mphhlwn3h7bboiuprhkdfztouzpuzawi
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -175,6 +175,7 @@ models:
       wildcard_events_timeout_seconds: 5.0
       mech_events_sweep_pending_enabled: false
       mech_events_sweep_max_age_seconds: 3600.0
+      mech_events_chain_id: 0
     class_name: Params
   requests:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeifo47f3ueldju6j5zve3yfzu3q4usxk2av364zwyeu52ydvowxita
+  behaviours.py: bafybeiacply3zgdqran4p3lcpfmbjn5li6uw7hcxukjcpgpltq2n6bcyse
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -27,7 +27,7 @@ fingerprint:
   tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
   tests/test_wildcard_write_client.py: bafybeifqvm3fek6sex6yum47tvzvph3ntufmmwyc7ctpuoepjhm2jykhlu
-  wildcard_write_client.py: bafybeiflaa5noxki56ebie6tbcp5zbqf4vqg55llle4dxkmafgvvqk6buy
+  wildcard_write_client.py: bafybeia5mum3wwjnkyzhwcm4bsq2alqmczxttcuhzy532fsgjur6v4nc3e
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeicng37eruy5aitgqekyo6jk3n6ieu6m5g6dqvnfq6pj2t7sc2kemi
+- valory/task_execution:0.1.0:bafybeiedozhs2h3jwfbcr2e43hkyde3mqtxy236ztvtf73vlhyqumdey2i
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,11 +8,11 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeihyndqy6kxez7soazqa6xpycpvl5v7guxrucegfogjrxabzol2msa
+  behaviours.py: bafybeifiek52rdzejdjur2yvou22ugxwkgbyneutmwdtaj6yzbbjff4ope
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeicj3ztx52k2sukkfqkjetyj3rz2zcggmy4xjqgx5avdxoccxap4bm
+  models.py: bafybeicbsdo5aliovq6q7xrscpimklp7p7osoywg6amixpaepr7zembika
   payloads.py: bafybeif2gnz5k7eyb6of4iiisni426zscwanjfmtrr37f7ceu4cjqo2ob4
   rounds.py: bafybeiagfyc4lz5sda5gwux4jcld7io26n5d77tdmewcwcs6l63sobfvt4
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
@@ -22,6 +22,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
+  tests/test_onchain_write_path.py: bafybeih6nrses6qmtgifzesm4vo42bqehqtds4ajaxwcjosaztfqszlqyi
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
@@ -46,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
-- valory/task_execution:0.1.0:bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq
+- valory/task_execution:0.1.0:bafybeiaarodwftwxwt2lortpnhj6zk3nfffz4trc3ph654xex7scxtqqu4
 behaviours:
   main:
     args: {}
@@ -172,6 +173,8 @@ models:
       mech_events_enabled: false
       wildcard_events_url: ''
       wildcard_events_timeout_seconds: 5.0
+      mech_events_sweep_pending_enabled: false
+      mech_events_sweep_max_age_seconds: 3600.0
     class_name: Params
   requests:
     args: {}

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -17,8 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Tests for the on-chain write path additions in
-:py:class:`PostTxSettlementBehaviour`.
+"""Tests for the on-chain write path additions in :py:class:`PostTxSettlementBehaviour`.
 
 Three pieces:
 
@@ -42,6 +41,7 @@ module's class definition; the methods under test are pure functions of
 context plus the unbound method invoked with that context is enough —
 no FSM scaffolding required. Same pattern matches what the existing
 tests in ``test_behaviours.py`` use for narrow-scope unit checks.
+
 """
 
 from __future__ import annotations
@@ -50,9 +50,6 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, cast
 
-import pytest
-
-from packages.valory.skills.task_submission_abci import behaviours as beh_mod
 from packages.valory.skills.task_submission_abci.behaviours import (
     PENDING_TASKS,
     PostTxSettlementBehaviour,
@@ -101,6 +98,17 @@ def _make_self(
     the "non-dict entry" defensive test can pass a mixed
     ``["garbage", {...}]`` without a ``[list-item]`` mypy error; the
     sweep code path skips non-dict entries at runtime.
+
+    :param pending: value to stash under ``shared_state[PENDING_TASKS]``,
+        or ``None`` to leave the key unset (simulates a fresh mech boot).
+    :param enabled: value for ``params.mech_events_enabled``.
+    :param sweep_enabled: value for ``params.mech_events_sweep_pending_enabled``.
+    :param max_age: value for ``params.mech_events_sweep_max_age_seconds``.
+    :param chain_id: value for ``params.mech_events_chain_id``.
+    :param marketplace_address: value for ``params.mech_marketplace_address``.
+    :return: a fixture typed as :class:`PostTxSettlementBehaviour` (a
+        :class:`SimpleNamespace` at runtime) suitable for the unbound-method
+        call pattern used by every test in this module.
     """
     shared_state: Dict[str, Any] = {}
     if pending is not None:
@@ -170,9 +178,11 @@ def test_sweep_returns_empty_when_mech_events_disabled() -> None:
 
 
 def test_sweep_returns_empty_when_sweep_flag_disabled() -> None:
-    """The sweep can be flipped off independently from the delivered-event
-    write — ``mech_events_sweep_pending_enabled=False`` short-circuits even
-    when ``mech_events_enabled`` is on."""
+    """``mech_events_sweep_pending_enabled=False`` short-circuits the sweep on its own.
+
+    The sweep can be flipped off independently from the delivered-event
+    write, so operators can roll each out separately.
+    """
     self_ = _make_self(
         pending=[_make_pending_task("r-sweep-off", age_seconds=9999)],
         enabled=True,
@@ -185,8 +195,7 @@ def test_sweep_returns_empty_when_sweep_flag_disabled() -> None:
 
 
 def test_sweep_returns_empty_when_max_age_zero() -> None:
-    """A zero (or negative) max-age is treated as 'sweep off' to avoid
-    accidentally sweeping every fresh task that the agent just enqueued."""
+    """A zero (or negative) max-age is treated as 'sweep off' to avoid accidentally sweeping every fresh task that the agent just enqueued."""
     self_ = _make_self(
         pending=[_make_pending_task("r-zero", age_seconds=9999)],
         max_age=0.0,
@@ -197,8 +206,7 @@ def test_sweep_returns_empty_when_max_age_zero() -> None:
 
 
 def test_sweep_returns_empty_when_pending_missing() -> None:
-    """No ``PENDING_TASKS`` in shared_state → no-op, no crash. The mech
-    boots before the handler stamps the key on some agent configs."""
+    """No ``PENDING_TASKS`` in shared_state → no-op, no crash. The mech boots before the handler stamps the key on some agent configs."""
     self_ = _make_self(pending=None)
     events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
@@ -206,6 +214,7 @@ def test_sweep_returns_empty_when_pending_missing() -> None:
 
 
 def test_sweep_returns_empty_when_pending_empty() -> None:
+    """An empty ``PENDING_TASKS`` list produces no events and no swept ids."""
     self_ = _make_self(pending=[])
     events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
@@ -234,12 +243,14 @@ def test_sweep_skips_recent_tasks() -> None:
 
 
 def test_sweep_emits_for_stale_task_and_leaves_queue_untouched() -> None:
-    """A task older than max-age becomes a request-only event and its
-    ``request_id`` is returned to the caller. The sweep itself does NOT
-    mutate the queue — the caller drops the swept tasks only after a
-    confirmed wildcard POST 2xx (via ``_drop_swept_from_pending``). The
-    DB's ON CONFLICT (predict-api side) handles concurrent step-in, so
-    the mech doesn't need to consult the contract to decide."""
+    """A stale task becomes a request-only event and its ``request_id`` is returned.
+
+    The sweep itself does NOT mutate the queue — the caller drops the
+    swept tasks only after a confirmed wildcard POST 2xx (via
+    ``_drop_swept_from_pending``). The DB's ON CONFLICT (predict-api
+    side) handles concurrent step-in, so the mech doesn't need to
+    consult the contract to decide.
+    """
     self_ = _make_self(
         pending=[_make_pending_task("r-stale", age_seconds=120)],
         max_age=60.0,
@@ -252,15 +263,17 @@ def test_sweep_emits_for_stale_task_and_leaves_queue_untouched() -> None:
     assert event["source"] == "mech_onchain"
     assert swept == ["r-stale"]
     # Sweep leaves the queue as-is until _drop_swept_from_pending fires.
-    assert [
-        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
-    ] == ["r-stale"]
+    assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
+        "r-stale"
+    ]
 
 
 def test_sweep_mixed_queue_returns_stale_and_leaves_all_pending() -> None:
-    """Mixed queue: only the stale entries become events; the returned
-    ``swept_request_ids`` mirrors that selection. The sweep does not
-    drop anything from the queue — that happens post-write."""
+    """Mixed queue: only stale entries become events, and ``swept_request_ids`` mirrors that.
+
+    The sweep does not drop anything from the queue — that happens
+    post-write in ``_drop_swept_from_pending``.
+    """
     pending = [
         _make_pending_task("r-stale-1", age_seconds=120),
         _make_pending_task("r-fresh-1", age_seconds=10),
@@ -274,18 +287,22 @@ def test_sweep_mixed_queue_returns_stale_and_leaves_all_pending() -> None:
     assert emitted == {"r-stale-1", "r-stale-2"}
     assert set(swept) == {"r-stale-1", "r-stale-2"}
     # The queue is still all four entries — deferred mutation.
-    assert [
-        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
-    ] == ["r-stale-1", "r-fresh-1", "r-stale-2", "r-fresh-2"]
+    assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
+        "r-stale-1",
+        "r-fresh-1",
+        "r-stale-2",
+        "r-fresh-2",
+    ]
     # Same list object (no rebinding), so other consumers see the queue.
     assert self_.context.shared_state[PENDING_TASKS] is pending_ref
 
 
 def test_sweep_leaves_tasks_without_enqueued_stamp() -> None:
-    """A pending task created before the sweep code shipped (no
-    ``enqueued_at_local``) is left in the queue rather than swept blindly.
-    The next enqueue path stamps fresh; the gap is bounded by mech
-    restart cadence."""
+    """A pending task without ``enqueued_at_local`` is left in the queue rather than swept blindly.
+
+    Pre-sweep-deployment entries won't carry the stamp. The next enqueue
+    path stamps fresh; the gap is bounded by mech restart cadence.
+    """
     self_ = _make_self(
         pending=[
             _make_pending_task("r-pre-sweep", include_enqueued_at=False),
@@ -297,14 +314,14 @@ def test_sweep_leaves_tasks_without_enqueued_stamp() -> None:
     assert [e["request"]["request_id"] for e in events] == ["r-stale"]
     assert swept == ["r-stale"]
     # Queue still holds both entries until the post-write drop.
-    assert [
-        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
-    ] == ["r-pre-sweep", "r-stale"]
+    assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
+        "r-pre-sweep",
+        "r-stale",
+    ]
 
 
 def test_sweep_leaves_non_dict_entries_alone() -> None:
-    """Whatever bug puts non-dict entries in PENDING_TASKS is not the
-    sweep's problem; leave them as-is rather than dropping silently."""
+    """Whatever bug puts non-dict entries in PENDING_TASKS is not the sweep's problem; leave them as-is rather than dropping silently."""
     self_ = _make_self(
         pending=[
             "garbage",  # malformed entry
@@ -323,9 +340,11 @@ def test_sweep_leaves_non_dict_entries_alone() -> None:
 
 
 def test_drop_swept_from_pending_removes_only_swept_ids() -> None:
-    """``_drop_swept_from_pending`` is the only path that mutates the
-    pending queue for a swept task. It removes only the request_ids in
-    ``swept_request_ids`` and leaves everything else in place."""
+    """``_drop_swept_from_pending`` mutates the queue only for the ids in ``swept_request_ids``.
+
+    Everything else in the queue is left in place, in the same list
+    object (in-place mutation, not a rebind).
+    """
     pending = [
         _make_pending_task("r-a"),
         _make_pending_task("r-b"),
@@ -333,27 +352,25 @@ def test_drop_swept_from_pending_removes_only_swept_ids() -> None:
     ]
     self_ = _make_self(pending=pending)
     PostTxSettlementBehaviour._drop_swept_from_pending(self_, ["r-a", "r-c"])
-    assert [
-        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
-    ] == ["r-b"]
+    assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
+        "r-b"
+    ]
     # In-place mutation, not a rebind.
     assert self_.context.shared_state[PENDING_TASKS] is pending
 
 
 def test_drop_swept_from_pending_noop_on_empty_swept() -> None:
-    """An empty ``swept_request_ids`` (no request-only events staged
-    this round) leaves the queue untouched."""
+    """An empty ``swept_request_ids`` (no request-only events staged this round) leaves the queue untouched."""
     pending = [_make_pending_task("r-only")]
     self_ = _make_self(pending=pending)
     PostTxSettlementBehaviour._drop_swept_from_pending(self_, [])
-    assert [
-        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
-    ] == ["r-only"]
+    assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
+        "r-only"
+    ]
 
 
 def test_drop_swept_from_pending_noop_when_pending_missing() -> None:
-    """``_drop_swept_from_pending`` is safe to call when
-    ``shared_state[PENDING_TASKS]`` was never populated."""
+    """``_drop_swept_from_pending`` is safe to call when ``shared_state[PENDING_TASKS]`` was never populated."""
     self_ = _make_self(pending=None)
     # Should not raise, should not add the key.
     PostTxSettlementBehaviour._drop_swept_from_pending(self_, ["r-x"])
@@ -364,14 +381,14 @@ def test_drop_swept_from_pending_noop_when_pending_missing() -> None:
 
 
 def test_request_only_event_carries_expected_fields() -> None:
-    """The shape the wildcard server's MechEvent model expects: a request
-    half with ``delivery_mech=None`` and a ``source='mech_onchain'``
-    top-level field; ``response=None``.
+    """Event carries ``request.delivery_mech=None``, ``source='mech_onchain'``, ``response=None``.
 
+    Mirrors the shape the wildcard server's MechEvent model expects.
     Mirrors the server-side validator in ``server/src/models/mech.py``:
     a request-only event with ``source='mech_offchain'`` would be
     rejected (an off-chain HTTP path doesn't produce undelivered events
     by construction).
+
     """
     self_ = _make_self()
     task = _make_pending_task(
@@ -402,8 +419,7 @@ def test_request_only_event_carries_expected_fields() -> None:
 
 
 def test_request_only_event_handles_bytes_cid() -> None:
-    """``data`` on the pending task can be raw bytes from the contract
-    event; surface it as a 0x-hex content_cid for the lake."""
+    """``data`` on the pending task can be raw bytes from the contract event; surface it as a 0x-hex content_cid for the lake."""
     self_ = _make_self()
     task = _make_pending_task("r-bytes", data=b"\xab" * 32)
     event = PostTxSettlementBehaviour._build_request_only_event(
@@ -415,41 +431,42 @@ def test_request_only_event_handles_bytes_cid() -> None:
 
 def test_request_only_event_skipped_for_missing_request_id() -> None:
     """Malformed pending entries (missing requestId / priorityMech /
+
     requester) return ``None`` so the sweep keeps the task on the queue
-    rather than emitting a wildcard 422-bait row."""
+    rather than emitting a wildcard 422-bait row.
+    """
     self_ = _make_self()
     bad = _make_pending_task("r-missing")
     del bad["requestId"]
     assert (
-        PostTxSettlementBehaviour._build_request_only_event(
-            self_, bad, time.time()
-        )
+        PostTxSettlementBehaviour._build_request_only_event(self_, bad, time.time())
         is None
     )
 
 
 def test_request_only_event_skipped_for_missing_priority_mech() -> None:
+    """A pending entry with an empty ``priorityMech`` returns ``None`` from the event builder.
+
+    Same defensive skip as the missing-request_id case.
+    """
     self_ = _make_self()
     bad = _make_pending_task("r-no-pri")
     bad["priorityMech"] = ""
     assert (
-        PostTxSettlementBehaviour._build_request_only_event(
-            self_, bad, time.time()
-        )
+        PostTxSettlementBehaviour._build_request_only_event(self_, bad, time.time())
         is None
     )
 
 
 def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
-    """A task with a non-numeric ``enqueued_at_local`` falls back to
-    ``now`` rather than crashing the sweep. Defends against a future
-    code path that stores a string there."""
+    """A non-numeric ``enqueued_at_local`` falls back to ``now`` rather than crashing the sweep.
+
+    Defends against a future code path that stores a string there.
+    """
     self_ = _make_self()
     bad = _make_pending_task("r-bad-ts")
     bad["enqueued_at_local"] = "not-a-number"
-    event = PostTxSettlementBehaviour._build_request_only_event(
-        self_, bad, time.time()
-    )
+    event = PostTxSettlementBehaviour._build_request_only_event(self_, bad, time.time())
     assert event is not None
     assert event["request"]["requested_at"].endswith("Z")
 
@@ -458,10 +475,12 @@ def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
 
 
 def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() -> None:
-    """The extractor now keys on the presence of ``wildcard_event``, not
-    on ``is_offchain``. An on-chain marketplace task that carried a
-    ``wildcard_event`` (built by the task_execution finalize step) gets
-    included in the batch."""
+    """The extractor keys on the presence of ``wildcard_event``, not on ``is_offchain``.
+
+    An on-chain marketplace task that carried a ``wildcard_event``
+    (built by the task_execution finalize step) gets included in the
+    batch.
+    """
     # Build a self_ that exposes synchronized_data.done_tasks; the
     # extract method is a property-only function.
     self_ = cast(
@@ -482,8 +501,7 @@ def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() 
 
 
 def test_extract_offchain_events_skips_tasks_without_wildcard_event() -> None:
-    """Done tasks without ``wildcard_event`` (e.g. on-chain non-marketplace
-    legacy mech tasks) stay out of the batch."""
+    """Done tasks without ``wildcard_event`` (e.g. on-chain non-marketplace legacy mech tasks) stay out of the batch."""
     self_ = cast(
         PostTxSettlementBehaviour,
         SimpleNamespace(

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -20,12 +20,18 @@
 """Tests for the on-chain write path additions in
 :py:class:`PostTxSettlementBehaviour`.
 
-Two pieces:
+Three pieces:
 
-  - ``_sweep_pending_undelivered`` walks ``shared_state[PENDING_TASKS]``,
-    emits request-only events for tasks past the local sweep age, and
-    removes those tasks from the queue. All gated on
+  - ``_sweep_pending_undelivered`` walks ``shared_state[PENDING_TASKS]``
+    and RETURNS ``(events, swept_request_ids)`` for tasks past the local
+    sweep age, without mutating the queue. All gated on
     ``mech_events_enabled`` AND ``mech_events_sweep_pending_enabled``.
+  - ``_drop_swept_from_pending`` mutates ``PENDING_TASKS`` in place to
+    drop the swept tasks. The caller only fires this after a confirmed
+    wildcard POST 2xx, so any of the six early-return paths in
+    ``_do_wildcard_write_best_effort`` (missing mech address, missing
+    marketplace, mixed chains, unconfigured chain id, digest failure,
+    POST failure) leaves the tasks on the queue for a retry.
   - ``_build_request_only_event`` shapes one entry into the wildcard
     event payload (``request`` half, ``response: None``,
     ``source: 'mech_onchain'``).
@@ -141,8 +147,9 @@ def test_sweep_returns_empty_when_mech_events_disabled() -> None:
         pending=[_make_pending_task("r-disabled", age_seconds=9999)],
         enabled=False,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
+    assert swept == []
     # Pending list untouched.
     assert len(self_.context.shared_state[PENDING_TASKS]) == 1
 
@@ -156,8 +163,9 @@ def test_sweep_returns_empty_when_sweep_flag_disabled() -> None:
         enabled=True,
         sweep_enabled=False,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
+    assert swept == []
     assert len(self_.context.shared_state[PENDING_TASKS]) == 1
 
 
@@ -168,22 +176,25 @@ def test_sweep_returns_empty_when_max_age_zero() -> None:
         pending=[_make_pending_task("r-zero", age_seconds=9999)],
         max_age=0.0,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
+    assert swept == []
 
 
 def test_sweep_returns_empty_when_pending_missing() -> None:
     """No ``PENDING_TASKS`` in shared_state → no-op, no crash. The mech
     boots before the handler stamps the key on some agent configs."""
     self_ = _make_self(pending=None)
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
+    assert swept == []
 
 
 def test_sweep_returns_empty_when_pending_empty() -> None:
     self_ = _make_self(pending=[])
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
+    assert swept == []
 
 
 # Age-driven selection -----------------------------------------------------
@@ -198,53 +209,60 @@ def test_sweep_skips_recent_tasks() -> None:
         ],
         max_age=60.0,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert events == []
+    assert swept == []
     assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
         "r-fresh-a",
         "r-fresh-b",
     ]
 
 
-def test_sweep_emits_for_stale_task_and_removes_it() -> None:
-    """A task older than max-age becomes a request-only event and leaves
-    the queue. The DB's ON CONFLICT (predict-api side) handles concurrent
-    step-in, so the mech doesn't need to consult the contract to decide."""
+def test_sweep_emits_for_stale_task_and_leaves_queue_untouched() -> None:
+    """A task older than max-age becomes a request-only event and its
+    ``request_id`` is returned to the caller. The sweep itself does NOT
+    mutate the queue — the caller drops the swept tasks only after a
+    confirmed wildcard POST 2xx (via ``_drop_swept_from_pending``). The
+    DB's ON CONFLICT (predict-api side) handles concurrent step-in, so
+    the mech doesn't need to consult the contract to decide."""
     self_ = _make_self(
         pending=[_make_pending_task("r-stale", age_seconds=120)],
         max_age=60.0,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert len(events) == 1
     event = events[0]
     assert event["request"]["request_id"] == "r-stale"
     assert event["response"] is None
     assert event["source"] == "mech_onchain"
-    # Task removed from the queue.
-    assert self_.context.shared_state[PENDING_TASKS] == []
+    assert swept == ["r-stale"]
+    # Sweep leaves the queue as-is until _drop_swept_from_pending fires.
+    assert [
+        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
+    ] == ["r-stale"]
 
 
-def test_sweep_mixed_queue_keeps_recent_emits_stale() -> None:
-    """Mixed queue: only the stale entries become events; recent stay put.
-
-    Confirms the sweep mutates the queue in-place rather than rebinding —
-    other consumers (the task picker in task_execution) hold the same
-    list reference.
-    """
+def test_sweep_mixed_queue_returns_stale_and_leaves_all_pending() -> None:
+    """Mixed queue: only the stale entries become events; the returned
+    ``swept_request_ids`` mirrors that selection. The sweep does not
+    drop anything from the queue — that happens post-write."""
     pending = [
         _make_pending_task("r-stale-1", age_seconds=120),
         _make_pending_task("r-fresh-1", age_seconds=10),
         _make_pending_task("r-stale-2", age_seconds=200),
         _make_pending_task("r-fresh-2", age_seconds=30),
     ]
-    pending_ref = pending  # capture identity for the in-place check
+    pending_ref = pending  # capture identity to confirm no rebinding
     self_ = _make_self(pending=pending, max_age=60.0)
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     emitted = {e["request"]["request_id"] for e in events}
     assert emitted == {"r-stale-1", "r-stale-2"}
-    remaining = [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]]
-    assert remaining == ["r-fresh-1", "r-fresh-2"]
-    # Same list object (in-place mutation), not a fresh assignment.
+    assert set(swept) == {"r-stale-1", "r-stale-2"}
+    # The queue is still all four entries — deferred mutation.
+    assert [
+        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
+    ] == ["r-stale-1", "r-fresh-1", "r-stale-2", "r-fresh-2"]
+    # Same list object (no rebinding), so other consumers see the queue.
     assert self_.context.shared_state[PENDING_TASKS] is pending_ref
 
 
@@ -260,10 +278,13 @@ def test_sweep_leaves_tasks_without_enqueued_stamp() -> None:
         ],
         max_age=60.0,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert [e["request"]["request_id"] for e in events] == ["r-stale"]
-    remaining = [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]]
-    assert remaining == ["r-pre-sweep"]
+    assert swept == ["r-stale"]
+    # Queue still holds both entries until the post-write drop.
+    assert [
+        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
+    ] == ["r-pre-sweep", "r-stale"]
 
 
 def test_sweep_leaves_non_dict_entries_alone() -> None:
@@ -276,10 +297,52 @@ def test_sweep_leaves_non_dict_entries_alone() -> None:
         ],
         max_age=60.0,
     )
-    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    events, swept = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
     assert [e["request"]["request_id"] for e in events] == ["r-stale"]
-    # The garbage entry survives.
+    assert swept == ["r-stale"]
+    # The garbage entry survives, and so does the stale task pre-drop.
     assert "garbage" in self_.context.shared_state[PENDING_TASKS]
+
+
+# Deferred queue mutation --------------------------------------------------
+
+
+def test_drop_swept_from_pending_removes_only_swept_ids() -> None:
+    """``_drop_swept_from_pending`` is the only path that mutates the
+    pending queue for a swept task. It removes only the request_ids in
+    ``swept_request_ids`` and leaves everything else in place."""
+    pending = [
+        _make_pending_task("r-a"),
+        _make_pending_task("r-b"),
+        _make_pending_task("r-c"),
+    ]
+    self_ = _make_self(pending=pending)
+    PostTxSettlementBehaviour._drop_swept_from_pending(self_, ["r-a", "r-c"])
+    assert [
+        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
+    ] == ["r-b"]
+    # In-place mutation, not a rebind.
+    assert self_.context.shared_state[PENDING_TASKS] is pending
+
+
+def test_drop_swept_from_pending_noop_on_empty_swept() -> None:
+    """An empty ``swept_request_ids`` (no request-only events staged
+    this round) leaves the queue untouched."""
+    pending = [_make_pending_task("r-only")]
+    self_ = _make_self(pending=pending)
+    PostTxSettlementBehaviour._drop_swept_from_pending(self_, [])
+    assert [
+        t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]
+    ] == ["r-only"]
+
+
+def test_drop_swept_from_pending_noop_when_pending_missing() -> None:
+    """``_drop_swept_from_pending`` is safe to call when
+    ``shared_state[PENDING_TASKS]`` was never populated."""
+    self_ = _make_self(pending=None)
+    # Should not raise, should not add the key.
+    PostTxSettlementBehaviour._drop_swept_from_pending(self_, ["r-x"])
+    assert PENDING_TASKS not in self_.context.shared_state
 
 
 # Request-only event shape --------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -1,0 +1,415 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the on-chain write path additions in
+:py:class:`PostTxSettlementBehaviour`.
+
+Two pieces:
+
+  - ``_sweep_pending_undelivered`` walks ``shared_state[PENDING_TASKS]``,
+    emits request-only events for tasks past the local sweep age, and
+    removes those tasks from the queue. All gated on
+    ``mech_events_enabled`` AND ``mech_events_sweep_pending_enabled``.
+  - ``_build_request_only_event`` shapes one entry into the wildcard
+    event payload (``request`` half, ``response: None``,
+    ``source: 'mech_onchain'``).
+
+The behaviour class is instantiated indirectly by reaching into the
+module's class definition; the methods under test are pure functions of
+``self.context.shared_state`` + ``self.params``, so a SimpleNamespace
+context plus the unbound method invoked with that context is enough —
+no FSM scaffolding required. Same pattern matches what the existing
+tests in ``test_behaviours.py`` use for narrow-scope unit checks.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from packages.valory.skills.task_submission_abci import behaviours as beh_mod
+from packages.valory.skills.task_submission_abci.behaviours import (
+    PENDING_TASKS,
+    PostTxSettlementBehaviour,
+)
+
+
+def _make_logger() -> SimpleNamespace:
+    """No-op logger that absorbs every level."""
+    return SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+
+
+def _make_self(
+    *,
+    pending: List[Dict[str, Any]] | None = None,
+    enabled: bool = True,
+    sweep_enabled: bool = True,
+    max_age: float = 60.0,
+    chain_id: int = 100,
+    marketplace_address: str = "0xMARKET",
+) -> SimpleNamespace:
+    """Build the minimum 'self' a sweep / build call expects.
+
+    The behaviour's :py:meth:`_sweep_pending_undelivered` and
+    :py:meth:`_build_request_only_event` only touch ``self.context``,
+    ``self.params``, and (indirectly) ``self.context.logger``, so a flat
+    SimpleNamespace is enough. ``_sweep_pending_undelivered`` calls
+    ``self._build_request_only_event`` on the same self_, so we wire
+    that method onto the namespace as well so the unbound-method
+    invocation pattern works (calling
+    ``PostTxSettlementBehaviour._sweep_pending_undelivered(self_)``).
+    """
+    shared_state: Dict[str, Any] = {}
+    if pending is not None:
+        shared_state[PENDING_TASKS] = pending
+    self_ = SimpleNamespace(
+        context=SimpleNamespace(
+            shared_state=shared_state,
+            logger=_make_logger(),
+        ),
+        params=SimpleNamespace(
+            mech_events_enabled=enabled,
+            mech_events_sweep_pending_enabled=sweep_enabled,
+            mech_events_sweep_max_age_seconds=max_age,
+            mech_events_chain_id=chain_id,
+            mech_marketplace_address=marketplace_address,
+        ),
+    )
+    # Bind ``_build_request_only_event`` to the namespace so the sweep's
+    # internal ``self._build_request_only_event(...)`` call resolves.
+    self_._build_request_only_event = (
+        lambda task, now_ts: PostTxSettlementBehaviour._build_request_only_event(
+            self_, task, now_ts
+        )
+    )
+    return self_
+
+
+def _make_pending_task(
+    request_id: str = "req-1",
+    *,
+    age_seconds: float = 0.0,
+    priority_mech: str = "0xPRIO",
+    requester: str = "0xREQUESTER",
+    delivery_rate: int | None = 10**16,
+    data: Any = "bafy-cid",
+    include_enqueued_at: bool = True,
+) -> Dict[str, Any]:
+    """Build one PENDING_TASKS entry. ``age_seconds`` ago = now - age."""
+    task: Dict[str, Any] = {
+        "requestId": request_id,
+        "priorityMech": priority_mech,
+        "requester": requester,
+        "request_delivery_rate": delivery_rate,
+        "data": data,
+    }
+    if include_enqueued_at:
+        task["enqueued_at_local"] = time.time() - age_seconds
+    return task
+
+
+# Gating -------------------------------------------------------------------
+
+
+def test_sweep_returns_empty_when_mech_events_disabled() -> None:
+    """``mech_events_enabled=False`` short-circuits before any sweep."""
+    self_ = _make_self(
+        pending=[_make_pending_task("r-disabled", age_seconds=9999)],
+        enabled=False,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert events == []
+    # Pending list untouched.
+    assert len(self_.context.shared_state[PENDING_TASKS]) == 1
+
+
+def test_sweep_returns_empty_when_sweep_flag_disabled() -> None:
+    """The sweep can be flipped off independently from the delivered-event
+    write — ``mech_events_sweep_pending_enabled=False`` short-circuits even
+    when ``mech_events_enabled`` is on."""
+    self_ = _make_self(
+        pending=[_make_pending_task("r-sweep-off", age_seconds=9999)],
+        enabled=True,
+        sweep_enabled=False,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert events == []
+    assert len(self_.context.shared_state[PENDING_TASKS]) == 1
+
+
+def test_sweep_returns_empty_when_max_age_zero() -> None:
+    """A zero (or negative) max-age is treated as 'sweep off' to avoid
+    accidentally sweeping every fresh task that the agent just enqueued."""
+    self_ = _make_self(
+        pending=[_make_pending_task("r-zero", age_seconds=9999)],
+        max_age=0.0,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert events == []
+
+
+def test_sweep_returns_empty_when_pending_missing() -> None:
+    """No ``PENDING_TASKS`` in shared_state → no-op, no crash. The mech
+    boots before the handler stamps the key on some agent configs."""
+    self_ = _make_self(pending=None)
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert events == []
+
+
+def test_sweep_returns_empty_when_pending_empty() -> None:
+    self_ = _make_self(pending=[])
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert events == []
+
+
+# Age-driven selection -----------------------------------------------------
+
+
+def test_sweep_skips_recent_tasks() -> None:
+    """Tasks within the max-age window stay in the queue and emit nothing."""
+    self_ = _make_self(
+        pending=[
+            _make_pending_task("r-fresh-a", age_seconds=5),
+            _make_pending_task("r-fresh-b", age_seconds=30),
+        ],
+        max_age=60.0,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert events == []
+    assert [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]] == [
+        "r-fresh-a",
+        "r-fresh-b",
+    ]
+
+
+def test_sweep_emits_for_stale_task_and_removes_it() -> None:
+    """A task older than max-age becomes a request-only event and leaves
+    the queue. The DB's ON CONFLICT (predict-api side) handles concurrent
+    step-in, so the mech doesn't need to consult the contract to decide."""
+    self_ = _make_self(
+        pending=[_make_pending_task("r-stale", age_seconds=120)],
+        max_age=60.0,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert len(events) == 1
+    event = events[0]
+    assert event["request"]["request_id"] == "r-stale"
+    assert event["response"] is None
+    assert event["source"] == "mech_onchain"
+    # Task removed from the queue.
+    assert self_.context.shared_state[PENDING_TASKS] == []
+
+
+def test_sweep_mixed_queue_keeps_recent_emits_stale() -> None:
+    """Mixed queue: only the stale entries become events; recent stay put.
+
+    Confirms the sweep mutates the queue in-place rather than rebinding —
+    other consumers (the task picker in task_execution) hold the same
+    list reference.
+    """
+    pending = [
+        _make_pending_task("r-stale-1", age_seconds=120),
+        _make_pending_task("r-fresh-1", age_seconds=10),
+        _make_pending_task("r-stale-2", age_seconds=200),
+        _make_pending_task("r-fresh-2", age_seconds=30),
+    ]
+    pending_ref = pending  # capture identity for the in-place check
+    self_ = _make_self(pending=pending, max_age=60.0)
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    emitted = {e["request"]["request_id"] for e in events}
+    assert emitted == {"r-stale-1", "r-stale-2"}
+    remaining = [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]]
+    assert remaining == ["r-fresh-1", "r-fresh-2"]
+    # Same list object (in-place mutation), not a fresh assignment.
+    assert self_.context.shared_state[PENDING_TASKS] is pending_ref
+
+
+def test_sweep_leaves_tasks_without_enqueued_stamp() -> None:
+    """A pending task created before the sweep code shipped (no
+    ``enqueued_at_local``) is left in the queue rather than swept blindly.
+    The next enqueue path stamps fresh; the gap is bounded by mech
+    restart cadence."""
+    self_ = _make_self(
+        pending=[
+            _make_pending_task("r-pre-sweep", include_enqueued_at=False),
+            _make_pending_task("r-stale", age_seconds=999),
+        ],
+        max_age=60.0,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert [e["request"]["request_id"] for e in events] == ["r-stale"]
+    remaining = [t["requestId"] for t in self_.context.shared_state[PENDING_TASKS]]
+    assert remaining == ["r-pre-sweep"]
+
+
+def test_sweep_leaves_non_dict_entries_alone() -> None:
+    """Whatever bug puts non-dict entries in PENDING_TASKS is not the
+    sweep's problem; leave them as-is rather than dropping silently."""
+    self_ = _make_self(
+        pending=[
+            "garbage",  # malformed entry
+            _make_pending_task("r-stale", age_seconds=120),
+        ],
+        max_age=60.0,
+    )
+    events = PostTxSettlementBehaviour._sweep_pending_undelivered(self_)
+    assert [e["request"]["request_id"] for e in events] == ["r-stale"]
+    # The garbage entry survives.
+    assert "garbage" in self_.context.shared_state[PENDING_TASKS]
+
+
+# Request-only event shape --------------------------------------------------
+
+
+def test_request_only_event_carries_expected_fields() -> None:
+    """The shape the wildcard server's MechEvent model expects: a request
+    half with ``delivery_mech=None`` and a ``source='mech_onchain'``
+    top-level field; ``response=None``.
+
+    Mirrors the server-side validator in ``server/src/models/mech.py``:
+    a request-only event with ``source='mech_offchain'`` would be
+    rejected (an off-chain HTTP path doesn't produce undelivered events
+    by construction).
+    """
+    self_ = _make_self()
+    task = _make_pending_task(
+        "r-shape", age_seconds=60, priority_mech="0xPRIORITY", requester="0xREQ"
+    )
+    event = PostTxSettlementBehaviour._build_request_only_event(
+        self_, task, time.time()
+    )
+    assert event is not None
+    assert event["source"] == "mech_onchain"
+    assert event["response"] is None
+    req = event["request"]
+    assert req["request_id"] == "r-shape"
+    assert req["priority_mech"] == "0xPRIORITY"
+    assert req["requester"] == "0xREQ"
+    assert req["delivery_mech"] is None
+    # Chain bits flow from params.
+    assert req["chain_id"] == 100
+    assert req["marketplace_address"] == "0xMARKET"
+    # requested_at is ISO 8601 with Z (matches the off-chain build pattern).
+    assert req["requested_at"].endswith("Z")
+    # delivery_rate stays a string (matches off-chain encoder).
+    assert req["delivery_rate"] == str(10**16)
+    # Placeholder prompt/tool — wildcard requires them non-empty; the lake's
+    # undelivered signal is the absent mech_responses row, not these fields.
+    assert req["prompt"] == "[onchain undelivered]"
+    assert req["tool"] == "unknown"
+
+
+def test_request_only_event_handles_bytes_cid() -> None:
+    """``data`` on the pending task can be raw bytes from the contract
+    event; surface it as a 0x-hex content_cid for the lake."""
+    self_ = _make_self()
+    task = _make_pending_task("r-bytes", data=b"\xab" * 32)
+    event = PostTxSettlementBehaviour._build_request_only_event(
+        self_, task, time.time()
+    )
+    assert event is not None
+    assert event["request"]["content_cid"] == "0x" + "ab" * 32
+
+
+def test_request_only_event_skipped_for_missing_request_id() -> None:
+    """Malformed pending entries (missing requestId / priorityMech /
+    requester) return ``None`` so the sweep keeps the task on the queue
+    rather than emitting a wildcard 422-bait row."""
+    self_ = _make_self()
+    bad = _make_pending_task("r-missing")
+    del bad["requestId"]
+    assert (
+        PostTxSettlementBehaviour._build_request_only_event(
+            self_, bad, time.time()
+        )
+        is None
+    )
+
+
+def test_request_only_event_skipped_for_missing_priority_mech() -> None:
+    self_ = _make_self()
+    bad = _make_pending_task("r-no-pri")
+    bad["priorityMech"] = ""
+    assert (
+        PostTxSettlementBehaviour._build_request_only_event(
+            self_, bad, time.time()
+        )
+        is None
+    )
+
+
+def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
+    """A task with a non-numeric ``enqueued_at_local`` falls back to
+    ``now`` rather than crashing the sweep. Defends against a future
+    code path that stores a string there."""
+    self_ = _make_self()
+    bad = _make_pending_task("r-bad-ts")
+    bad["enqueued_at_local"] = "not-a-number"
+    event = PostTxSettlementBehaviour._build_request_only_event(
+        self_, bad, time.time()
+    )
+    assert event is not None
+    assert event["request"]["requested_at"].endswith("Z")
+
+
+# Extract -----------------------------------------------------------------
+
+
+def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() -> None:
+    """The extractor now keys on the presence of ``wildcard_event``, not
+    on ``is_offchain``. An on-chain marketplace task that carried a
+    ``wildcard_event`` (built by the task_execution finalize step) gets
+    included in the batch."""
+    # Build a self_ that exposes synchronized_data.done_tasks; the
+    # extract method is a property-only function.
+    self_ = SimpleNamespace(
+        synchronized_data=SimpleNamespace(
+            done_tasks=[
+                {"is_offchain": True, "wildcard_event": {"src": "off"}},
+                {"is_offchain": False, "wildcard_event": {"src": "on"}},
+                {"is_offchain": False, "wildcard_event": None},  # skipped
+                {"is_offchain": True, "wildcard_event": "not-a-dict"},  # skipped
+            ]
+        )
+    )
+    events = PostTxSettlementBehaviour._extract_offchain_events(self_)
+    assert events == [{"src": "off"}, {"src": "on"}]
+
+
+def test_extract_offchain_events_skips_tasks_without_wildcard_event() -> None:
+    """Done tasks without ``wildcard_event`` (e.g. on-chain non-marketplace
+    legacy mech tasks) stay out of the batch."""
+    self_ = SimpleNamespace(
+        synchronized_data=SimpleNamespace(
+            done_tasks=[
+                {"is_offchain": True},  # no wildcard_event at all
+                {"is_offchain": False},
+            ]
+        )
+    )
+    events = PostTxSettlementBehaviour._extract_offchain_events(self_)
+    assert events == []

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import time
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 import pytest
 
@@ -71,23 +71,36 @@ def _make_logger() -> SimpleNamespace:
 
 def _make_self(
     *,
-    pending: List[Dict[str, Any]] | None = None,
+    pending: List[Any] | None = None,
     enabled: bool = True,
     sweep_enabled: bool = True,
     max_age: float = 60.0,
     chain_id: int = 100,
     marketplace_address: str = "0xMARKET",
-) -> SimpleNamespace:
+) -> PostTxSettlementBehaviour:
     """Build the minimum 'self' a sweep / build call expects.
 
     The behaviour's :py:meth:`_sweep_pending_undelivered` and
     :py:meth:`_build_request_only_event` only touch ``self.context``,
     ``self.params``, and (indirectly) ``self.context.logger``, so a flat
-    SimpleNamespace is enough. ``_sweep_pending_undelivered`` calls
+    :class:`SimpleNamespace` context is enough at runtime.
+    ``_sweep_pending_undelivered`` calls
     ``self._build_request_only_event`` on the same self_, so we wire
     that method onto the namespace as well so the unbound-method
     invocation pattern works (calling
     ``PostTxSettlementBehaviour._sweep_pending_undelivered(self_)``).
+
+    The return is annotated as :class:`PostTxSettlementBehaviour` via
+    :func:`typing.cast` so the many unbound-method callsites in the
+    tests below type-check under the stricter mypy config the CI runs
+    (``--disallow-untyped-defs``). At runtime this is still a
+    :class:`SimpleNamespace`; the cast is a mypy annotation, not a
+    conversion.
+
+    ``pending`` accepts ``List[Any]`` (not ``List[Dict[str, Any]]``) so
+    the "non-dict entry" defensive test can pass a mixed
+    ``["garbage", {...}]`` without a ``[list-item]`` mypy error; the
+    sweep code path skips non-dict entries at runtime.
     """
     shared_state: Dict[str, Any] = {}
     if pending is not None:
@@ -107,12 +120,14 @@ def _make_self(
     )
     # Bind ``_build_request_only_event`` to the namespace so the sweep's
     # internal ``self._build_request_only_event(...)`` call resolves.
+    # Cast the inner ``self_`` for the same mypy reason as the outer cast
+    # on this function's return.
     self_._build_request_only_event = (
         lambda task, now_ts: PostTxSettlementBehaviour._build_request_only_event(
-            self_, task, now_ts
+            cast(PostTxSettlementBehaviour, self_), task, now_ts
         )
     )
-    return self_
+    return cast(PostTxSettlementBehaviour, self_)
 
 
 def _make_pending_task(
@@ -449,15 +464,18 @@ def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() 
     included in the batch."""
     # Build a self_ that exposes synchronized_data.done_tasks; the
     # extract method is a property-only function.
-    self_ = SimpleNamespace(
-        synchronized_data=SimpleNamespace(
-            done_tasks=[
-                {"is_offchain": True, "wildcard_event": {"src": "off"}},
-                {"is_offchain": False, "wildcard_event": {"src": "on"}},
-                {"is_offchain": False, "wildcard_event": None},  # skipped
-                {"is_offchain": True, "wildcard_event": "not-a-dict"},  # skipped
-            ]
-        )
+    self_ = cast(
+        PostTxSettlementBehaviour,
+        SimpleNamespace(
+            synchronized_data=SimpleNamespace(
+                done_tasks=[
+                    {"is_offchain": True, "wildcard_event": {"src": "off"}},
+                    {"is_offchain": False, "wildcard_event": {"src": "on"}},
+                    {"is_offchain": False, "wildcard_event": None},  # skipped
+                    {"is_offchain": True, "wildcard_event": "not-a-dict"},  # skipped
+                ]
+            )
+        ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == [{"src": "off"}, {"src": "on"}]
@@ -466,13 +484,16 @@ def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() 
 def test_extract_offchain_events_skips_tasks_without_wildcard_event() -> None:
     """Done tasks without ``wildcard_event`` (e.g. on-chain non-marketplace
     legacy mech tasks) stay out of the batch."""
-    self_ = SimpleNamespace(
-        synchronized_data=SimpleNamespace(
-            done_tasks=[
-                {"is_offchain": True},  # no wildcard_event at all
-                {"is_offchain": False},
-            ]
-        )
+    self_ = cast(
+        PostTxSettlementBehaviour,
+        SimpleNamespace(
+            synchronized_data=SimpleNamespace(
+                done_tasks=[
+                    {"is_offchain": True},  # no wildcard_event at all
+                    {"is_offchain": False},
+                ]
+            )
+        ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == []

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -429,6 +429,32 @@ def test_request_only_event_handles_bytes_cid() -> None:
     assert event["request"]["content_cid"] == "0x" + "ab" * 32
 
 
+def test_request_only_event_coerces_bytes_request_id_to_decimal_string() -> None:
+    r"""Undelivered marketplace tasks hold ``requestId`` as raw bytes.
+
+    ``get_marketplace_undelivered_reqs`` populates ``requestId`` with the
+    contract-event byte payload; the int conversion only happens later,
+    once the task actually runs in task_execution. If the sweep did a
+    plain ``str(bytes)`` it would emit ``"b'\x12\x34...'"`` — completely
+    different from the decimal string the delivered event carries via
+    the same request_id, so predict-api's ON CONFLICT reconciliation
+    would never fire and a request that later gets delivered would stay
+    marked undelivered forever.
+
+    Regression guard: assert the built event's ``request.request_id`` is
+    the decimal string form of the bytes, matching the delivered shape.
+    """
+    self_ = _make_self()
+    # 42 as big-endian bytes → same integer the delivered path would emit.
+    task = _make_pending_task("placeholder")
+    task["requestId"] = (42).to_bytes(4, "big")
+    event = PostTxSettlementBehaviour._build_request_only_event(
+        self_, task, time.time()
+    )
+    assert event is not None
+    assert event["request"]["request_id"] == "42"
+
+
 def test_request_only_event_skipped_for_missing_request_id() -> None:
     """Malformed pending entries (missing requestId / priorityMech /
 

--- a/packages/valory/skills/task_submission_abci/tests/test_wildcard_write_client.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_wildcard_write_client.py
@@ -138,6 +138,45 @@ class TestComputeBatchHash:
         events_b = [{"r": "second"}, {"r": "first"}]
         assert compute_batch_hash(events_a) != compute_batch_hash(events_b)
 
+    def test_hash_excludes_source_field(self) -> None:
+        """The ``source`` top-level field is stripped from the hash surface.
+
+        ``compute_batch_hash`` mirrors the server-side
+        ``model_dump(exclude={"source"})`` in predict-api's
+        ``routes/mech.py``. Regression guard for the ``BATCH_HASH_MISMATCH``
+        rollout risk: without this exclusion, an older off-chain mech
+        that never sent ``source`` would hash ``{request, response}``
+        while the server would hash ``{request, response, source:
+        "mech_offchain"}`` (Pydantic's default injects the field on
+        parse), and every write from a not-yet-upgraded mech would be
+        rejected during the ordered rollout window.
+
+        Three payload shapes must all produce identical hashes:
+
+          * ``{"a": 1, "source": "mech_onchain"}``
+          * ``{"a": 1, "source": "mech_offchain"}``
+          * ``{"a": 1}``  (old mech, no source key)
+        """
+        h_onchain = compute_batch_hash([{"a": 1, "source": "mech_onchain"}])
+        h_offchain = compute_batch_hash([{"a": 1, "source": "mech_offchain"}])
+        h_missing = compute_batch_hash([{"a": 1}])
+        assert h_onchain == h_offchain == h_missing
+
+    def test_hash_still_changes_on_non_source_fields(self) -> None:
+        """The source-exclusion is targeted; every other field still counts.
+
+        A regression that widened the strip to also exclude another
+        real field would hide tamper. Confirm ``request`` still tips
+        the hash even when a ``source`` key sits alongside it.
+        """
+        h1 = compute_batch_hash(
+            [{"request": {"prompt": "a"}, "source": "mech_onchain"}]
+        )
+        h2 = compute_batch_hash(
+            [{"request": {"prompt": "b"}, "source": "mech_onchain"}]
+        )
+        assert h1 != h2
+
 
 # ---------------------------------------------------------------------------
 # build_typed_data

--- a/packages/valory/skills/task_submission_abci/wildcard_write_client.py
+++ b/packages/valory/skills/task_submission_abci/wildcard_write_client.py
@@ -63,16 +63,36 @@ def canonical_json_bytes(value: Any) -> bytes:
 
 
 def compute_batch_hash(events: List[Dict[str, Any]]) -> str:
-    """Return ``"0x" + keccak256(canonical_json(events)).hex()``.
+    """Return ``"0x" + keccak256(canonical_json(events_without_source)).hex()``.
 
     The result is what goes into the signed typed-data's
     ``message.batch_hash`` field. The server recomputes from the parsed
     wire payload and rejects on mismatch.
 
+    ``source`` is stripped from a shallow copy of each event before
+    hashing, in symmetry with the server's own
+    ``model_dump(exclude={"source"})`` in ``routes/mech.py``. Without
+    this exclusion an older off-chain mech that never sent ``source``
+    would hash ``{request, response}`` while the server would hash
+    ``{request, response, source: "mech_offchain"}`` (Pydantic's default
+    injects the field on parse), so every write from a not-yet-upgraded
+    mech would surface as ``BATCH_HASH_MISMATCH`` during the ordered
+    rollout window. Excluding source on both sides keeps the "predict-api
+    first, then mech" rollout honest.
+
+    Trade-off: an in-flight flip of ``source`` (``mech_offchain`` ↔
+    ``mech_onchain``) between mech and server would not invalidate the
+    signature. Low impact because source is a provenance tag on rows
+    the mech's own EOA already signed for; the mech owner is trusted
+    for the origin of their own rows.
+
     :param events: the ordered list of settled-delivery event dicts.
+        ``source`` may or may not be present on each dict; the hash
+        excludes it either way.
     :return: the 0x-prefixed 32-byte hex digest of the canonical batch.
     """
-    return "0x" + keccak(canonical_json_bytes(events)).hex()
+    hash_input = [{k: v for k, v in event.items() if k != "source"} for event in events]
+    return "0x" + keccak(canonical_json_bytes(hash_input)).hex()
 
 
 def compute_eip712_digest(typed_data: Dict[str, Any]) -> bytes:


### PR DESCRIPTION
## Summary

- `_build_wildcard_event` sets the wire-level `source` to `mech_offchain` or `mech_onchain` based on the task's `is_offchain` flag, and the build gate relaxes to include on-chain marketplace tasks too.
- `filter_requests` stamps `enqueued_at_local` on every pending task; `PostTxSettlementBehaviour._sweep_pending_undelivered` walks the queue and emits request-only events (`response=None`, `source=mech_onchain`) for tasks past the configurable max age.
- `_extract_offchain_events` now keys on the presence of `wildcard_event`, so on-chain deliveries ride the same batch as off-chain.
- Two new default-off params: `mech_events_sweep_pending_enabled`, `mech_events_sweep_max_age_seconds`. Sweep is gated independently from the delivered-event write so operators can stage rollout.
- 597 tests pass locally (existing + new).

PRs land in order: predict-api#165 (the migration + model + writer) first, then this. Reversing the order would make request-only POSTs return 422 until the server catches up.

## Why local-clock sweep, not `getRequestStatus`

The contract's `RequestInfo.responseTimeout` is authoritative but reading it per sweep is one RPC per pending task. We explicitly avoid that: `filter_requests` stamps `enqueued_at_local` at enqueue time, and the sweep uses a configurable local max age (default 1 hour). If step-in delivers between the sweep and the predict-api write, the DB's `ON CONFLICT (request_id) DO UPDATE ... WHERE delivery_mech IS NULL` clause reconciles to the correct row. See `autonolas-marketplace/docs/onchain_write_path_scope.md` §3.2 and §3.4 for the trade-off.

## Notes for review

- Request-only events use placeholder `prompt='[onchain undelivered]'` and `tool='unknown'`. The IPFS body for the request isn't resolved at sweep time (would require a blocking fetch per task); the analytics-side undelivered signal is the absent `mech_responses` row, not the prompt content.
- The sweep operates in-place on `shared_state[PENDING_TASKS]` so other consumers (the task picker in `task_execution`) see the removal.
- Sweep is feature-flag gated separately (`mech_events_sweep_pending_enabled`); default off until v1 is validated against a live deployment. Operators can flip `mech_events_enabled` first to write delivered on-chain rows, then flip the sweep on once that's stable.
- PR targets `offchain-epic` per the team's branching request, not `main`.

## Test plan

- [x] `uv run pytest packages/valory/skills/task_submission_abci/tests/ packages/valory/skills/task_execution/tests/` — 597 passed locally.
- [ ] `autonomy packages lock --check` — verify the hash updates I generated round-trip cleanly.
- [ ] Cross-repo manual run of `autonolas-marketplace/docs/onchain_write_path_e2e.md` after predict-api#165 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)