### PR TITLE
fix(task_submission): preserve done_tasks across PostTxSettlementRound

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,12 +8,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu",
+        "skill/valory/mech_abci/0.1.0": "bafybeifqmjqfdhs3beaswozr6zugsst43tq6ias7chg5tjayekcr7e45ai",
         "skill/valory/task_execution/0.1.0": "bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeict3okafrtmy3hjnz2rlrcjjf5e2y7goqy5zr4svrvic2mlt54q2u",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiet4mcpr36cm6wuprswfrxgibr5ob5rii277ynx65gl7a27qpekcm",
-        "service/valory/mech/0.1.0": "bafybeifpdygfygghydm7i3xfsnjbshdoyluq4dtu2izhit6utc43herg2u"
+        "agent/valory/mech/0.1.0": "bafybeiexugogtn7crjto2yxfwqj76y7w66cv7pabzdgjr3x5obztvjlemu",
+        "service/valory/mech/0.1.0": "bafybeiazqc66bhsw6gaw5eg2kng3utmlh654l6ymuumfdwnl65cwlplk2e"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu
+- valory/mech_abci:0.1.0:bafybeifqmjqfdhs3beaswozr6zugsst43tq6ias7chg5tjayekcr7e45ai
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
 - valory/task_execution:0.1.0:bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq
-- valory/task_submission_abci:0.1.0:bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4
+- valory/task_submission_abci:0.1.0:bafybeict3okafrtmy3hjnz2rlrcjjf5e2y7goqy5zr4svrvic2mlt54q2u
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiet4mcpr36cm6wuprswfrxgibr5ob5rii277ynx65gl7a27qpekcm
+agent: valory/mech:0.1.0:bafybeiexugogtn7crjto2yxfwqj76y7w66cv7pabzdgjr3x5obztvjlemu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,7 +30,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
-- valory/task_submission_abci:0.1.0:bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4
+- valory/task_submission_abci:0.1.0:bafybeict3okafrtmy3hjnz2rlrcjjf5e2y7goqy5zr4svrvic2mlt54q2u
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -208,6 +208,19 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     the analytics row just arrives later via the replay buffer). The
     NO_MAJORITY arm only fires if the agents can't agree on having reached
     this round at all, which is the same shape as every consensus round.
+
+    ``done_tasks`` MUST survive this round untouched. It is in
+    ``cross_period_persisted_keys`` because
+    ``TaskPoolingBehaviour.handle_submitted_tasks`` reads it at the START
+    of the next cycle to know which ``request_id``s to prune from
+    ``shared_state[DONE_TASKS]``. Clearing here on DONE strands the
+    delivered tasks in shared state, so every subsequent cycle re-pools
+    and re-delivers the same batch — the Safe tx succeeds each time but
+    the inner ``mech.deliverMulti`` reverts on the already-delivered
+    ids, burning gas without emitting new Deliver events. Any re-fire
+    concern on the NO_MAJORITY / ROUND_TIMEOUT self-loop must be handled
+    inside the behaviour (idempotence flag) rather than by mutating a
+    field the next behaviour depends on.
     """
 
     payload_class = PostTxSettlementPayload
@@ -218,20 +231,7 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
         """Process the end of the block."""
         if self.threshold_reached:
-            # Clear ``done_tasks`` on exit, matching the
-            # ``TransactionPreparationRound`` pattern. Without this the
-            # next entry to this round on NO_MAJORITY / ROUND_TIMEOUT
-            # (both self-loop) would re-read the same stale events and
-            # re-fire the wildcard POST; the events also survive across
-            # periods via ``cross_period_persisted_keys``, so the next
-            # cycle's behaviour would see last period's events too.
-            return (
-                self.synchronized_data.update(
-                    synchronized_data_class=SynchronizedData,
-                    **{get_name(SynchronizedData.done_tasks): []},
-                ),
-                Event.DONE,
-            )
+            return self.synchronized_data, Event.DONE
         if not self.is_majority_possible(
             self.collection, self.synchronized_data.nb_participants
         ):

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeicj3ztx52k2sukkfqkjetyj3rz2zcggmy4xjqgx5avdxoccxap4bm
   payloads.py: bafybeif2gnz5k7eyb6of4iiisni426zscwanjfmtrr37f7ceu4cjqo2ob4
-  rounds.py: bafybeiagfyc4lz5sda5gwux4jcld7io26n5d77tdmewcwcs6l63sobfvt4
+  rounds.py: bafybeig3tdavbjyn7gf2qhz3fo2nn2lyhu7zvrncdlmjed2mskriw2k4eu
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
-  tests/test_rounds.py: bafybeiewxotnlbq2qckyat2flyewq56n6kh6ejyllbjgebx2xiw3rbhptq
+  tests/test_rounds.py: bafybeiaqdpzmf5t4l3rldukzynj7akiz5wpbbcrtzqd3gkjqs5jybtqyhe
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
   tests/test_wildcard_write_client.py: bafybeifqvm3fek6sex6yum47tvzvph3ntufmmwyc7ctpuoepjhm2jykhlu
   wildcard_write_client.py: bafybeiflaa5noxki56ebie6tbcp5zbqf4vqg55llle4dxkmafgvvqk6buy

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -512,3 +512,26 @@ class TestPostTxSettlementRound:
         assert result is not None
         _, event = result
         assert event == Event.NO_MAJORITY
+
+    def test_done_tasks_preserved_on_done(self) -> None:
+        """Regression pin: ``done_tasks`` MUST survive DONE untouched.
+
+        ``TaskPoolingBehaviour.handle_submitted_tasks`` reads
+        ``synchronized_data.done_tasks`` at the START of the next cycle to
+        know which ``request_id``s to prune from
+        ``shared_state[DONE_TASKS]``. If this round clears the field on
+        DONE, the next cycle sees an empty list, ``remove_tasks`` is a
+        no-op, and the same batch is re-delivered on every settlement
+        cycle — the Safe tx succeeds but ``mech.deliverMulti`` reverts on
+        the already-delivered ids, burning gas without emitting new
+        Deliver events. Any wildcard re-fire concern on self-loop must be
+        guarded inside the behaviour, not by mutating this field.
+        """
+        tasks = [_make_task("req-1"), _make_task("req-2")]
+        payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
+        round_ = _make_post_tx_round(payloads, done_tasks=tasks)
+        result = round_.end_block()
+        assert result is not None
+        new_sync_data, event = result
+        assert event == Event.DONE
+        assert cast(SynchronizedData, new_sync_data).done_tasks == tasks


### PR DESCRIPTION
## Summary

- `PostTxSettlementRound.end_block` was clearing `synchronized_data.done_tasks` on `Event.DONE`. That field is what `TaskPoolingBehaviour.handle_submitted_tasks` reads at the start of the next cycle to know which `request_id`s to prune from `shared_state[DONE_TASKS]`.
- With the clear in place, `submitted_tasks` reaches `remove_tasks(...)` as `[]` on every cycle, so delivered tasks are never pruned. The same batch is re-pooled, re-prepared, and re-submitted every settlement round. Safe `execTransaction` succeeds each time, but `mech.deliverMulti` reverts on the already-delivered ids — burning gas, emitting no new `Deliver` events, degrading on-chain delivery rate.
- Restores `PostTxSettlementRound.end_block` to a straight `(synchronized_data, DONE)` return. `done_tasks` is already in `cross_period_persisted_keys` and now flows correctly into the next cycle's `handle_submitted_tasks`. Adds a regression test that pins the invariant.

## Root cause

Introduced by commit `330cb8ad` (PR #457 second-pass review). That commit added the clear to prevent the round from re-firing the wildcard POST on its `NO_MAJORITY` / `ROUND_TIMEOUT` self-loops. Correct concern, wrong layer — it guarded a shared consensus field that a downstream behaviour depends on. The re-fire concern is not observable while `mech_events_enabled=False` (behaviour short-circuits before the POST) and is safe when the flag is on (wildcard server is idempotent on `request_id`). If the round-level guard is wanted later, the right place for it is an idempotence flag inside `PostTxSettlementBehaviour`, not mutation of `synchronized_data.done_tasks`.

## Production impact observed

Single-agent Polygon mech (agent 21, offchain flag off): batch grew monotonically 10 → 19 over a 71-minute window; 150 finalized Safe txs across 150 cycles, all Success on Polygonscan; only ~4 actual `Deliver` events emitted (the first-time deliveries). Roughly ~13 POL/hour wasted at 275 gwei on redundant `execTransaction` calls.

Both `mech_events_enabled=False` and `mech_events_enabled=True` hit the bug — the round-level clear runs regardless of the behaviour-level flag.

## Test plan

- [x] `pytest packages/valory/skills/task_submission_abci/tests/` — 238/238 pass
- [x] `tomte tox -e black-check isort-check flake8 darglint mypy`
- [x] `autonomy packages lock --check`
- [x] `autonomy push-all`
- [ ] Deploy to single-agent Polygon mech; watch `Marketplace Tasks Found: N` — pre-fix it grows monotonically, post-fix it should track new task arrivals only (grows then drains on settlement)
- [ ] Cross-check Polygonscan: `ExecutionFailure` on Safe internal txs (currently visible) should stop appearing on the delivery Safe calls
- [ ] Multi-agent smoke: run on a 4-agent test service, confirm `TaskPoolingRound` consensus still lands cleanly

## Files

- `packages/valory/skills/task_submission_abci/rounds.py` — drop the clear, expand the class docstring so the invariant is explicit
- `packages/valory/skills/task_submission_abci/tests/test_rounds.py` — `test_done_tasks_preserved_on_done` regression pin
- `packages/packages.json`, `packages/valory/agents/mech/aea-config.yaml`, `packages/valory/services/mech/service.yaml`, `packages/valory/skills/mech_abci/skill.yaml`, `packages/valory/skills/task_submission_abci/skill.yaml` — IPFS hash bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)