### PR TITLE
chore: bump 0.21.23 -> 0.21.26 refs in workflow / README / tox comments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-versions }}
       - uses: maus007/docker-run-action-fork@v1
         with:
-            image: valory/open-autonomy-user:0.21.23
+            image: valory/open-autonomy-user:0.21.26
             options: -v ${{ github.workspace }}:/work
             run: |
               echo "Pushing Packages"
@@ -44,7 +44,7 @@ jobs:
       - name: Set up tag and vars
         uses: maus007/docker-run-action-fork@v1
         with:
-          image: valory/open-autonomy-user:0.21.23
+          image: valory/open-autonomy-user:0.21.26
           options: -v ${{ github.workspace }}:/work
           run: |
             echo "Setting Tag Images"
@@ -64,7 +64,7 @@ jobs:
       - uses: maus007/docker-run-action-fork@v1
         name: Build Images
         with:
-            image: valory/open-autonomy-user:0.21.23
+            image: valory/open-autonomy-user:0.21.26
             options: -v ${{ github.workspace }}:/work
             shell: bash
             run: |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center" style="margin-bottom: 0;">
     Autonolas AI Mechs
     <br><a href="./LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/github/license/valory-xyz/mech"></a>
-    <a href="https://pypi.org/project/open-autonomy/0.21.23/"><img alt="Framework: Open Autonomy 0.21.23" src="https://img.shields.io/badge/framework-Open%20Autonomy%200.21.23-blueviolet"></a>
+    <a href="https://pypi.org/project/open-autonomy/0.21.26/"><img alt="Framework: Open Autonomy 0.21.26" src="https://img.shields.io/badge/framework-Open%20Autonomy%200.21.26-blueviolet"></a>
     <!-- <a href="https://github.com/valory-xyz/mech/releases/latest">
     <img alt="Latest release" src="https://img.shields.io/github/v/release/valory-xyz/mech"> -->
     </a>

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ extra_pylint_ignored_modules = pandas,numpy,aea_cli_ipfs,compose,multidict,gql
 ; non-fleet `tomte[black]` consumers don't get unexpected config injection.
 tomte_defaults = true
 ; anchorpy 0.20.2 (pulled transitively via open-aea-ledger-solana since
-; open-autonomy 0.21.23) ships a pytest plugin with a broken import
+; open-autonomy 0.21.26) ships a pytest plugin with a broken import
 ; (`from pytest_xprocess import getrootdir` — top-level module is
 ; `xprocess` in modern pytest-xprocess). Pytest's `-p no:` disables a
 ; pytest11 entry point before its module is imported; the entry point
@@ -43,8 +43,8 @@ addopts = -p no:pytest_anchorpy
 ; Liccheck whitelist for deps with no PyPI-declared license. All four are
 ; MIT per their GitHub repos but ship no Trove classifier or License field,
 ; so liccheck reports them UNKNOWN under PARANOID. The first three are
-; pulled in via open-aea-ledger-solana (open-autonomy 0.21.23 / open-aea
-; 2.2.7); peewee is the SQLite ORM used by the vendored valory/kv_store
+; pulled in via open-aea-ledger-solana (open-autonomy 0.21.26 / open-aea
+; 2.2.9); peewee is the SQLite ORM used by the vendored valory/kv_store
 ; connection.
 [Authorized Packages]
 anchorpy: 0.20.2


### PR DESCRIPTION
## Summary

Follow-up to #465 (merged). Addresses three propagation misses caught in review — all text / CI-config, **no package fingerprint changes**.

## Changes

1. **`.github/workflows/release.yaml`** (lines 22, 47, 67) — bumped `image: valory/open-autonomy-user:0.21.23` → `0.21.26`. That image runs `autonomy push-all` / `fetch` / `build-image` at release time. On 0.21.23 it expects the 2.2.7 open-aea family and would hit a pip-resolution conflict inside the image build against the 2.2.9 pins now in `packages/valory/**/*.yaml`.

2. **`README.md`** (line 8) — framework badge label + PyPI URL still read "Open Autonomy 0.21.23". Updated both.

3. **`tox.ini`** (lines 35, 46-47) — comments justifying the anchorpy pytest-plugin disable and the liccheck whitelist cite `open-autonomy 0.21.23 / open-aea 2.2.7` as current. Workarounds remain valid post-bump (`uv.lock` confirms `anchorpy==0.20.2` via the 2.2.9 solana plugin); just refreshed the version numbers in the prose so the comments don't misrepresent state.

## Verification

- `autonomy packages lock --check`: green (unchanged — no package files touched)
- Full-tree grep for `0.21.23` and `2.2.7` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)