### PR TITLE
feat(mech): dual-purpose use_offchain, drop mech_events_enabled, rename wildcard→predict_api

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeigfhqxcb2qmureyq2h637kaqs6rksnlhexkpwjzfocsxqwsp35r4m",
-        "skill/valory/task_execution/0.1.0": "bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicaznkgq6sovmebykhzrdwswvbkgvksxrrpzjs2qso5watx3n74wy",
+        "skill/valory/mech_abci/0.1.0": "bafybeicreimiiyr6dtvhyacf2625345sczcj54rsv7a7vjrh6whepd3cta",
+        "skill/valory/task_execution/0.1.0": "bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiesfrw6tmn6h7kbql3mcpejbpf3rsr2j3wohkakkeozebvf2oxyvi",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiaifr5ya4najolwr7zdtdwmz4q4ejfhtvkafn35big7kambo7ljmq",
-        "service/valory/mech/0.1.0": "bafybeigabk477akzczypxmtsgtlg7eyop46hgde4dtd5tabx3jna3ntenq"
+        "agent/valory/mech/0.1.0": "bafybeidcprl2mj4iuwvqznru67ndtcqndelg7bg77xk2aehkld4azpl2w4",
+        "service/valory/mech/0.1.0": "bafybeid6rqldxdxml3ki4rp6hby2fyxlhahlw6x35b3rzfbo7jmorbltfi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeicreimiiyr6dtvhyacf2625345sczcj54rsv7a7vjrh6whepd3cta",
-        "skill/valory/task_execution/0.1.0": "bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiesfrw6tmn6h7kbql3mcpejbpf3rsr2j3wohkakkeozebvf2oxyvi",
+        "skill/valory/mech_abci/0.1.0": "bafybeigvomrayvkwvativspmvgwdveqiqyndqlteluv235jigd6xgrdlsa",
+        "skill/valory/task_execution/0.1.0": "bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiblfzy23r3bgcfdceeoilz2fiqscdyrer3b2xewctq77tlnkja5fa",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidcprl2mj4iuwvqznru67ndtcqndelg7bg77xk2aehkld4azpl2w4",
-        "service/valory/mech/0.1.0": "bafybeid6rqldxdxml3ki4rp6hby2fyxlhahlw6x35b3rzfbo7jmorbltfi"
+        "agent/valory/mech/0.1.0": "bafybeifg32fr5cf7enk2owgtjyn7rdr5o6goinfdgmsg2lod5amhu6dfjy",
+        "service/valory/mech/0.1.0": "bafybeifgey2wtnotht4aj6yuwb4rsxsofolhadrqvh6yylstcxphu3d4sy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeib33ygqjlxsw4sl7t56zdlsui6kukk2wz6gspddrof2c3pjeisyem",
-        "skill/valory/task_execution/0.1.0": "bafybeib4ca677b4fbvtcf2zpfxjr7aob55qeuo7hhqjeenvhfs7ob7cujq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeie4gnqfzbizxqgpn56qgqkw76z23cj3kuued2dsysoampe7s4y5ou",
+        "skill/valory/mech_abci/0.1.0": "bafybeibbtfds4fe7whywgewsvd7q4m5zdr3r7tzcjjcviht7vy3i7abiwa",
+        "skill/valory/task_execution/0.1.0": "bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicpoimeoh7onez3vcjounzov63zjz4sm6ppzysdowhf5beyhqcodi",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeigmprmqsw4rga2yx4xjouysasyreym52lwl2ol7of7zou7wai3mju",
-        "service/valory/mech/0.1.0": "bafybeihptuvknnbiap4qxi2jwxt5t7okj7t227xocp5jsywnqyskmbzhly"
+        "agent/valory/mech/0.1.0": "bafybeiawl7wpiecxaax3ruawcttvbuukuplte4ifhx4ychy5q57playxza",
+        "service/valory/mech/0.1.0": "bafybeigycr7hqxr4mdc3oillsvfpgm6n7ba476nzkglz4gh2btziwggday"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeibbtfds4fe7whywgewsvd7q4m5zdr3r7tzcjjcviht7vy3i7abiwa",
+        "skill/valory/mech_abci/0.1.0": "bafybeiazxfadofj5ztzhw4d5i2tpf2cmqvhnys3ohpie5vqug4ze25p77a",
         "skill/valory/task_execution/0.1.0": "bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicpoimeoh7onez3vcjounzov63zjz4sm6ppzysdowhf5beyhqcodi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiehicmh2mg77ysphvo3ox7yc2g34lx3cstj2tbsjrqjwt7otcapm4",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiawl7wpiecxaax3ruawcttvbuukuplte4ifhx4ychy5q57playxza",
-        "service/valory/mech/0.1.0": "bafybeigycr7hqxr4mdc3oillsvfpgm6n7ba476nzkglz4gh2btziwggday"
+        "agent/valory/mech/0.1.0": "bafybeichnpuvhvq6f2czhz2vj5eynjgemgaxfs2qnwcidhy5munaxepr5e",
+        "service/valory/mech/0.1.0": "bafybeiaoz5cmozd37k6leysfzhzcudfmwxnx7kc4toj7qeqhe6uxnvo734"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeiatxn2wb7pasde63hi4cghzoxzr6thj2xe3zwllr54f4kjx7b4ciq",
-        "skill/valory/task_execution/0.1.0": "bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibdegmyw2pq54byeac7izj7vcm6egzhj6d72di7s3xdt3pfmai22i",
+        "skill/valory/mech_abci/0.1.0": "bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia",
+        "skill/valory/task_execution/0.1.0": "bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidos57xj77zosblpmu2hsxkhczvotjwyxw2gwzhlumh3r6y7cyyxa",
-        "service/valory/mech/0.1.0": "bafybeig5rxdfzpxvfheh6nvd5wnpkmktrfpzytefo6db66pwkvnpum7myi"
+        "agent/valory/mech/0.1.0": "bafybeiab7emnojt4uglfdpk7x6x26wmnqs5azf7favs7qw3o3yebmkydxa",
+        "service/valory/mech/0.1.0": "bafybeicjlkkltnpt4m3pse74e4fgq4lwbmbg7mx4ecdvmtsouzslmjbrxy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeifgqseomidt5l2u5s5lsjm6piuadx7ohlkpmvabudg6nxbilqptzy",
-        "skill/valory/task_execution/0.1.0": "bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicjnwilfpsg4oolysfdc2klexzegx4czg5d5hpwebl5hq7zieduma",
+        "skill/valory/mech_abci/0.1.0": "bafybeigfhqxcb2qmureyq2h637kaqs6rksnlhexkpwjzfocsxqwsp35r4m",
+        "skill/valory/task_execution/0.1.0": "bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicaznkgq6sovmebykhzrdwswvbkgvksxrrpzjs2qso5watx3n74wy",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeibh3eg4iicpje3v4vexudoxvh55wndjw2pwo7aufibhferybclbtm",
-        "service/valory/mech/0.1.0": "bafybeicruslx6xuidogwwdgb5eeglybbsyt5ktylul4d7fblpcu6fmtfke"
+        "agent/valory/mech/0.1.0": "bafybeiaifr5ya4najolwr7zdtdwmz4q4ejfhtvkafn35big7kambo7ljmq",
+        "service/valory/mech/0.1.0": "bafybeigabk477akzczypxmtsgtlg7eyop46hgde4dtd5tabx3jna3ntenq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeigvomrayvkwvativspmvgwdveqiqyndqlteluv235jigd6xgrdlsa",
-        "skill/valory/task_execution/0.1.0": "bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiblfzy23r3bgcfdceeoilz2fiqscdyrer3b2xewctq77tlnkja5fa",
+        "skill/valory/mech_abci/0.1.0": "bafybeiatxn2wb7pasde63hi4cghzoxzr6thj2xe3zwllr54f4kjx7b4ciq",
+        "skill/valory/task_execution/0.1.0": "bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibdegmyw2pq54byeac7izj7vcm6egzhj6d72di7s3xdt3pfmai22i",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeifg32fr5cf7enk2owgtjyn7rdr5o6goinfdgmsg2lod5amhu6dfjy",
-        "service/valory/mech/0.1.0": "bafybeifgey2wtnotht4aj6yuwb4rsxsofolhadrqvh6yylstcxphu3d4sy"
+        "agent/valory/mech/0.1.0": "bafybeidos57xj77zosblpmu2hsxkhczvotjwyxw2gwzhlumh3r6y7cyyxa",
+        "service/valory/mech/0.1.0": "bafybeig5rxdfzpxvfheh6nvd5wnpkmktrfpzytefo6db66pwkvnpum7myi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeiazxfadofj5ztzhw4d5i2tpf2cmqvhnys3ohpie5vqug4ze25p77a",
+        "skill/valory/mech_abci/0.1.0": "bafybeifgqseomidt5l2u5s5lsjm6piuadx7ohlkpmvabudg6nxbilqptzy",
         "skill/valory/task_execution/0.1.0": "bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiehicmh2mg77ysphvo3ox7yc2g34lx3cstj2tbsjrqjwt7otcapm4",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicjnwilfpsg4oolysfdc2klexzegx4czg5d5hpwebl5hq7zieduma",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeichnpuvhvq6f2czhz2vj5eynjgemgaxfs2qnwcidhy5munaxepr5e",
-        "service/valory/mech/0.1.0": "bafybeiaoz5cmozd37k6leysfzhzcudfmwxnx7kc4toj7qeqhe6uxnvo734"
+        "agent/valory/mech/0.1.0": "bafybeibh3eg4iicpje3v4vexudoxvh55wndjw2pwo7aufibhferybclbtm",
+        "service/valory/mech/0.1.0": "bafybeicruslx6xuidogwwdgb5eeglybbsyt5ktylul4d7fblpcu6fmtfke"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiazxfadofj5ztzhw4d5i2tpf2cmqvhnys3ohpie5vqug4ze25p77a
+- valory/mech_abci:0.1.0:bafybeifgqseomidt5l2u5s5lsjm6piuadx7ohlkpmvabudg6nxbilqptzy
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
 - valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
-- valory/task_submission_abci:0.1.0:bafybeiehicmh2mg77ysphvo3ox7yc2g34lx3cstj2tbsjrqjwt7otcapm4
+- valory/task_submission_abci:0.1.0:bafybeicjnwilfpsg4oolysfdc2klexzegx4czg5d5hpwebl5hq7zieduma
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigvomrayvkwvativspmvgwdveqiqyndqlteluv235jigd6xgrdlsa
+- valory/mech_abci:0.1.0:bafybeiatxn2wb7pasde63hi4cghzoxzr6thj2xe3zwllr54f4kjx7b4ciq
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq
-- valory/task_submission_abci:0.1.0:bafybeiblfzy23r3bgcfdceeoilz2fiqscdyrer3b2xewctq77tlnkja5fa
+- valory/task_execution:0.1.0:bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy
+- valory/task_submission_abci:0.1.0:bafybeibdegmyw2pq54byeac7izj7vcm6egzhj6d72di7s3xdt3pfmai22i
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeib33ygqjlxsw4sl7t56zdlsui6kukk2wz6gspddrof2c3pjeisyem
+- valory/mech_abci:0.1.0:bafybeibbtfds4fe7whywgewsvd7q4m5zdr3r7tzcjjcviht7vy3i7abiwa
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeib4ca677b4fbvtcf2zpfxjr7aob55qeuo7hhqjeenvhfs7ob7cujq
-- valory/task_submission_abci:0.1.0:bafybeie4gnqfzbizxqgpn56qgqkw76z23cj3kuued2dsysoampe7s4y5ou
+- valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
+- valory/task_submission_abci:0.1.0:bafybeicpoimeoh7onez3vcjounzov63zjz4sm6ppzysdowhf5beyhqcodi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigfhqxcb2qmureyq2h637kaqs6rksnlhexkpwjzfocsxqwsp35r4m
+- valory/mech_abci:0.1.0:bafybeicreimiiyr6dtvhyacf2625345sczcj54rsv7a7vjrh6whepd3cta
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm
-- valory/task_submission_abci:0.1.0:bafybeicaznkgq6sovmebykhzrdwswvbkgvksxrrpzjs2qso5watx3n74wy
+- valory/task_execution:0.1.0:bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq
+- valory/task_submission_abci:0.1.0:bafybeiesfrw6tmn6h7kbql3mcpejbpf3rsr2j3wohkakkeozebvf2oxyvi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiatxn2wb7pasde63hi4cghzoxzr6thj2xe3zwllr54f4kjx7b4ciq
+- valory/mech_abci:0.1.0:bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy
-- valory/task_submission_abci:0.1.0:bafybeibdegmyw2pq54byeac7izj7vcm6egzhj6d72di7s3xdt3pfmai22i
+- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
+- valory/task_submission_abci:0.1.0:bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeibbtfds4fe7whywgewsvd7q4m5zdr3r7tzcjjcviht7vy3i7abiwa
+- valory/mech_abci:0.1.0:bafybeiazxfadofj5ztzhw4d5i2tpf2cmqvhnys3ohpie5vqug4ze25p77a
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
 - valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
-- valory/task_submission_abci:0.1.0:bafybeicpoimeoh7onez3vcjounzov63zjz4sm6ppzysdowhf5beyhqcodi
+- valory/task_submission_abci:0.1.0:bafybeiehicmh2mg77ysphvo3ox7yc2g34lx3cstj2tbsjrqjwt7otcapm4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeifgqseomidt5l2u5s5lsjm6piuadx7ohlkpmvabudg6nxbilqptzy
+- valory/mech_abci:0.1.0:bafybeigfhqxcb2qmureyq2h637kaqs6rksnlhexkpwjzfocsxqwsp35r4m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
-- valory/task_submission_abci:0.1.0:bafybeicjnwilfpsg4oolysfdc2klexzegx4czg5d5hpwebl5hq7zieduma
+- valory/task_execution:0.1.0:bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm
+- valory/task_submission_abci:0.1.0:bafybeicaznkgq6sovmebykhzrdwswvbkgvksxrrpzjs2qso5watx3n74wy
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicreimiiyr6dtvhyacf2625345sczcj54rsv7a7vjrh6whepd3cta
+- valory/mech_abci:0.1.0:bafybeigvomrayvkwvativspmvgwdveqiqyndqlteluv235jigd6xgrdlsa
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq
-- valory/task_submission_abci:0.1.0:bafybeiesfrw6tmn6h7kbql3mcpejbpf3rsr2j3wohkakkeozebvf2oxyvi
+- valory/task_execution:0.1.0:bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq
+- valory/task_submission_abci:0.1.0:bafybeiblfzy23r3bgcfdceeoilz2fiqscdyrer3b2xewctq77tlnkja5fa
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidcprl2mj4iuwvqznru67ndtcqndelg7bg77xk2aehkld4azpl2w4
+agent: valory/mech:0.1.0:bafybeifg32fr5cf7enk2owgtjyn7rdr5o6goinfdgmsg2lod5amhu6dfjy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiawl7wpiecxaax3ruawcttvbuukuplte4ifhx4ychy5q57playxza
+agent: valory/mech:0.1.0:bafybeichnpuvhvq6f2czhz2vj5eynjgemgaxfs2qnwcidhy5munaxepr5e
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiaifr5ya4najolwr7zdtdwmz4q4ejfhtvkafn35big7kambo7ljmq
+agent: valory/mech:0.1.0:bafybeidcprl2mj4iuwvqznru67ndtcqndelg7bg77xk2aehkld4azpl2w4
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeibh3eg4iicpje3v4vexudoxvh55wndjw2pwo7aufibhferybclbtm
+agent: valory/mech:0.1.0:bafybeiaifr5ya4najolwr7zdtdwmz4q4ejfhtvkafn35big7kambo7ljmq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigmprmqsw4rga2yx4xjouysasyreym52lwl2ol7of7zou7wai3mju
+agent: valory/mech:0.1.0:bafybeiawl7wpiecxaax3ruawcttvbuukuplte4ifhx4ychy5q57playxza
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeifg32fr5cf7enk2owgtjyn7rdr5o6goinfdgmsg2lod5amhu6dfjy
+agent: valory/mech:0.1.0:bafybeidos57xj77zosblpmu2hsxkhczvotjwyxw2gwzhlumh3r6y7cyyxa
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeichnpuvhvq6f2czhz2vj5eynjgemgaxfs2qnwcidhy5munaxepr5e
+agent: valory/mech:0.1.0:bafybeibh3eg4iicpje3v4vexudoxvh55wndjw2pwo7aufibhferybclbtm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidos57xj77zosblpmu2hsxkhczvotjwyxw2gwzhlumh3r6y7cyyxa
+agent: valory/mech:0.1.0:bafybeiab7emnojt4uglfdpk7x6x26wmnqs5azf7favs7qw3o3yebmkydxa
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/composition.py
+++ b/packages/valory/skills/mech_abci/composition.py
@@ -45,9 +45,9 @@ abci_app_transition_mapping: AbciAppTransitionMapping = {
     TaskSubmissionAbciApp.FinishedTaskExecutionWithErrorRound: ResetAndPauseAbci.ResetAndPauseRound,
     TaskSubmissionAbciApp.FinishedWithoutTasksRound: ResetAndPauseAbci.ResetAndPauseRound,
     # Settlement-confirmed path runs through the new PostTxSettlement
-    # round so the wildcard data-lake POST fires once per settled FSM
+    # round so the predict-api data lake POST fires once per settled FSM
     # round; the round itself is fail-soft (always advances on DONE)
-    # so a wildcard outage does not stall the loop.
+    # so a predict-api outage does not stall the loop.
     TransactionSubmissionAbciApp.FinishedTransactionSubmissionRound: TaskSubmissionAbciApp.PostTxSettlementRound,  # pylint: disable=C0301
     TaskSubmissionAbciApp.FinishedPostTxSettlementRound: ResetAndPauseAbci.ResetAndPauseRound,
     TransactionSubmissionAbciApp.FailedRound: ResetAndPauseAbci.ResetAndPauseRound,

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiblfzy23r3bgcfdceeoilz2fiqscdyrer3b2xewctq77tlnkja5fa
+- valory/task_submission_abci:0.1.0:bafybeibdegmyw2pq54byeac7izj7vcm6egzhj6d72di7s3xdt3pfmai22i
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq
+- valory/task_execution:0.1.0:bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,7 +30,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeicpoimeoh7onez3vcjounzov63zjz4sm6ppzysdowhf5beyhqcodi
+- valory/task_submission_abci:0.1.0:bafybeiehicmh2mg77ysphvo3ox7yc2g34lx3cstj2tbsjrqjwt7otcapm4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeigawvaywwgbr4fhxir2fpwze3wp7pctvwtp5gpkjritknqoecxfz4
   behaviours.py: bafybeibnqxq3le55hn3s3wdlf7wwyzn5y3df4ta5d3ikdb53ypfbl5myjq
-  composition.py: bafybeiaag6c436uiprfmn7lm3f3ukmpezd47yqpd5b74dsu4w3wcmqhcrm
+  composition.py: bafybeibc73befd2eiwf2hvzct7ayse6dqutru6vddnzuk5swpi2ncjdrpe
   dialogues.py: bafybeigph4dbt75rpfjoxp5zzplb4m5izwblbpt6qssnrvvl2joj6o5cke
   fsm_specification.yaml: bafybeih2b72kr7avbrmduezvbjfpo32h6w3mcucy44ri2aox5m6q6iae6q
   handlers.py: bafybeihnzh6rkrsn6xvmio4c3borzothkj5u62qcbjnzr5gt6hcy6iudsu
@@ -16,7 +16,7 @@ fingerprint:
   tests/__init__.py: bafybeicswkogdqefhafjpbl2afcwtruegtmkumlk5mbapauys2od7rt7di
   tests/conftest.py: bafybeiaqouyzclh4wvnf36jgcmgzm7k4snfghnm3v4yowb4pomyn6qvezu
   tests/test_behaviours.py: bafybeibjw3tusfxxmr3byy6sdmu7gefotya4xvhd7ia43ll7fgyqggx7ye
-  tests/test_composition.py: bafybeifjx57plcn3zg2xb3nlnhxukcnxmnapv7ynxai2wiqbdmg46fgiye
+  tests/test_composition.py: bafybeihrzdjr7w4dght6bhstcni4zswp4rzgzkgx5bpx4lcesh46h6noqm
   tests/test_dialogues.py: bafybeiaicu6h4d3rppxbjhkifwlrfpjmxd6y4sdqnlskdjqijkct2tvhci
   tests/test_handlers.py: bafybeicekjso4qfxaiqpaapgosxkvr4tbce6evnxguhzunug4subrikgci
   tests/test_models.py: bafybeif4iuuknrtx3tc72y2ii237dqtl6nlqgpdywy227sfqbvxkk6mugy
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeie4gnqfzbizxqgpn56qgqkw76z23cj3kuued2dsysoampe7s4y5ou
+- valory/task_submission_abci:0.1.0:bafybeicpoimeoh7onez3vcjounzov63zjz4sm6ppzysdowhf5beyhqcodi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeib4ca677b4fbvtcf2zpfxjr7aob55qeuo7hhqjeenvhfs7ob7cujq
+- valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
 behaviours:
   main:
     args: {}
@@ -171,9 +171,9 @@ models:
       tools_to_pricing: {}
       service_endpoint_base: https://dummy_service.autonolas.tech/
       default_chain_id: gnosis
-      mech_events_enabled: false
-      wildcard_events_url: ''
-      wildcard_events_timeout_seconds: 5.0
+      use_offchain: false
+      predict_api_events_url: https://mpp.autonolas.tech/mech/events
+      predict_api_events_timeout_seconds: 5.0
       mech_events_sweep_pending_enabled: false
       mech_events_sweep_max_age_seconds: 3600.0
       mech_events_chain_id: 0

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,7 +30,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiehicmh2mg77ysphvo3ox7yc2g34lx3cstj2tbsjrqjwt7otcapm4
+- valory/task_submission_abci:0.1.0:bafybeicjnwilfpsg4oolysfdc2klexzegx4czg5d5hpwebl5hq7zieduma
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeicjnwilfpsg4oolysfdc2klexzegx4czg5d5hpwebl5hq7zieduma
+- valory/task_submission_abci:0.1.0:bafybeicaznkgq6sovmebykhzrdwswvbkgvksxrrpzjs2qso5watx3n74wy
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
+- valory/task_execution:0.1.0:bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeibdegmyw2pq54byeac7izj7vcm6egzhj6d72di7s3xdt3pfmai22i
+- valory/task_submission_abci:0.1.0:bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy
+- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiesfrw6tmn6h7kbql3mcpejbpf3rsr2j3wohkakkeozebvf2oxyvi
+- valory/task_submission_abci:0.1.0:bafybeiblfzy23r3bgcfdceeoilz2fiqscdyrer3b2xewctq77tlnkja5fa
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq
+- valory/task_execution:0.1.0:bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeicaznkgq6sovmebykhzrdwswvbkgvksxrrpzjs2qso5watx3n74wy
+- valory/task_submission_abci:0.1.0:bafybeiesfrw6tmn6h7kbql3mcpejbpf3rsr2j3wohkakkeozebvf2oxyvi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm
+- valory/task_execution:0.1.0:bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/tests/test_composition.py
+++ b/packages/valory/skills/mech_abci/tests/test_composition.py
@@ -87,7 +87,7 @@ class TestAbciAppTransitionMapping:
     ) -> None:
         """Successful settlement now lands in PostTxSettlementRound first.
 
-        The round fires the wildcard data-lake POST and then advances to
+        The round fires the predict-api data lake POST and then advances to
         ResetAndPauseRound via its own FinishedPostTxSettlementRound exit.
         The two-edge wiring keeps the settlement→reset path intact while
         slotting in the analytics-write side effect.

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1553,7 +1553,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # for the paid HTTP path, ``mech_onchain`` for the on-chain rails.
         # See ``autonolas-marketplace/docs/onchain_write_path_scope.md`` for
         # the agreed shape.
-        predict_api_mode_enabled = getattr(self.params, "use_offchain", False)
+        predict_api_mode_enabled = self.params.use_offchain
         is_marketplace_delivery = bool(done_task.get("is_marketplace_mech"))
         if predict_api_mode_enabled and (is_offchain or is_marketplace_delivery):
             done_task["predict_api_event"] = self._build_predict_api_event(

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -103,7 +103,7 @@ def _iso_z(dt: datetime) -> str:
 
     Normalises through ``astimezone(timezone.utc)`` so a datetime with any
     UTC offset (``+00:00``, ``+05:30``, ``-08:00``) emits the same canonical
-    string for the same wall-clock instant. The wildcard server's Pydantic
+    string for the same wall-clock instant. The predict-api server's Pydantic
     ``AwareDatetime`` round-trips through ``model_dump(mode="json")`` which
     emits ``...Z`` for UTC; the mech's ``batch_hash`` recompute on the
     server side compares byte-for-byte against ours, so leaving the offset
@@ -127,10 +127,10 @@ def _iso_z(dt: datetime) -> str:
 
 
 # Cap on the JSON-serialised size of each ``raw_content`` blob attached to
-# a wildcard event. The blob rides Tendermint consensus replication into
+# a predict-api event. The blob rides Tendermint consensus replication into
 # ``synchronized_data`` on every agent and the field is requester-influenced
 # (``params``, ``model``, response body), so an uncapped large payload would
-# inflate per-node state. 256 KiB matches the wildcard server's ``_MAX_TEXT``
+# inflate per-node state. 256 KiB matches the predict-api server's ``_MAX_TEXT``
 # cap on individual TEXT columns; the analytics ETL drops the row to a
 # truncated sentinel when the cap is hit so the rest of the event still
 # lands.
@@ -1533,30 +1533,30 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # pop the data key value as it's bytes which causes issues
         # with json dumps and not required anywhere
         done_task.pop("data", None)
-        # Attach the offchain wildcard-event payload before the
+        # Attach the offchain predict-api event payload before the
         # IN_MEMORY_REQUESTS pop below; the post-settlement behaviour in
         # task_submission_abci reads it off ``synchronized_data.done_tasks``
-        # (i.e. after consensus replication) and posts it to the wildcard
+        # (i.e. after consensus replication) and posts it to the predict-api
         # data lake, but the buffered request metadata it needs is local
         # to this agent's shared_state and goes away at the pop.
         #
-        # Gated on BOTH ``is_offchain`` AND the ``mech_events_enabled`` flag
+        # Gated on BOTH ``is_offchain`` AND the ``use_offchain`` flag
         # so Phase 1 is genuinely dark: when the flag is off, no payload is
         # built and nothing rides Tendermint consensus replication. The flag
         # check lives here as well as in the post-settlement behaviour so
         # the consensus-state cost is gated, not just the HTTP write.
-        # Build the wildcard event for both off-chain HTTP deliveries
+        # Build the predict-api event for both off-chain HTTP deliveries
         # (is_offchain=True) and on-chain marketplace deliveries
         # (is_offchain=False AND is_marketplace_mech). The ``source`` field
-        # on the event (set by ``_build_wildcard_event``) is what
-        # disambiguates the two paths on the wildcard side: ``mech_offchain``
+        # on the event (set by ``_build_predict_api_event``) is what
+        # disambiguates the two paths on the predict-api side: ``mech_offchain``
         # for the paid HTTP path, ``mech_onchain`` for the on-chain rails.
         # See ``autonolas-marketplace/docs/onchain_write_path_scope.md`` for
         # the agreed shape.
-        wildcard_mode_enabled = getattr(self.params, "mech_events_enabled", False)
+        predict_api_mode_enabled = getattr(self.params, "use_offchain", False)
         is_marketplace_delivery = bool(done_task.get("is_marketplace_mech"))
-        if wildcard_mode_enabled and (is_offchain or is_marketplace_delivery):
-            done_task["wildcard_event"] = self._build_wildcard_event(
+        if predict_api_mode_enabled and (is_offchain or is_marketplace_delivery):
+            done_task["predict_api_event"] = self._build_predict_api_event(
                 done_task=done_task,
                 cid=cid,
                 executing_task=cast(Dict[str, Any], executing_task),
@@ -1571,29 +1571,29 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(req_id, None)
         self._reset_executing_task()
 
-    def _build_wildcard_event(
+    def _build_predict_api_event(
         self,
         *,
         done_task: Dict[str, Any],
         cid: str,
         executing_task: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Build the structured wildcard-event payload from on-hand data.
+        """Build the structured predict-api event payload from on-hand data.
 
         The post-settlement behaviour batches every event from one FSM round
-        into a single signed POST to the wildcard data lake. Fields are
+        into a single signed POST to the predict-api data lake. Fields are
         populated best-effort from the buffered request metadata
         (``IN_MEMORY_REQUESTS``), the offchain response
         (``OFFCHAIN_REQUEST_RESPONSES``), the in-flight ``executing_task``,
         and skill params. Optional fields that aren't readily available are
-        left ``None``; the wildcard server accepts a NULL there. Required
+        left ``None``; the predict-api server accepts a NULL there. Required
         fields default to safe placeholders rather than blocking the row: a
-        malformed event surfaces as a 422 when the wildcard write fires (and
+        malformed event surfaces as a 422 when the predict-api write fires (and
         lands in the local replay buffer so it's recoverable), which is
         preferable to silently dropping analytics data.
 
         Datetimes are emitted as ISO 8601 strings with UTC offset so the
-        wildcard ``AwareDatetime`` parser accepts them; mech ints (Unix
+        predict-api ``AwareDatetime`` parser accepts them; mech ints (Unix
         seconds) are converted here so the structured event can ride the
         FSM consensus channel without round-tripping through a custom
         codec.
@@ -1654,15 +1654,15 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         delivery_mech = str(
             done_task.get("mech_address") or self.params.mech_marketplace_address or ""
         )
-        # Wildcard ``source`` derives from the per-task ``is_offchain``
+        # The predict-api ``source`` derives from the per-task ``is_offchain``
         # flag: True → ``mech_offchain`` (paid HTTP path); False →
         # ``mech_onchain`` (the on-chain marketplace rails). This is the
-        # only field that disambiguates the two paths on the wildcard
+        # only field that disambiguates the two paths on the predict-api
         # side; the per-row ``is_offchain`` boolean stays on the
         # response payload as well (the lake keeps both because the
         # ipfs_historical backfill describes either path).
         is_offchain_task = bool(executing_task.get("is_offchain", False))
-        wildcard_source = "mech_offchain" if is_offchain_task else "mech_onchain"
+        predict_api_source = "mech_offchain" if is_offchain_task else "mech_onchain"
 
         # `start_time` is a perf_counter() value (monotonic, not wall-clock),
         # not suitable as a delivered_at timestamp. Use the current wall-clock
@@ -1698,7 +1698,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # the executed_at on the response so the time-leading index entry is
         # always populated for an offchain row. The requester can store the
         # value as a Unix int or as an ISO 8601 string — ``str(int)`` would
-        # produce ``"1700000000"`` which the wildcard's ``AwareDatetime``
+        # produce ``"1700000000"`` which the predict-api's ``AwareDatetime``
         # parser rejects with a 422, so coerce int / float explicitly.
         requested_at_raw = request_data.get("datetime") or request_data.get(
             "requested_at"
@@ -1772,7 +1772,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             nonce_int = int(nonce_raw) if nonce_raw is not None else None
         except (TypeError, ValueError):
             nonce_int = None
-        # The wildcard server requires ``prompt`` to be a non-empty string;
+        # The predict-api server requires ``prompt`` to be a non-empty string;
         # placeholder rather than dropping the row. Enforce the cap on the
         # UTF-8 BYTE length, not on ``len()`` (code points) — a CJK prompt
         # of 50k code points encodes to ~150 KB and would otherwise sail
@@ -1788,11 +1788,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # Failed-row ``error`` carries the available diagnostic, regardless
         # of which branch put us on the failed arm. When ``invalid`` is set
         # but no ``result_text`` is available (the tool produced no
-        # response object), the field is ``None``; the wildcard server's
+        # response object), the field is ``None``; the predict-api server's
         # CHECK allows a ``failed`` row with empty error so the row still
         # lands as a settled failure.
         error_text = str(result_text) if status == "failed" and result_text else None
-        # Strip the result from the failed arm so the wildcard's
+        # Strip the result from the failed arm so the predict-api's
         # status/error/result shape CHECK accepts the row.
         result_value: Optional[str] = (
             None if status == "failed" else (str(result_text) if result_text else "")
@@ -1819,7 +1819,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 # which keys the requester as ``requester`` and carries no
                 # ``sender`` field. This block now runs for on-chain
                 # marketplace deliveries too, so falling back to
-                # ``requester`` keeps the wildcard row correctly populated
+                # ``requester`` keeps the predict-api row correctly populated
                 # instead of writing an empty ``requester``.
                 "requester": str(
                     executing_task.get("sender")
@@ -1878,7 +1878,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "response_cid": None,
                 "delivered_at": now_iso,
             },
-            "source": wildcard_source,
+            "source": predict_api_source,
         }
 
     def _reset_executing_task(self) -> None:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1540,18 +1540,23 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # data lake, but the buffered request metadata it needs is local
         # to this agent's shared_state and goes away at the pop.
         #
-        # Gated on BOTH ``is_offchain`` AND the ``use_offchain`` flag
-        # so Phase 1 is genuinely dark: when the flag is off, no payload is
-        # built and nothing rides Tendermint consensus replication. The flag
-        # check lives here as well as in the post-settlement behaviour so
-        # the consensus-state cost is gated, not just the HTTP write.
-        # Build the predict-api event for both off-chain HTTP deliveries
-        # (is_offchain=True) and on-chain marketplace deliveries
-        # (is_offchain=False AND is_marketplace_mech). The ``source`` field
-        # on the event (set by ``_build_predict_api_event``) is what
-        # disambiguates the two paths on the predict-api side: ``mech_offchain``
-        # for the paid HTTP path, ``mech_onchain`` for the on-chain rails.
-        # See ``autonolas-marketplace/docs/onchain_write_path_scope.md`` for
+        # Gate the whole event build on ``use_offchain``. When the flag
+        # is off, no payload is built and nothing rides Tendermint
+        # consensus replication — so the ingress-side consensus cost
+        # matches the egress-side HTTP write cost (nothing on either
+        # side). The paired gate in
+        # :py:meth:`task_submission_abci.behaviours.PostTxSettlementBehaviour._do_predict_api_write_best_effort`
+        # additionally warns if it receives events under a locally-off
+        # flag, so a config drift between the two skill copies of
+        # ``use_offchain`` is alertable rather than silent.
+        # Build the event for both off-chain HTTP deliveries
+        # (``is_offchain=True``) and on-chain marketplace deliveries
+        # (``is_offchain=False`` AND ``is_marketplace_delivery=True``).
+        # The ``source`` field on the event (set by
+        # ``_build_predict_api_event``) disambiguates the two paths on
+        # the predict-api side: ``mech_offchain`` for the paid HTTP path,
+        # ``mech_onchain`` for the on-chain rails. See
+        # ``autonolas-marketplace/docs/onchain_write_path_scope.md`` for
         # the agreed shape.
         predict_api_mode_enabled = self.params.use_offchain
         is_marketplace_delivery = bool(done_task.get("is_marketplace_mech"))

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -469,7 +469,7 @@ class ContractHandler(BaseHandler):
                 # The contract's RequestInfo.responseTimeout is the
                 # authoritative timeout; this local stamp is the proxy the
                 # mech uses to decide when to emit a request-only event
-                # to the wildcard data lake. See
+                # to the predict-api data lake. See
                 # ``autonolas-marketplace/docs/onchain_write_path_scope.md``
                 # §3.2 for the design.
                 req.setdefault("enqueued_at_local", time.time())

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -114,23 +114,16 @@ class Params(Model):
         )
         self.offchain_tx_list: List = list()
         self.default_chain_id: str = self._ensure_get("default_chain_id", kwargs, str)
-        # EIP-155 integer chain id for the wildcard data-lake write and the
+        # EIP-155 integer chain id for the predict-api data lake write and the
         # EIP-712 domain. Separate from ``default_chain_id`` (the AEA alias
-        # ``"gnosis"``) because the wildcard schema and the EIP-712 domain
+        # ``"gnosis"``) because the predict-api schema and the EIP-712 domain
         # bind to the integer, and converting at the boundary via a
         # hardcoded alias→int table couples task_execution to a chain
         # registry it has no other reason to know about. Defaults to 0,
-        # which fails the wildcard server's per-chain marketplace
+        # which fails the predict-api server's per-chain marketplace
         # allowlist on first POST — operator-friendly: the row is rejected
         # at a known boundary rather than silently mis-tagged.
         self.mech_events_chain_id: int = int(kwargs.get("mech_events_chain_id", 0) or 0)
-        # Feature flag for the wildcard analytics write path, mirrored from
-        # task_submission_abci so the build cost at finalize is also gated:
-        # when False (Phase 1 default) ``_finalize_done_task`` skips the
-        # ``_build_wildcard_event`` call entirely so nothing rides Tendermint
-        # consensus replication. Must agree with the task_submission_abci
-        # value across the deployment.
-        self.mech_events_enabled: bool = bool(kwargs.get("mech_events_enabled", False))
         self.gnosis_ledger_rpc: str = kwargs.get("gnosis_ledger_rpc", "")
         self.polygon_ledger_rpc: str = kwargs.get("polygon_ledger_rpc", "")
         self.base_ledger_rpc: str = kwargs.get("base_ledger_rpc", "")
@@ -143,9 +136,13 @@ class Params(Model):
             key.lower(): value
             for key, value in kwargs.get("payment_type_to_asset_address", {}).items()
         }
-        # Phase 1 ships dark: the offchain HTTP path is disabled by default and
-        # enabled per deployment in the Phase 2 rollout. False = today's
-        # on-chain + IPFS behaviour, unchanged.
+        # Dual-purpose gate: controls BOTH offchain-request ingress AND
+        # egress to the predict-api events endpoint (settlement writes for
+        # both offchain-settled AND on-chain-settled requests). A mech is
+        # either part of the predict-api analytics pipeline or it isn't;
+        # there's no coherent state where ingress and egress diverge.
+        # Default False = on-chain + IPFS only, no analytics writes,
+        # unchanged for legacy deployments. Set True to enrol the mech.
         self.use_offchain: bool = kwargs.get("use_offchain", False)
         # Off-chain preimage retention. Ships dark like use_offchain: False keeps
         # today's behaviour (no durable preimage buffer). When enabled, each

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -143,7 +143,7 @@ class Params(Model):
         # there's no coherent state where ingress and egress diverge.
         # Default False = on-chain + IPFS only, no analytics writes,
         # unchanged for legacy deployments. Set True to enrol the mech.
-        self.use_offchain: bool = kwargs.get("use_offchain", False)
+        self.use_offchain: bool = bool(kwargs.get("use_offchain", False))
         # Off-chain preimage retention. Ships dark like use_offchain: False keeps
         # today's behaviour (no durable preimage buffer). When enabled, each
         # off-chain (request, response) pair is mirrored into the kv_store and a

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -140,7 +140,14 @@ class Params(Model):
         # egress to the predict-api events endpoint (settlement writes for
         # both offchain-settled AND on-chain-settled requests). A mech is
         # either part of the predict-api analytics pipeline or it isn't;
-        # there's no coherent state where ingress and egress diverge.
+        # the coupling is deliberate. On-chain-only mechs that want
+        # analytics writes (``mech_onchain`` source) still flip this on
+        # and accept that their offchain HTTP handler is also live — the
+        # handler is inert if no client's ``MECH_OFFCHAIN_URL`` points
+        # at it, so the cost is a wire nothing rides rather than a
+        # traffic-shape change. If an operator genuinely wants analytics
+        # without ingress, that's a re-split of this flag and needs its
+        # own review round, not an env override on the current shape.
         # Default False = on-chain + IPFS only, no analytics writes,
         # unchanged for legacy deployments. Set True to enrol the mech.
         self.use_offchain: bool = bool(kwargs.get("use_offchain", False))

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -143,8 +143,8 @@ class Params(Model):
         # the coupling is deliberate. On-chain-only mechs that want
         # analytics writes (``mech_onchain`` source) still flip this on
         # and accept that their offchain HTTP handler is also live — the
-        # handler is inert if no client's ``MECH_OFFCHAIN_URL`` points
-        # at it, so the cost is a wire nothing rides rather than a
+        # handler is inert unless a client actually sends offchain requests
+        # to it, so the cost is a wire nothing rides rather than a
         # traffic-shape change. If an operator genuinely wants analytics
         # without ingress, that's a re-split of this flag and needs its
         # own review round, not an env override on the current shape.

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   models.py: bafybeih3es32osrundnhoguzursbc4zfde7qa27zmrkepdud24jffmrycy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeid4lqan22icsja5cslnwaxtiazu27bwgyjkdthkxozrr4mcziji4m
+  tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeibacvq3lfffzifh4gnagcrwpunbcpxlayay3koqfn4x32acqqosdq
+  behaviours.py: bafybeif7ontnnq6dxlvba3r523oivgxw7aj2bcn6rvnlyq3gibrafzi3ce
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeih6bh6mxxxvi2fs4dgvgmw4ovvwmwh7r57u7nuzqdv5q4unvggc2i
-  models.py: bafybeifztz5yjgefe52ebu4pfnr72rovx55pp77l2dzr3636o4qfl5x2ie
+  models.py: bafybeibidbtpijvb7lapn6dymrw3moj53xq64rx3e4nxzk2go2oyz7kpbi
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeibakesf2zd24qlfsiv7yiki2ib4dwmersdn3mlsjuagklikvw6bk4
+  tests/test_behaviours.py: bafybeibsk7avvvcdigatu6ztzxxmpzyof2g6cgezl2whkgwhzhylmzaj4y
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,10 +7,10 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeif7ontnnq6dxlvba3r523oivgxw7aj2bcn6rvnlyq3gibrafzi3ce
+  behaviours.py: bafybeihatg4ggqhrimoqbbgghiq7fbnenjbmgc6osxswplcingk3kg5bjm
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeih6bh6mxxxvi2fs4dgvgmw4ovvwmwh7r57u7nuzqdv5q4unvggc2i
-  models.py: bafybeibidbtpijvb7lapn6dymrw3moj53xq64rx3e4nxzk2go2oyz7kpbi
+  models.py: bafybeih3es32osrundnhoguzursbc4zfde7qa27zmrkepdud24jffmrycy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeid4lqan22icsja5cslnwaxtiazu27bwgyjkdthkxozrr4mcziji4m

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   models.py: bafybeibidbtpijvb7lapn6dymrw3moj53xq64rx3e4nxzk2go2oyz7kpbi
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeibsk7avvvcdigatu6ztzxxmpzyof2g6cgezl2whkgwhzhylmzaj4y
+  tests/test_behaviours.py: bafybeid4lqan22icsja5cslnwaxtiazu27bwgyjkdthkxozrr4mcziji4m
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -10,7 +10,7 @@ fingerprint:
   behaviours.py: bafybeihatg4ggqhrimoqbbgghiq7fbnenjbmgc6osxswplcingk3kg5bjm
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeih6bh6mxxxvi2fs4dgvgmw4ovvwmwh7r57u7nuzqdv5q4unvggc2i
-  models.py: bafybeih3es32osrundnhoguzursbc4zfde7qa27zmrkepdud24jffmrycy
+  models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifg7hk64avhvsdtlf63lzunhrsoijxovtdb7bxq2wz5ymojxlm23a
+  behaviours.py: bafybeibacvq3lfffzifh4gnagcrwpunbcpxlayay3koqfn4x32acqqosdq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeicj6x3dsm4bk25n4n3pxmm6ioturmopztqfywcehaajjfcawcr4hm
-  models.py: bafybeieuhchssbazb4f3nnvjex6trifp4kxse4lh6ihenmeemq36zhws7i
+  handlers.py: bafybeih6bh6mxxxvi2fs4dgvgmw4ovvwmwh7r57u7nuzqdv5q4unvggc2i
+  models.py: bafybeifztz5yjgefe52ebu4pfnr72rovx55pp77l2dzr3636o4qfl5x2ie
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeib5ivnfbc7unufy5jde3hv7wvzrgpj7e7pz2ulj25kfjqqdu4gmti
+  tests/test_behaviours.py: bafybeibakesf2zd24qlfsiv7yiki2ib4dwmersdn3mlsjuagklikvw6bk4
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
@@ -114,7 +114,6 @@ models:
       use_offchain: false
       default_chain_id: gnosis
       mech_events_chain_id: 0
-      mech_events_enabled: false
       gnosis_ledger_rpc: http://localhost:8545
       polygon_ledger_rpc: http://localhost:8545
       base_ledger_rpc: http://localhost:8545

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3531,7 +3531,7 @@ def _finalize_gate_setup(
     lets it. ``to_multihash`` is monkeypatched to a cheap prefix so
     ``_finalize_done_task`` doesn't try to run the real multihash logic.
 
-    :param behaviour: FetchDataBehaviour fixture.
+    :param behaviour: TaskExecutionBehaviour fixture.
     :param shared_state: shared_state fixture.
     :param params_stub: params fixture.
     :param monkeypatch: pytest monkeypatch fixture used to swap
@@ -3591,7 +3591,7 @@ def test_finalize_done_task_attaches_predict_api_event_when_use_offchain_on(
     behaviour then reads off ``synchronized_data.done_tasks`` after
     consensus replication.
 
-    :param behaviour: FetchDataBehaviour fixture.
+    :param behaviour: TaskExecutionBehaviour fixture.
     :param params_stub: params fixture with ``use_offchain=True``.
     :param shared_state: shared_state fixture.
     :param monkeypatch: pytest monkeypatch fixture.
@@ -3625,7 +3625,7 @@ def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
     ``source='mech_onchain'``. Regression against a docstring drift
     that was suggesting the condition was marketplace-only.
 
-    :param behaviour: FetchDataBehaviour fixture.
+    :param behaviour: TaskExecutionBehaviour fixture.
     :param params_stub: params fixture with ``use_offchain=True``.
     :param shared_state: shared_state fixture.
     :param monkeypatch: pytest monkeypatch fixture.
@@ -3658,7 +3658,7 @@ def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(
     when the flag is off. Pairs with the egress-side gate test in
     ``task_submission_abci/tests/test_onchain_write_path.py``.
 
-    :param behaviour: FetchDataBehaviour fixture.
+    :param behaviour: TaskExecutionBehaviour fixture.
     :param params_stub: params fixture, flipped to ``use_offchain=False`` here.
     :param shared_state: shared_state fixture.
     :param monkeypatch: pytest monkeypatch fixture.

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3500,3 +3500,179 @@ def test_build_predict_api_event_marketplace_task_falls_back_to_requester_key(
     )
     assert event["request"]["requester"] == "0xMARKETPLACE_REQUESTER"
     assert event["source"] == "mech_onchain"
+
+
+# ---------------------------------------------------------------------------
+# _finalize_done_task ingress gate: use_offchain drives predict_api_event
+# attach vs skip. Direct-call tests on _build_predict_api_event above pass
+# the builder inputs by hand and never traverse the gate, so a flag flip
+# would go uncaught. These pair the gate on/off with an offchain and a
+# marketplace-onchain shape to pin the exact condition
+# (use_offchain AND (is_offchain OR is_marketplace_delivery)).
+# ---------------------------------------------------------------------------
+
+
+def _finalize_gate_setup(
+    behaviour: Any,
+    shared_state: Dict[str, Any],
+    params_stub: Any,
+    monkeypatch: Any,
+    *,
+    is_offchain: bool,
+    is_marketplace_mech: bool,
+    req_id: str = "req-gate",
+) -> None:
+    """Wire the minimum ``behaviour`` state for a ``_finalize_done_task`` call.
+
+    Seeds ``_executing_task`` / ``_done_task`` in the same shape the
+    happy-path ``_handle_store_response`` test does, plus
+    ``IN_MEMORY_REQUESTS`` / ``OFFCHAIN_REQUEST_RESPONSES`` so
+    ``_build_predict_api_event`` can produce a real event when the gate
+    lets it. ``to_multihash`` is monkeypatched to a cheap prefix so
+    ``_finalize_done_task`` doesn't try to run the real multihash logic.
+
+    :param behaviour: FetchDataBehaviour fixture.
+    :param shared_state: shared_state fixture.
+    :param params_stub: params fixture.
+    :param monkeypatch: pytest monkeypatch fixture used to swap
+        ``to_multihash`` and ``set_gauge``.
+    :param is_offchain: value stamped on both the executing_task and
+        the done_task; drives the ``is_offchain`` branch of the gate.
+    :param is_marketplace_mech: value on the ``mech_to_config`` entry;
+        drives the ``is_marketplace_delivery`` branch of the gate.
+    :param req_id: request id used across the seeded structures.
+    """
+    request_data = {
+        "prompt": "gate-check",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    response_data = {
+        "result": "p_yes=0.7",
+        "schema_version": "2.0",
+        "executed_at": "2026-06-25T13:19:06.953661Z",
+    }
+    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {req_id: json.dumps(request_data)}
+    shared_state.setdefault(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})[req_id] = {
+        "response": response_data
+    }
+    my_mech = params_stub.agent_mech_contract_address.lower()
+    params_stub.mech_to_config = {
+        my_mech: SimpleNamespace(
+            is_marketplace_mech=is_marketplace_mech,
+            use_dynamic_pricing=False,
+        )
+    }
+    behaviour._executing_task = {
+        "requestId": req_id,
+        "request_delivery_rate": 10**16,
+        "is_offchain": is_offchain,
+        "sender": "0xrequester",
+    }
+    behaviour._done_task = {
+        "request_id": req_id,
+        "is_offchain": is_offchain,
+        "tool": "prediction-offline",
+        "mech_address": my_mech,
+    }
+    monkeypatch.setattr(beh_mod, "to_multihash", lambda x: f"mh:{x}")
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+
+
+def test_finalize_done_task_attaches_predict_api_event_when_use_offchain_on(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """``use_offchain=True`` + off-chain HTTP delivery: event attached to done_task.
+
+    Pins the ingress-side gate on. This is the shape the post-settlement
+    behaviour then reads off ``synchronized_data.done_tasks`` after
+    consensus replication.
+
+    :param behaviour: FetchDataBehaviour fixture.
+    :param params_stub: params fixture with ``use_offchain=True``.
+    :param shared_state: shared_state fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    params_stub.use_offchain = True
+    _finalize_gate_setup(
+        behaviour,
+        shared_state,
+        params_stub,
+        monkeypatch,
+        is_offchain=True,
+        is_marketplace_mech=True,
+    )
+    behaviour._finalize_done_task("bafycid")
+    done_tasks = shared_state[beh_mod.DONE_TASKS]
+    assert len(done_tasks) == 1
+    assert isinstance(done_tasks[0].get("predict_api_event"), dict)
+    assert done_tasks[0]["predict_api_event"].get("source") == "mech_offchain"
+
+
+def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """``use_offchain=True`` + on-chain marketplace delivery: event still attached.
+
+    The gate accepts ``is_marketplace_delivery`` too, so on-chain
+    marketplace tasks flow into the same predict-api write path with
+    ``source='mech_onchain'``. Regression against a docstring drift
+    that was suggesting the condition was marketplace-only.
+
+    :param behaviour: FetchDataBehaviour fixture.
+    :param params_stub: params fixture with ``use_offchain=True``.
+    :param shared_state: shared_state fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    params_stub.use_offchain = True
+    _finalize_gate_setup(
+        behaviour,
+        shared_state,
+        params_stub,
+        monkeypatch,
+        is_offchain=False,
+        is_marketplace_mech=True,
+    )
+    behaviour._finalize_done_task("bafycid")
+    done_tasks = shared_state[beh_mod.DONE_TASKS]
+    assert len(done_tasks) == 1
+    assert isinstance(done_tasks[0].get("predict_api_event"), dict)
+    assert done_tasks[0]["predict_api_event"].get("source") == "mech_onchain"
+
+
+def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """``use_offchain=False``: no ``predict_api_event`` on the done_task even for an off-chain HTTP delivery.
+
+    The Phase-1 dark ship promise: nothing rides consensus replication
+    when the flag is off. Pairs with the egress-side gate test in
+    ``task_submission_abci/tests/test_onchain_write_path.py``.
+
+    :param behaviour: FetchDataBehaviour fixture.
+    :param params_stub: params fixture, flipped to ``use_offchain=False`` here.
+    :param shared_state: shared_state fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    params_stub.use_offchain = False
+    _finalize_gate_setup(
+        behaviour,
+        shared_state,
+        params_stub,
+        monkeypatch,
+        is_offchain=True,
+        is_marketplace_mech=True,
+    )
+    behaviour._finalize_done_task("bafycid")
+    done_tasks = shared_state[beh_mod.DONE_TASKS]
+    assert len(done_tasks) == 1
+    assert "predict_api_event" not in done_tasks[0]

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3020,7 +3020,7 @@ def test_ensure_payment_model_does_not_reset_inflight_from_other_flow(
 
 
 # ---------------------------------------------------------------------------
-# _iso_z + _build_wildcard_event timestamp normalisation
+# _iso_z + _build_predict_api_event timestamp normalisation
 # ---------------------------------------------------------------------------
 
 
@@ -3068,7 +3068,7 @@ def test_iso_z_naive_datetime_raises() -> None:
         beh_mod._iso_z(datetime(2026, 6, 25, 13, 19, 6))
 
 
-def _wildcard_event_setup(
+def _predict_api_event_setup(
     behaviour: Any,
     shared_state: Dict[str, Any],
     request_data: Dict[str, Any],
@@ -3078,7 +3078,7 @@ def _wildcard_event_setup(
     """Wire shared_state and return the done_task and executing_task dicts."""
     # Each test varies the request/response fields without re-deriving
     # the dict shape; this helper centralises the IN_MEMORY_REQUESTS +
-    # OFFCHAIN_REQUEST_RESPONSES seeding that _build_wildcard_event reads.
+    # OFFCHAIN_REQUEST_RESPONSES seeding that _build_predict_api_event reads.
     if response_data is None:
         response_data = {
             "result": "p_yes=0.7",
@@ -3103,7 +3103,7 @@ def _wildcard_event_setup(
     return done_task, executing_task
 
 
-def test_build_wildcard_event_emits_z_on_all_timestamps(
+def test_build_predict_api_event_emits_z_on_all_timestamps(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3119,10 +3119,10 @@ def test_build_wildcard_event_emits_z_on_all_timestamps(
         "nonce": "uuid-1",
         "requested_at": "2026-06-25T13:19:06.651013+00:00",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     assert event["request"]["requested_at"].endswith("Z")
@@ -3133,7 +3133,7 @@ def test_build_wildcard_event_emits_z_on_all_timestamps(
     assert "+00:00" not in event["response"]["delivered_at"]
 
 
-def test_build_wildcard_event_normalises_non_utc_requested_at(
+def test_build_predict_api_event_normalises_non_utc_requested_at(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3148,16 +3148,16 @@ def test_build_wildcard_event_normalises_non_utc_requested_at(
         # 18:49:06 IST == 13:19:06 UTC.
         "requested_at": "2026-06-25T18:49:06.651013+05:30",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     assert event["request"]["requested_at"] == "2026-06-25T13:19:06.651013Z"
 
 
-def test_build_wildcard_event_unix_requested_at_is_z(
+def test_build_predict_api_event_unix_requested_at_is_z(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3169,16 +3169,16 @@ def test_build_wildcard_event_unix_requested_at_is_z(
         # 2026-06-25T13:19:06Z
         "requested_at": 1782393546,
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     assert event["request"]["requested_at"] == "2026-06-25T13:19:06Z"
 
 
-def test_build_wildcard_event_z_suffix_requested_at_is_parsed(
+def test_build_predict_api_event_z_suffix_requested_at_is_parsed(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3194,16 +3194,16 @@ def test_build_wildcard_event_z_suffix_requested_at_is_parsed(
         "tool": "prediction-offline",
         "requested_at": "2026-06-25T13:19:06.651013Z",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     assert event["request"]["requested_at"] == "2026-06-25T13:19:06.651013Z"
 
 
-def test_build_wildcard_event_unix_requested_at_out_of_range_falls_back(
+def test_build_predict_api_event_unix_requested_at_out_of_range_falls_back(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3220,17 +3220,17 @@ def test_build_wildcard_event_unix_requested_at_out_of_range_falls_back(
         # range Python's datetime can represent on a 64-bit platform.
         "requested_at": 99_999_999_999_999,
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     # Fallback ends in Z because executed_at does.
     assert event["request"]["requested_at"].endswith("Z")
 
 
-def test_build_wildcard_event_unix_executed_at_out_of_range_falls_back(
+def test_build_predict_api_event_unix_executed_at_out_of_range_falls_back(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3249,16 +3249,16 @@ def test_build_wildcard_event_unix_executed_at_out_of_range_falls_back(
         "schema_version": "2.0",
         "executed_at": 99_999_999_999_999,  # past representable range
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data, response_data=response_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     assert event["response"]["executed_at"].endswith("Z")
 
 
-def test_build_wildcard_event_malformed_requested_at_falls_back(
+def test_build_predict_api_event_malformed_requested_at_falls_back(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3272,10 +3272,10 @@ def test_build_wildcard_event_malformed_requested_at_falls_back(
         "tool": "prediction-offline",
         "requested_at": "not-a-timestamp",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy-cid", executing_task=executing_task
     )
     assert event["request"]["requested_at"].endswith("Z")
@@ -3383,20 +3383,20 @@ def test_execute_task_offchain_missing_ipfs_data_sets_invalid_request(
 
 
 # ---------------------------------------------------------------------------
-# On-chain write path: source field on _build_wildcard_event
+# On-chain write path: source field on _build_predict_api_event
 # ---------------------------------------------------------------------------
 #
-# After the on-chain write path lands, _build_wildcard_event sets a
+# After the on-chain write path lands, _build_predict_api_event sets a
 # top-level ``source`` field on the returned event dict based on the
 # task's ``is_offchain`` flag:
 #   - is_offchain=True  → source="mech_offchain" (the paid HTTP path).
 #   - is_offchain=False → source="mech_onchain"  (the on-chain rails).
-# The wildcard server uses this field to tag both mech_requests and
+# The predict-api server uses this field to tag both mech_requests and
 # mech_responses rows for the analytics ETL. See
 # ``autonolas-marketplace/docs/onchain_write_path_scope.md`` §3.
 
 
-def test_build_wildcard_event_offchain_task_carries_mech_offchain_source(
+def test_build_predict_api_event_offchain_task_carries_mech_offchain_source(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3407,10 +3407,10 @@ def test_build_wildcard_event_offchain_task_carries_mech_offchain_source(
         "tool": "prediction-offline",
         "requested_at": "2026-06-25T13:19:06.651013Z",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy", executing_task=executing_task
     )
     assert event["source"] == "mech_offchain"
@@ -3419,7 +3419,7 @@ def test_build_wildcard_event_offchain_task_carries_mech_offchain_source(
     assert event["response"]["is_offchain"] is True
 
 
-def test_build_wildcard_event_onchain_task_carries_mech_onchain_source(
+def test_build_predict_api_event_onchain_task_carries_mech_onchain_source(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3433,30 +3433,30 @@ def test_build_wildcard_event_onchain_task_carries_mech_onchain_source(
 
     :param behaviour: the wired ``task_execution`` behaviour under test.
     :param params_stub: params fixture — indirectly consumed by
-        ``_wildcard_event_setup`` to populate ``self.params`` bits.
+        ``_predict_api_event_setup`` to populate ``self.params`` bits.
     :param shared_state: shared_state fixture used by
-        ``_wildcard_event_setup`` to build ``done_task`` / ``executing_task``.
+        ``_predict_api_event_setup`` to build ``done_task`` / ``executing_task``.
     """
     request_data = {
         "prompt": "p",
         "tool": "prediction-offline",
         "requested_at": "2026-06-25T13:19:06.651013Z",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
     # Flip the flags on both halves: the source decision keys on the
     # executing_task; the response payload's is_offchain mirrors it.
     executing_task["is_offchain"] = False
     done_task["is_offchain"] = False
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy", executing_task=executing_task
     )
     assert event["source"] == "mech_onchain"
     assert event["response"]["is_offchain"] is False
 
 
-def test_build_wildcard_event_marketplace_task_falls_back_to_requester_key(
+def test_build_predict_api_event_marketplace_task_falls_back_to_requester_key(
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
@@ -3466,19 +3466,19 @@ def test_build_wildcard_event_marketplace_task_falls_back_to_requester_key(
     Pending marketplace tasks come from
     ``MechMarketplaceContract.get_marketplace_undelivered_reqs``, which
     keys the requester as ``requester`` and carries no ``sender`` field.
-    The delivered wildcard row must still populate ``request.requester``
+    The delivered predict-api row must still populate ``request.requester``
     or the analytics-side join breaks.
 
-    The shared ``_wildcard_event_setup`` fixture always stamps
+    The shared ``_predict_api_event_setup`` fixture always stamps
     ``sender`` on ``executing_task`` (that's the off-chain HTTP shape).
     This test deletes it and injects ``requester`` alone, exercising the
-    ``sender or requester`` fallback added in ``_build_wildcard_event``.
+    ``sender or requester`` fallback added in ``_build_predict_api_event``.
 
     :param behaviour: task_execution behaviour under test.
     :param params_stub: params fixture — consumed by
-        ``_wildcard_event_setup`` to populate ``self.params`` bits.
+        ``_predict_api_event_setup`` to populate ``self.params`` bits.
     :param shared_state: shared_state fixture used by
-        ``_wildcard_event_setup`` for ``IN_MEMORY_REQUESTS`` /
+        ``_predict_api_event_setup`` for ``IN_MEMORY_REQUESTS`` /
         ``OFFCHAIN_REQUEST_RESPONSES`` seeding.
     """
     request_data = {
@@ -3486,7 +3486,7 @@ def test_build_wildcard_event_marketplace_task_falls_back_to_requester_key(
         "tool": "prediction-offline",
         "requested_at": "2026-06-25T13:19:06.651013Z",
     }
-    done_task, executing_task = _wildcard_event_setup(
+    done_task, executing_task = _predict_api_event_setup(
         behaviour, shared_state, request_data
     )
     # Marketplace shape: only ``requester``, no ``sender``. Also flip the
@@ -3495,7 +3495,7 @@ def test_build_wildcard_event_marketplace_task_falls_back_to_requester_key(
     executing_task["requester"] = "0xMARKETPLACE_REQUESTER"
     executing_task["is_offchain"] = False
     done_task["is_offchain"] = False
-    event = behaviour._build_wildcard_event(
+    event = behaviour._build_predict_api_event(
         done_task=done_task, cid="bafy", executing_task=executing_task
     )
     assert event["request"]["requester"] == "0xMARKETPLACE_REQUESTER"

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -71,7 +71,7 @@ from packages.valory.skills.task_submission_abci.rounds import (
     TaskSubmissionAbciApp,
     TransactionPreparationRound,
 )
-from packages.valory.skills.task_submission_abci.wildcard_write_client import (
+from packages.valory.skills.task_submission_abci.predict_api_events_client import (
     build_typed_data,
     compute_batch_hash,
     compute_eip712_digest,
@@ -113,7 +113,7 @@ NONCE = "nonce"
 SENDER = "sender"
 REQUESTER_KEY = "requester"
 
-# Wildcard analytics-write outcome counter. Labels:
+# predict-api analytics-write outcome counter. Labels:
 #
 # * ``batch_label``: ``"delivered"`` (this round's on-chain settled
 #   events, sourced from ``synchronized_data.done_tasks``) or ``"sweep"``
@@ -125,14 +125,14 @@ REQUESTER_KEY = "requester"
 #
 # Delivered events have no queue-side parking spot (they come from this
 # round's ``synchronized_data.done_tasks`` and are not re-queued across
-# rounds), so a transient wildcard failure silently discards the row —
+# rounds), so a transient predict-api failure silently discards the row —
 # the replay buffer that would recover it is a future PR. This counter
 # gives operators a signal before the buffer lands: sustained non-``ok``
 # on ``batch_label="delivered"`` means the analytics lake is missing
 # rows for that window.
-mech_wildcard_events_total = Counter(
-    "mech_wildcard_events_total",
-    "Wildcard analytics-write batch outcomes",
+mech_predict_api_events_total = Counter(
+    "mech_predict_api_events_total",
+    "predict-api analytics-write batch outcomes",
     labelnames=["batch_label", "outcome"],
 )
 MECH_ADDRESS = "mech_address"
@@ -1848,21 +1848,21 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     """Runs once on-chain settlement of the round's tx confirms.
 
     Reads ``synchronized_data.done_tasks`` for the just-settled cycle,
-    extracts every entry's pre-built ``wildcard_event`` payload (set on
-    the offchain path inside :py:meth:`task_execution.behaviours._build_wildcard_event`),
+    extracts every entry's pre-built ``predict_api_event`` payload (set on
+    the offchain path inside :py:meth:`task_execution.behaviours._build_predict_api_event`),
     bundles them into one EIP-712-signed batch, and POSTs the batch to
-    the wildcard data lake at ``params.wildcard_events_url``. The wildcard
+    the predict-api data lake at ``params.predict_api_events_url``. The predict-api
     server is idempotent on ``request_id``, so multi-agent services don't
     need a keeper pattern: each agent posts its own copy under its own
     EOA signature; the per-EOA rate limiter on the server keeps the
     co-owners in separate budgets.
 
-    The behaviour is fail-soft by construction. A wildcard outage / 5xx
+    The behaviour is fail-soft by construction. A predict-api outage / 5xx
     / network drop does NOT stop the FSM — the settlement already landed
     on-chain, the analytics row just arrives later. For Phase 1 dark
     rollout, failures are logged and dropped; the replay buffer (kv_store
     backed, scheduled drainer) stacks on top of the open mech#455 PR and
-    lands in a follow-up. ``mech_events_enabled=False`` short-circuits
+    lands in a follow-up. ``use_offchain=False`` short-circuits
     the whole behaviour to a fixed "done" payload.
     """
 
@@ -1871,7 +1871,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     def async_act(self) -> Generator:
         """Build, sign, and POST the offchain-events batch, then advance."""
         with self.context.benchmark_tool.measure(self.behaviour_id).local():
-            yield from self._do_wildcard_write_best_effort()
+            yield from self._do_predict_api_write_best_effort()
             payload = PostTxSettlementPayload(
                 sender=self.context.agent_address, content="done"
             )
@@ -1884,7 +1884,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     # Note on the two ``mech_events_chain_id`` params: task_execution's
     # copy powers delivered events; task_submission_abci's copy powers
     # sweep events. A drift is visible in the sweep batch's chain_id=0
-    # short-circuit (WARNING log inside ``_post_wildcard_batch``) and
+    # short-circuit (WARNING log inside ``_post_predict_api_batch``) and
     # does not affect delivered under the split-batch design. An earlier
     # revision of this file also tried a cross-skill consistency check
     # here via ``self.context.skills.task_execution.models.params``, but
@@ -1892,14 +1892,14 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     # check crashed PostTxSettlement on every round. Dropped in favour
     # of the per-batch short-circuit log.
 
-    def _do_wildcard_write_best_effort(self) -> Generator:
-        """Best-effort wildcard write. Never raises; logs failure paths.
+    def _do_predict_api_write_best_effort(self) -> Generator:
+        """Best-effort predict-api write. Never raises; logs failure paths.
 
         Three short-circuit returns before any work:
 
             1. The feature flag is off (the default during Phase 1).
-            2. The skill has no wildcard URL configured.
-            3. The round's done_tasks carry no offchain wildcard_event
+            2. The skill has no predict-api URL configured.
+            3. The round's done_tasks carry no offchain predict_api_event
                entries and the pending-task sweep produced no
                request-only events (a truly quiet round).
 
@@ -1907,13 +1907,13 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             the underlying generator-based helpers; this method does not
             ``return`` anything.
         """
-        if not getattr(self.params, "mech_events_enabled", False):
+        if not getattr(self.params, "use_offchain", False):
             return
-        wildcard_url = getattr(self.params, "wildcard_events_url", "") or ""
-        if not wildcard_url:
+        predict_api_url = getattr(self.params, "predict_api_events_url", "") or ""
+        if not predict_api_url:
             self.context.logger.debug(
-                "mech_events_enabled set but wildcard_events_url empty; "
-                "skipping post-tx wildcard write."
+                "use_offchain set but predict_api_events_url empty; "
+                "skipping post-tx predict-api write."
             )
             return
 
@@ -1924,13 +1924,13 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # alongside the events but does NOT mutate the pending queue: any
         # guard-skip or POST failure below would otherwise drop the tasks
         # with no re-queue and no written row. The queue is only mutated
-        # once the wildcard POST has confirmed a 2xx (or a terminal 4xx —
-        # see ``_post_wildcard_batch`` for the poison-drop rationale).
+        # once the predict-api POST has confirmed a 2xx (or a terminal 4xx —
+        # see ``_post_predict_api_batch`` for the poison-drop rationale).
         request_only_events, swept_request_ids = self._sweep_pending_undelivered()
         if not delivered_events and not request_only_events:
             self.context.logger.debug(
-                "No wildcard_event entries in done_tasks and no swept "
-                "pending tasks; post-tx wildcard write is a no-op for "
+                "No predict_api_event entries in done_tasks and no swept "
+                "pending tasks; post-tx predict-api write is a no-op for "
                 "this round."
             )
             return
@@ -1949,14 +1949,14 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         mech_address = getattr(self.params, "agent_mech_contract_address", "") or ""
         if not mech_address:
             self.context.logger.warning(
-                "No agent_mech_contract_address available; skipping wildcard write."
+                "No agent_mech_contract_address available; skipping predict-api write."
             )
             return
 
         verifying_contract = getattr(self.params, "mech_marketplace_address", "") or ""
         if not verifying_contract:
             self.context.logger.warning(
-                "No mech_marketplace_address on params; skipping wildcard write."
+                "No mech_marketplace_address on params; skipping predict-api write."
             )
             return
 
@@ -1972,34 +1972,34 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # batches isolate the failure modes: a bad sweep can never cost
         # us a real delivered row.
         if delivered_events:
-            yield from self._post_wildcard_batch(
+            yield from self._post_predict_api_batch(
                 events=delivered_events,
                 mech_address=mech_address,
                 verifying_contract=verifying_contract,
-                wildcard_url=wildcard_url,
+                predict_api_url=predict_api_url,
                 batch_label="delivered",
                 swept_request_ids=None,  # delivered has no queue-side state
             )
         if request_only_events:
-            yield from self._post_wildcard_batch(
+            yield from self._post_predict_api_batch(
                 events=request_only_events,
                 mech_address=mech_address,
                 verifying_contract=verifying_contract,
-                wildcard_url=wildcard_url,
+                predict_api_url=predict_api_url,
                 batch_label="sweep",
                 swept_request_ids=swept_request_ids,
             )
 
-    def _post_wildcard_batch(  # noqa: C901
+    def _post_predict_api_batch(  # noqa: C901
         self,
         events: List[Dict[str, Any]],
         mech_address: str,
         verifying_contract: str,
-        wildcard_url: str,
+        predict_api_url: str,
         batch_label: str,
         swept_request_ids: Optional[List[str]],
     ) -> Generator:
-        """Hash, sign, and POST one wildcard batch. Post-write side effects vary by outcome.
+        """Hash, sign, and POST one predict-api batch. Post-write side effects vary by outcome.
 
         Called separately for the delivered-events batch and the
         sweep-events batch so a poison sweep event can't take real
@@ -2028,7 +2028,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             only, or sweep only — never mixed).
         :param mech_address: on-chain mech contract for the signed typed-data.
         :param verifying_contract: marketplace contract for the EIP-712 domain.
-        :param wildcard_url: server endpoint (``POST /mech/events``).
+        :param predict_api_url: server endpoint (``POST /mech/events``).
         :param batch_label: ``"delivered"`` or ``"sweep"``, used in log lines.
         :param swept_request_ids: request-ids to drop from ``PENDING_TASKS``
             on outcome-appropriate paths. ``None`` for the delivered batch.
@@ -2036,7 +2036,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         """
         # The EIP-712 domain.chainId binds the signature to one chain. Read
         # it from the first event's ``request.chain_id`` — every event in
-        # the batch was built by either ``task_execution._build_wildcard_event``
+        # the batch was built by either ``task_execution._build_predict_api_event``
         # (delivered) or ``self._build_request_only_event`` (sweep) against
         # the corresponding skill's ``mech_events_chain_id`` param. The
         # value-by-construction check below rejects a heterogeneous batch
@@ -2053,7 +2053,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             for e in events
         ):
             self.context.logger.warning(
-                "Wildcard %s batch contains events from multiple chains; "
+                "predict-api %s batch contains events from multiple chains; "
                 "skipping. A single Safe should only ever build events for "
                 "one chain — check the mech_events_chain_id param on both "
                 "task_execution and task_submission_abci.",
@@ -2069,7 +2069,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         if chain_id == 0:
             self.context.logger.warning(
                 "mech_events_chain_id is 0 (unconfigured) for the %s "
-                "batch; skipping wildcard write. If this is the sweep "
+                "batch; skipping predict-api write. If this is the sweep "
                 "batch, the task_submission_abci copy of the param is the "
                 "usual culprit — task_execution's copy fills the delivered "
                 "batch's chain id independently.",
@@ -2106,11 +2106,11 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             # tasks stay on the queue (retryable — a subsequent FSM cycle
             # may see clean content).
             self.context.logger.warning(
-                "Wildcard %s EIP-712 digest build failed; dropping batch: %s",
+                "predict-api %s EIP-712 digest build failed; dropping batch: %s",
                 batch_label,
                 exc,
             )
-            mech_wildcard_events_total.labels(
+            mech_predict_api_events_total.labels(
                 batch_label=batch_label, outcome="pre_flight_failed"
             ).inc()
             return
@@ -2120,11 +2120,11 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             )
         except Exception as exc:
             self.context.logger.warning(
-                "Wildcard %s EIP-712 signing failed; dropping batch this round: %s",
+                "predict-api %s EIP-712 signing failed; dropping batch this round: %s",
                 batch_label,
                 exc,
             )
-            mech_wildcard_events_total.labels(
+            mech_predict_api_events_total.labels(
                 batch_label=batch_label, outcome="pre_flight_failed"
             ).inc()
             return
@@ -2149,24 +2149,24 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             # analytics-side ergonomics should not delete rows that
             # still need to run.
             self.context.logger.warning(
-                "Wildcard %s batch JSON serialisation failed; dropping this "
+                "predict-api %s batch JSON serialisation failed; dropping this "
                 "round (sweep tasks stay on the queue for retry): %s",
                 batch_label,
                 exc,
             )
-            mech_wildcard_events_total.labels(
+            mech_predict_api_events_total.labels(
                 batch_label=batch_label, outcome="pre_flight_failed"
             ).inc()
             return
 
         # Build the request with an explicit short timeout. ``get_http_response``
         # doesn't surface a timeout kwarg, so go one level lower: a slow or
-        # hung wildcard endpoint must not pin this behaviour until the
+        # hung predict-api endpoint must not pin this behaviour until the
         # round timeout fires; the analytics write is best-effort and a
         # missed batch is recoverable, but a stuck round is not.
         http_message, http_dialogue = self._build_http_request_message(
             method="POST",
-            url=wildcard_url,
+            url=predict_api_url,
             content=body,
             headers={"Content-Type": "application/json"},
         )
@@ -2175,19 +2175,19 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                 http_message,
                 http_dialogue,
                 timeout=float(
-                    getattr(self.params, "wildcard_events_timeout_seconds", 5.0)
+                    getattr(self.params, "predict_api_events_timeout_seconds", 5.0)
                 ),
             )
         except Exception as exc:
             # Network-level failures are retryable — the server may come
             # back, so leave sweep tasks on the queue for the next cycle.
             self.context.logger.warning(
-                "Wildcard %s POST raised; dropping batch this round "
+                "predict-api %s POST raised; dropping batch this round "
                 "(follow-up PR adds kv_store replay buffer): %s",
                 batch_label,
                 exc,
             )
-            mech_wildcard_events_total.labels(
+            mech_predict_api_events_total.labels(
                 batch_label=batch_label, outcome="network_error"
             ).inc()
             return
@@ -2195,13 +2195,13 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         status = getattr(response, "status_code", None)
         if status is not None and 200 <= status < 300:
             self.context.logger.info(
-                "Wildcard %s batch POST OK (status=%s batch_size=%d signer-eoa=%s)",
+                "predict-api %s batch POST OK (status=%s batch_size=%d signer-eoa=%s)",
                 batch_label,
                 status,
                 len(events),
                 self.context.agent_address,
             )
-            mech_wildcard_events_total.labels(
+            mech_predict_api_events_total.labels(
                 batch_label=batch_label, outcome="ok"
             ).inc()
             if swept_request_ids:
@@ -2250,7 +2250,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # per-event terminal rejection (e.g. server 422 on a subset) is
         # left as future work (needs a per-event ack from the server).
         self.context.logger.warning(
-            "Wildcard %s POST returned non-success (status=%s); dropping "
+            "predict-api %s POST returned non-success (status=%s); dropping "
             "this round, sweep tasks stay on the queue for retry. "
             "batch_size=%d signer-eoa=%s body_preview=%s",
             batch_label,
@@ -2259,20 +2259,20 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             self.context.agent_address,
             response.body[:512] if hasattr(response, "body") else "?",
         )
-        mech_wildcard_events_total.labels(
+        mech_predict_api_events_total.labels(
             batch_label=batch_label, outcome="http_error"
         ).inc()
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
-        """Return the ``wildcard_event`` payload from every done_task that carries one.
+        """Return the ``predict_api_event`` payload from every done_task that carries one.
 
         Both off-chain HTTP deliveries (``source = 'mech_offchain'``) and
         on-chain marketplace deliveries (``source = 'mech_onchain'``) now
-        ride the same wildcard write path; the per-event ``source`` field
-        set inside :py:meth:`task_execution.behaviours._build_wildcard_event`
-        is what disambiguates the two on the wildcard side. The filter
-        here keys on the presence of a ``wildcard_event`` field — built
-        only when both ``mech_events_enabled`` is set AND the task is a
+        ride the same predict-api write path; the per-event ``source`` field
+        set inside :py:meth:`task_execution.behaviours._build_predict_api_event`
+        is what disambiguates the two on the predict-api side. The filter
+        here keys on the presence of a ``predict_api_event`` field — built
+        only when both ``use_offchain`` is set AND the task is a
         marketplace task — so on-chain non-marketplace tasks (legacy
         mech contract) stay out of the lake by construction.
 
@@ -2281,7 +2281,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         done_tasks = cast(List[Dict[str, Any]], self.synchronized_data.done_tasks)
         events: List[Dict[str, Any]] = []
         for task in done_tasks:
-            event = task.get("wildcard_event")
+            event = task.get("predict_api_event")
             if not isinstance(event, dict):
                 continue
             events.append(event)
@@ -2295,7 +2295,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         Returns request-only events for any task that has sat in the
         queue past the operator-configured sweep window, alongside the
         ``request_id``s of the swept tasks so the caller can remove them
-        from the queue AFTER the wildcard POST confirms success.
+        from the queue AFTER the predict-api POST confirms success.
 
         The sweep does NOT mutate ``PENDING_TASKS``. Dropping tasks here
         (as an earlier revision of this PR did) would lose the
@@ -2325,7 +2325,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
 
         Gated on ``mech_events_sweep_pending_enabled`` so operators can
         roll this out independently from the delivered-event write
-        (which is what ``mech_events_enabled`` already gates). A
+        (which is what ``use_offchain`` already gates). A
         request-only event always carries ``source='mech_onchain'``;
         the off-chain path doesn't produce them by construction.
 
@@ -2333,10 +2333,10 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             an ordered list of request-only event dicts ready to append
             to the batch; ``swept_request_ids`` is the ordered list of
             ``request_id`` strings the caller should drop from
-            ``PENDING_TASKS`` if the wildcard POST returns 2xx. Empty
+            ``PENDING_TASKS`` if the predict-api POST returns 2xx. Empty
             lists on any short-circuit or when nothing timed out.
         """
-        if not getattr(self.params, "mech_events_enabled", False):
+        if not getattr(self.params, "use_offchain", False):
             return [], []
         if not getattr(self.params, "mech_events_sweep_pending_enabled", False):
             return [], []
@@ -2375,7 +2375,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             request_only_events.append(event)
             swept_request_ids.append(str(event["request"].get("request_id")))
             self.context.logger.info(
-                "Wildcard sweep: staging request-only event for "
+                "predict-api sweep: staging request-only event for "
                 "timed-out task request_id=%s, age=%.0fs "
                 "(queue not mutated until POST succeeds)",
                 event["request"].get("request_id"),
@@ -2385,7 +2385,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         return request_only_events, swept_request_ids
 
     def _drop_swept_from_pending(self, swept_request_ids: List[str]) -> None:
-        """Remove the swept tasks from ``PENDING_TASKS`` after a confirmed wildcard write.
+        """Remove the swept tasks from ``PENDING_TASKS`` after a confirmed predict-api write.
 
         Mutates the shared list in place: other consumers (the task
         picker in task_execution) hold the same reference and would not
@@ -2418,7 +2418,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         knows (request_id, requester, priority_mech, delivery_rate,
         content_cid) but not the IPFS-resolved fields (prompt, tool,
         model). Those would require an IPFS fetch at sweep time, which
-        we explicitly do not do; placeholders keep the wildcard schema
+        we explicitly do not do; placeholders keep the predict-api schema
         happy. The lake's analytics-side undelivered signal — the
         absence of a ``mech_responses`` row — does not depend on those
         fields, so the placeholder values do not corrupt downstream
@@ -2431,9 +2431,9 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             every event in the sweep shares the same ``requested_at``
             fallback if the task carries no local timestamp.
         :return: a dict with the same shape as the off-chain
-            ``_build_wildcard_event`` return, but with ``response: None``
+            ``_build_predict_api_event`` return, but with ``response: None``
             and ``source: 'mech_onchain'``; or ``None`` if the task
-            doesn't have the minimum fields the wildcard server
+            doesn't have the minimum fields the predict-api server
             requires.
         """
         request_id = task.get("requestId")
@@ -2477,7 +2477,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             content_cid = None
 
         # ``enqueued_at_local`` is monotonic-ish ``time.time()`` from
-        # the handler; the wildcard ``requested_at`` is the requester's
+        # the handler; the predict-api ``requested_at`` is the requester's
         # signed-header timestamp on the off-chain path. The on-chain
         # path's request timestamp is the block.timestamp, which we
         # don't have here without a contract read; use the local stamp
@@ -2502,7 +2502,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             str(delivery_rate_raw) if delivery_rate_raw is not None else None
         )
 
-        # The wildcard server requires ``prompt`` to be a non-empty
+        # The predict-api server requires ``prompt`` to be a non-empty
         # string and ``tool`` to be a non-empty string. Placeholders
         # match the off-chain build's pattern ("[offchain request]")
         # so a reader can spot a sweep-emitted row from the value.

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -63,6 +63,11 @@ from packages.valory.skills.task_submission_abci.payloads import (
     PostTxSettlementPayload,
     TransactionPayload,
 )
+from packages.valory.skills.task_submission_abci.predict_api_events_client import (
+    build_typed_data,
+    compute_batch_hash,
+    compute_eip712_digest,
+)
 from packages.valory.skills.task_submission_abci.rounds import (
     PostTxSettlementRound,
     SynchronizedData,
@@ -70,11 +75,6 @@ from packages.valory.skills.task_submission_abci.rounds import (
     TaskPoolingRound,
     TaskSubmissionAbciApp,
     TransactionPreparationRound,
-)
-from packages.valory.skills.task_submission_abci.predict_api_events_client import (
-    build_typed_data,
-    compute_batch_hash,
-    compute_eip712_digest,
 )
 from packages.valory.skills.transaction_settlement_abci.payload_tools import (
     hash_payload_to_hex,

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -1907,7 +1907,28 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             the underlying generator-based helpers; this method does not
             ``return`` anything.
         """
-        if not getattr(self.params, "use_offchain", False):
+        if not self.params.use_offchain:
+            # Divergence safety net. ``use_offchain`` is a duplicated
+            # param (declared on both this skill and ``task_execution``);
+            # if an operator flips ``task_execution.use_offchain=true`` but
+            # forgets this one, the ingress side builds
+            # ``predict_api_event`` entries and rides Tendermint
+            # consensus replication for them — and then the egress side
+            # here silently drops the entire batch. Warn loudly when we
+            # can see that has happened so the divergence is alertable
+            # rather than invisible.
+            if any(
+                isinstance(t, dict) and t.get("predict_api_event")
+                for t in cast(List[Dict[str, Any]], self.synchronized_data.done_tasks)
+            ):
+                self.context.logger.warning(
+                    "predict_api_event entries present in done_tasks but "
+                    "task_submission_abci.use_offchain is False — the "
+                    "ingress-side (task_execution) and egress-side "
+                    "(task_submission_abci) use_offchain flags are "
+                    "diverging. Dropping the batch. Align both skill "
+                    "configs to eliminate the ingress work."
+                )
             return
         predict_api_url = getattr(self.params, "predict_api_events_url", "") or ""
         if not predict_api_url:
@@ -2271,10 +2292,13 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         ride the same predict-api write path; the per-event ``source`` field
         set inside :py:meth:`task_execution.behaviours._build_predict_api_event`
         is what disambiguates the two on the predict-api side. The filter
-        here keys on the presence of a ``predict_api_event`` field — built
-        only when both ``use_offchain`` is set AND the task is a
-        marketplace task — so on-chain non-marketplace tasks (legacy
-        mech contract) stay out of the lake by construction.
+        here keys on the presence of a ``predict_api_event`` field, which
+        :py:meth:`task_execution.behaviours._finalize_done_task` sets only
+        when ``use_offchain`` is on AND the task is either an off-chain
+        HTTP delivery (``is_offchain=True``) or an on-chain marketplace
+        delivery (``is_marketplace_delivery=True``). On-chain
+        non-marketplace tasks on a legacy mech contract stay out of the
+        lake by construction.
 
         :return: an ordered list of ``MechEvent``-shaped dicts.
         """
@@ -2336,7 +2360,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             ``PENDING_TASKS`` if the predict-api POST returns 2xx. Empty
             lists on any short-circuit or when nothing timed out.
         """
-        if not getattr(self.params, "use_offchain", False):
+        if not self.params.use_offchain:
             return [], []
         if not getattr(self.params, "mech_events_sweep_pending_enabled", False):
             return [], []

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -137,7 +137,9 @@ class Params(BaseParams):
         # URL configured; the PostTxSettlement behaviour short-circuits
         # when either this is empty or ``use_offchain`` is False. No
         # API key here — the EOA signature is the credential.
-        self.predict_api_events_url: str = str(kwargs.get("predict_api_events_url", "") or "")
+        self.predict_api_events_url: str = str(
+            kwargs.get("predict_api_events_url", "") or ""
+        )
         # Explicit short timeout on the predict-api POST. The framework's
         # default ``request_timeout`` would let a slow or hung endpoint
         # pin this behaviour until ``ROUND_TIMEOUT`` fires; the analytics

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -123,25 +123,30 @@ class Params(BaseParams):
         self.mech_max_delivery_rate: int = int(
             next(iter(self.mech_to_max_delivery_rate.values()))
         )
-        # Feature flag for the wildcard analytics write path. Phase 1
-        # ships dark; deployments flip this on per-mech as the rollout
-        # advances. False by default so an out-of-the-box mech does no
-        # off-mech HTTP work at settlement time.
-        self.mech_events_enabled: bool = bool(kwargs.get("mech_events_enabled", False))
-        # Wildcard ``POST /mech/events`` endpoint. Empty string = no URL
-        # configured; the PostTxSettlement behaviour short-circuits when
-        # either this is empty or ``mech_events_enabled`` is False. No
+        # Dual-purpose gate: controls BOTH offchain-request ingress
+        # (handled in task_execution) AND egress to the predict-api events
+        # endpoint from PostTxSettlement (settlement writes for both
+        # offchain-settled AND on-chain-settled requests). A mech is
+        # either part of the predict-api analytics pipeline or it isn't;
+        # there's no coherent state where ingress and egress diverge.
+        # False by default so an out-of-the-box mech does no off-mech
+        # HTTP work at settlement time and does not accept offchain
+        # requests.
+        self.use_offchain: bool = bool(kwargs.get("use_offchain", False))
+        # predict-api ``POST /mech/events`` endpoint. Empty string = no
+        # URL configured; the PostTxSettlement behaviour short-circuits
+        # when either this is empty or ``use_offchain`` is False. No
         # API key here — the EOA signature is the credential.
-        self.wildcard_events_url: str = str(kwargs.get("wildcard_events_url", "") or "")
-        # Explicit short timeout on the wildcard POST. The framework's
+        self.predict_api_events_url: str = str(kwargs.get("predict_api_events_url", "") or "")
+        # Explicit short timeout on the predict-api POST. The framework's
         # default ``request_timeout`` would let a slow or hung endpoint
         # pin this behaviour until ``ROUND_TIMEOUT`` fires; the analytics
         # write is best-effort, so it must degrade quickly rather than
         # holding the round open. 5s comfortably covers one POST to a
         # healthy endpoint and surfaces a stuck endpoint as a dropped
         # batch on the next FSM cycle.
-        self.wildcard_events_timeout_seconds: float = float(
-            kwargs.get("wildcard_events_timeout_seconds", 5.0) or 5.0
+        self.predict_api_events_timeout_seconds: float = float(
+            kwargs.get("predict_api_events_timeout_seconds", 5.0) or 5.0
         )
         # On-chain undelivered-request sweep. The PostTxSettlement
         # behaviour walks ``shared_state[PENDING_TASKS]`` for tasks
@@ -149,7 +154,7 @@ class Params(BaseParams):
         # ``mech_events_sweep_max_age_seconds`` and emits a request-only
         # event for each (``MechEvent.response is None``,
         # ``source='mech_onchain'``). Gated separately from
-        # ``mech_events_enabled`` so the delivered-event write can roll
+        # ``use_offchain`` so the delivered-event write can roll
         # out before the sweep; default off until v1 lands and is
         # validated against a live deployment. See
         # ``autonolas-marketplace/docs/onchain_write_path_scope.md`` §3.2.

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -131,8 +131,8 @@ class Params(BaseParams):
         # the coupling is deliberate. On-chain-only mechs that want
         # analytics writes (``mech_onchain`` source) still flip this on
         # and accept that their offchain HTTP handler is also live — the
-        # handler is inert if no client's ``MECH_OFFCHAIN_URL`` points
-        # at it, so the cost is a wire nothing rides rather than a
+        # handler is inert unless a client actually sends offchain requests
+        # to it, so the cost is a wire nothing rides rather than a
         # traffic-shape change. The value is a duplicate of the flag
         # of the same name on ``task_execution``; if the two copies
         # drift (env override on one skill and not the other),

--- a/packages/valory/skills/task_submission_abci/models.py
+++ b/packages/valory/skills/task_submission_abci/models.py
@@ -128,10 +128,20 @@ class Params(BaseParams):
         # endpoint from PostTxSettlement (settlement writes for both
         # offchain-settled AND on-chain-settled requests). A mech is
         # either part of the predict-api analytics pipeline or it isn't;
-        # there's no coherent state where ingress and egress diverge.
-        # False by default so an out-of-the-box mech does no off-mech
-        # HTTP work at settlement time and does not accept offchain
-        # requests.
+        # the coupling is deliberate. On-chain-only mechs that want
+        # analytics writes (``mech_onchain`` source) still flip this on
+        # and accept that their offchain HTTP handler is also live — the
+        # handler is inert if no client's ``MECH_OFFCHAIN_URL`` points
+        # at it, so the cost is a wire nothing rides rather than a
+        # traffic-shape change. The value is a duplicate of the flag
+        # of the same name on ``task_execution``; if the two copies
+        # drift (env override on one skill and not the other),
+        # :py:meth:`PostTxSettlementBehaviour._do_predict_api_write_best_effort`
+        # emits a WARNING when it sees ``predict_api_event`` entries
+        # under a locally-off flag, so the misconfiguration is
+        # alertable rather than silent. False by default so an
+        # out-of-the-box mech does no off-mech HTTP work at settlement
+        # time and does not accept offchain requests.
         self.use_offchain: bool = bool(kwargs.get("use_offchain", False))
         # predict-api ``POST /mech/events`` endpoint. Empty string = no
         # URL configured; the PostTxSettlement behaviour short-circuits

--- a/packages/valory/skills/task_submission_abci/payloads.py
+++ b/packages/valory/skills/task_submission_abci/payloads.py
@@ -45,7 +45,7 @@ class PostTxSettlementPayload(BaseTxPayload):
     The payload carries a fixed sentinel so the round just needs
     consensus on participation rather than on any value: the work each
     agent performs in the behaviour (POSTing a signed batch to the
-    wildcard data lake) is idempotent on the server side and runs
+    predict-api data lake) is idempotent on the server side and runs
     independently per agent. The round transitions DONE once a
     threshold of agents has voted.
     """

--- a/packages/valory/skills/task_submission_abci/predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/predict_api_events_client.py
@@ -40,7 +40,12 @@ from eth_utils import keccak  # type: ignore[import-not-found]
 
 # The exact name/version pair that the server's allowlist binds via the
 # EIP-712 domain. Treat as a versioned constant; bumping the version
-# requires a coordinated change on both sides.
+# requires a coordinated change on both sides. Deliberately NOT renamed
+# in the wildcard→predict_api sweep — the server's EIP-712 domain
+# allowlist binds to these exact strings, and a rename here silently
+# breaks every server-side signature verification with no test
+# failure. If a future rename is genuinely wanted, ship the string
+# change alongside a coordinated server-side allowlist bump.
 EVENTS_DOMAIN_NAME = "Olas Mech Events"
 EVENTS_DOMAIN_VERSION = "1"
 EVENTS_PRIMARY_TYPE = "MechEventBatch"

--- a/packages/valory/skills/task_submission_abci/predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/predict_api_events_client.py
@@ -17,9 +17,9 @@
 #
 # ------------------------------------------------------------------------------
 
-r"""EIP-712 typed-data builder and batch-hash helper for the wildcard write client.
+r"""EIP-712 typed-data builder and batch-hash helper for the predict-api events client.
 
-The server side at ``wildcard/server/src/mech_sig.py`` (predict-api#162)
+The server side at ``server/src/mech_sig.py`` (predict-api#162)
 recomputes the same ``batch_hash`` from the parsed events array and
 compares against the signed value. Both sides must agree on the
 canonical-JSON encoding bit-for-bit:
@@ -49,7 +49,7 @@ EVENTS_PRIMARY_TYPE = "MechEventBatch"
 def canonical_json_bytes(value: Any) -> bytes:
     """Encode ``value`` as a deterministic UTF-8 byte string.
 
-    Mirror of ``wildcard/server/src/mech_sig.py::canonical_json_bytes``;
+    Mirror of ``server/src/mech_sig.py::canonical_json_bytes``;
     any divergence here breaks the batch-hash match on the server. Inputs
     must be JSON-native (no ``Decimal``, ``datetime``, etc.) — the caller
     is responsible for normalising before this function sees them.

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -195,15 +195,15 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
 
     Mirrors the optimus pattern at
     ``liquidity_trader_abci/states/post_tx_settlement.py``: each agent
-    runs the matching behaviour, which fires the offchain wildcard-data-lake
+    runs the matching behaviour, which fires the offchain predict-api data lake
     POST for the round's settled offchain deliveries, then sends back a
     fixed payload so the round can advance on consensus participation.
-    The wildcard write is idempotent server-side (PK on ``request_id``),
+    The predict-api write is idempotent server-side (PK on ``request_id``),
     so multi-agent services do not need a keeper-elects-one pattern; each
     agent posting its own copy is safe and the per-EOA rate limiter on
     the server scales naturally across agents.
 
-    The round always transitions DONE on threshold: a failed wildcard
+    The round always transitions DONE on threshold: a failed predict-api
     write does NOT block the FSM (the settlement already landed on-chain,
     the analytics row just arrives later via the replay buffer). The
     NO_MAJORITY arm only fires if the agents can't agree on having reached
@@ -303,7 +303,7 @@ class TaskSubmissionAbciApp(AbciApp[Event]):
             Event.DONE: FinishedPostTxSettlementRound,
             # Tendermint can't reach majority on participation: route back
             # to the post-tx round so a brief disagreement doesn't crash
-            # the FSM. The wildcard write is idempotent, so re-entry is safe.
+            # the FSM. The predict-api write is idempotent, so re-entry is safe.
             Event.NO_MAJORITY: PostTxSettlementRound,
             Event.ROUND_TIMEOUT: PostTxSettlementRound,
         },

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeiegx7qustzak3oibom3yzphvismtb3cmsjlmmvmepp2p7pzsczxya
+  models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
   rounds.py: bafybeifyjanb7hbqolgxsudzhr27otlaozgttjwufmqit6w5rgb2xc53yu
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy
+- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeidrqmdvmei6c5kxla4qebntilvxgwcc5s7zlivnpuiuv7unklhsqi
+  behaviours.py: bafybeihe5i2uh7rlyxgdf24vijxzngc55k3yi7vxq7rb2v6z3aqzxbyuui
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeiae55amwgzynnxldcjbv5nq5maztofwibwq5buhxhhy2vkyhxgwlq
+  tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
   tests/test_rounds.py: bafybeibervh4zm6a2fmfwcxsi4jl6vfc7owfl3474nhobiijf73fswul3e
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm
+- valory/task_execution:0.1.0:bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeigjgv2se57nhcn7tlhid7rfcpefhschefwoewhjj5zknfoahvjd3q
+  behaviours.py: bafybeib62ofqtjhjux3gb4zud3liupna2zog4zsiymetavdpxgwm6gnlfy
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeidrtfrwe3p2qnzgzgutu3h4svpphtwnrcxcfbuf6q6tg35wts5o64
+  models.py: bafybeifseshqkg5brosbmhlei4dnqwcmlu7r5istgj7utmsqpbgwdmjlq4
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeial5gesz6i2tyv2c3fasni2lh4issvn6bq3hveg6kvqjyfxlbitha
   rounds.py: bafybeifyjanb7hbqolgxsudzhr27otlaozgttjwufmqit6w5rgb2xc53yu
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeihl4dk5makds7ooqnyaq37uty7lxs43wylgof3zwhst2ywnluprve
+  tests/test_onchain_write_path.py: bafybeigdja7yraz6n6i2dh3dh5zkxdi5ro4e2qd3n5gpltai7jta7zvwam
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
   tests/test_rounds.py: bafybeibervh4zm6a2fmfwcxsi4jl6vfc7owfl3474nhobiijf73fswul3e

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,13 +8,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeib62ofqtjhjux3gb4zud3liupna2zog4zsiymetavdpxgwm6gnlfy
+  behaviours.py: bafybeidrqmdvmei6c5kxla4qebntilvxgwcc5s7zlivnpuiuv7unklhsqi
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeifseshqkg5brosbmhlei4dnqwcmlu7r5istgj7utmsqpbgwdmjlq4
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
-  predict_api_events_client.py: bafybeial5gesz6i2tyv2c3fasni2lh4issvn6bq3hveg6kvqjyfxlbitha
+  predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
   rounds.py: bafybeifyjanb7hbqolgxsudzhr27otlaozgttjwufmqit6w5rgb2xc53yu
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeigdja7yraz6n6i2dh3dh5zkxdi5ro4e2qd3n5gpltai7jta7zvwam
+  tests/test_onchain_write_path.py: bafybeiae55amwgzynnxldcjbv5nq5maztofwibwq5buhxhhy2vkyhxgwlq
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
   tests/test_rounds.py: bafybeibervh4zm6a2fmfwcxsi4jl6vfc7owfl3474nhobiijf73fswul3e
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
+- valory/task_execution:0.1.0:bafybeibe244e52b42fyckqdh5h74otpi2yg3iup4lsvf7chi67okf6ptvm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeifseshqkg5brosbmhlei4dnqwcmlu7r5istgj7utmsqpbgwdmjlq4
+  models.py: bafybeiegx7qustzak3oibom3yzphvismtb3cmsjlmmvmepp2p7pzsczxya
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
   rounds.py: bafybeifyjanb7hbqolgxsudzhr27otlaozgttjwufmqit6w5rgb2xc53yu
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq
+- valory/task_execution:0.1.0:bafybeies2iytb73xae2t7k53ap4nzfdfvyqrglofjzdduv5ck4ptanxsjy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,13 +8,14 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeibgtcqa7ur4qm643bhtochlz3ivdp5kqic4lqz7wxrtrmjumrw4nq
+  behaviours.py: bafybeigjgv2se57nhcn7tlhid7rfcpefhschefwoewhjj5zknfoahvjd3q
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
-  models.py: bafybeih7end4mjslb3ebdqg77ljt3cphrgrd5eqyvklaf33e2mebws7afi
-  payloads.py: bafybeif2gnz5k7eyb6of4iiisni426zscwanjfmtrr37f7ceu4cjqo2ob4
-  rounds.py: bafybeig3tdavbjyn7gf2qhz3fo2nn2lyhu7zvrncdlmjed2mskriw2k4eu
+  models.py: bafybeidrtfrwe3p2qnzgzgutu3h4svpphtwnrcxcfbuf6q6tg35wts5o64
+  payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
+  predict_api_events_client.py: bafybeial5gesz6i2tyv2c3fasni2lh4issvn6bq3hveg6kvqjyfxlbitha
+  rounds.py: bafybeifyjanb7hbqolgxsudzhr27otlaozgttjwufmqit6w5rgb2xc53yu
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -22,12 +23,11 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeielblv3y7tuas4r2d2mpbw2hlfcjcfrrlod5amigplevluk3u4f4e
+  tests/test_onchain_write_path.py: bafybeihl4dk5makds7ooqnyaq37uty7lxs43wylgof3zwhst2ywnluprve
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
-  tests/test_rounds.py: bafybeiaqdpzmf5t4l3rldukzynj7akiz5wpbbcrtzqd3gkjqs5jybtqyhe
+  tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
+  tests/test_rounds.py: bafybeibervh4zm6a2fmfwcxsi4jl6vfc7owfl3474nhobiijf73fswul3e
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
-  tests/test_wildcard_write_client.py: bafybeibhjqhm62jcisp4p2qcpvwdzityfy2hlimwaihkjrffmp7j3w5jzi
-  wildcard_write_client.py: bafybeia5mum3wwjnkyzhwcm4bsq2alqmczxttcuhzy532fsgjur6v4nc3e
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeib4ca677b4fbvtcf2zpfxjr7aob55qeuo7hhqjeenvhfs7ob7cujq
+- valory/task_execution:0.1.0:bafybeia5fbhjp4bgujz7ynxsgvbhcqi7dfls7ms3fczdj62xsgnvjkilja
 behaviours:
   main:
     args: {}
@@ -170,9 +170,9 @@ models:
       serious_slash_unit_amount: 8000000000000000
       service_endpoint_base: https://dummy_service.autonolas.tech/
       default_chain_id: gnosis
-      mech_events_enabled: false
-      wildcard_events_url: ''
-      wildcard_events_timeout_seconds: 5.0
+      use_offchain: false
+      predict_api_events_url: https://mpp.autonolas.tech/mech/events
+      predict_api_events_timeout_seconds: 5.0
       mech_events_sweep_pending_enabled: false
       mech_events_sweep_max_age_seconds: 3600.0
       mech_events_chain_id: 0

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeigwx6sal6isamlx4lgrz7i6l6lk5iwz4jn3u66h46l2dc2quwekhq
+- valory/task_execution:0.1.0:bafybeided62jostve2n5b4c7fsccxf4wce4ld3rbvalfdbqp77euon5rtq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -543,3 +543,179 @@ def test_extract_offchain_events_skips_tasks_without_predict_api_event() -> None
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == []
+
+
+# ---------------------------------------------------------------------------
+# _do_predict_api_write_best_effort egress gate: use_offchain drives whether
+# the external HTTP POST is even attempted, plus a divergence-warning
+# regression when the two flag copies drift out of sync.
+# ---------------------------------------------------------------------------
+
+
+def _make_egress_self(
+    *,
+    use_offchain: bool,
+    predict_api_events_url: str = "https://mpp.autonolas.tech/mech/events",
+    done_tasks: List[Dict[str, Any]] | None = None,
+    warnings_sink: List[str] | None = None,
+    debug_sink: List[str] | None = None,
+) -> PostTxSettlementBehaviour:
+    """Build a minimum ``self`` for a ``_do_predict_api_write_best_effort`` call.
+
+    The behaviour's egress path only touches ``self.params``,
+    ``self.synchronized_data.done_tasks``, ``self.context.logger``, and
+    the two internal helpers ``_extract_offchain_events`` /
+    ``_sweep_pending_undelivered`` / ``_build_http_request_message``.
+    We stub the latter three so this test proves the *gate* rather than
+    the batch construction (already covered by
+    ``_extract_offchain_events`` and ``_build_request_only_event`` tests
+    above).
+
+    :param use_offchain: value of ``params.use_offchain``.
+    :param predict_api_events_url: value of ``params.predict_api_events_url``.
+    :param done_tasks: ``synchronized_data.done_tasks`` list; used only
+        by the divergence-warning check.
+    :param warnings_sink: list to capture WARNING-level log lines.
+    :param debug_sink: list to capture DEBUG-level log lines.
+    :return: a fixture typed as :class:`PostTxSettlementBehaviour` for
+        the unbound-method call pattern used by every test in this
+        module.
+    """
+    warnings_sink = warnings_sink if warnings_sink is not None else []
+    debug_sink = debug_sink if debug_sink is not None else []
+    build_calls: List[Any] = []
+
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda msg, *a, **k: warnings_sink.append(msg),
+        error=lambda *a, **k: None,
+        debug=lambda msg, *a, **k: debug_sink.append(msg),
+    )
+    self_ = SimpleNamespace(
+        context=SimpleNamespace(shared_state={}, logger=logger),
+        params=SimpleNamespace(
+            use_offchain=use_offchain,
+            predict_api_events_url=predict_api_events_url,
+            mech_events_sweep_pending_enabled=False,
+            mech_events_sweep_max_age_seconds=60.0,
+            mech_events_chain_id=100,
+            mech_marketplace_address="0xMARKET",
+            agent_mech_contract_address="0xMECHCONTRACT",
+        ),
+        synchronized_data=SimpleNamespace(done_tasks=done_tasks or []),
+        # If the gate lets us through, ``_do_predict_api_write_best_effort``
+        # calls ``_build_http_request_message`` to construct the POST.
+        # Track the calls so the "gate off => no POST" invariant is
+        # observable without wiring the full HTTP dialogue.
+        _build_http_request_message=lambda *a, **k: build_calls.append((a, k)),
+        # Called by the egress helper when there are no offchain events
+        # in done_tasks; return an empty batch so the "no events" short-
+        # circuit fires cleanly.
+        _extract_offchain_events=lambda: [],
+        _sweep_pending_undelivered=lambda: ([], []),
+    )
+    # Expose the tracker on the fixture so tests can assert against it.
+    self_._egress_build_calls = build_calls  # type: ignore[attr-defined]
+    return cast(PostTxSettlementBehaviour, self_)
+
+
+def _drive_generator_once(gen: Any) -> None:
+    """Advance a short-circuited generator to completion.
+
+    ``_do_predict_api_write_best_effort`` is a Python generator. Every
+    egress-gate path under test returns before the first ``yield``, so
+    ``next(gen)`` either raises ``StopIteration`` cleanly (the ``return``
+    completed) or would suspend on a real dialogue — which is exactly
+    the surface these gate tests must not reach.
+
+    :param gen: the generator returned by
+        ``_do_predict_api_write_best_effort``.
+    """
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+
+
+def test_egress_gate_off_short_circuits_without_http_call() -> None:
+    """``use_offchain=False`` and no divergence: no HTTP build, no warning.
+
+    The Phase-1 dark ship promise on the egress side. Sibling to the
+    ingress-side test in
+    ``task_execution/tests/test_behaviours.py::test_finalize_done_task_omits_predict_api_event_when_use_offchain_off``.
+    """
+    self_ = _make_egress_self(use_offchain=False)
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    assert self_._egress_build_calls == []  # type: ignore[attr-defined]
+
+
+def test_egress_gate_off_with_diverged_ingress_emits_divergence_warning() -> None:
+    """``use_offchain=False`` but ``done_tasks`` carries predict_api_events: WARN and drop.
+
+    The two ``use_offchain`` copies (on ``task_execution`` and
+    ``task_submission_abci``) are independent env-overridable params —
+    an operator can flip one but forget the other. If the ingress side
+    is on but this side is off, ``done_tasks`` will already carry
+    ``predict_api_event`` entries at consensus-replication cost, and
+    dropping them silently (as the pre-fix shape did) is invisible to
+    alerting. The safety net here fires a WARNING so the misconfig
+    surfaces in ops logs.
+    """
+    warnings_sink: List[str] = []
+    self_ = _make_egress_self(
+        use_offchain=False,
+        done_tasks=[
+            {"is_offchain": True, "predict_api_event": {"src": "off"}},
+            {"is_offchain": False},
+        ],
+        warnings_sink=warnings_sink,
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    assert self_._egress_build_calls == []  # type: ignore[attr-defined]
+    assert any(
+        "diverging" in w and "task_execution" in w and "task_submission_abci" in w
+        for w in warnings_sink
+    ), warnings_sink
+
+
+def test_egress_gate_off_with_no_events_stays_silent() -> None:
+    """``use_offchain=False`` and empty ``done_tasks``: no warning fires.
+
+    Guards against the divergence warning becoming its own boot-noise
+    source on production mechs that ship dark by default (both flags
+    off, no ingress work happened, nothing to warn about).
+    """
+    warnings_sink: List[str] = []
+    self_ = _make_egress_self(
+        use_offchain=False, done_tasks=[], warnings_sink=warnings_sink
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    assert self_._egress_build_calls == []  # type: ignore[attr-defined]
+    assert warnings_sink == []
+
+
+def test_egress_gate_on_with_empty_url_short_circuits_at_debug_level() -> None:
+    """``use_offchain=True`` but empty ``predict_api_events_url``: DEBUG log, no HTTP call.
+
+    Same shape as the flag-off short-circuit but on the URL-missing
+    branch: an operator opted in to the pipeline but hasn't wired the
+    endpoint yet, so we degrade quietly (DEBUG, not WARNING) rather
+    than every settlement round shouting into ops logs.
+    """
+    debug_sink: List[str] = []
+    self_ = _make_egress_self(
+        use_offchain=True,
+        predict_api_events_url="",
+        debug_sink=debug_sink,
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    assert self_._egress_build_calls == []  # type: ignore[attr-defined]
+    assert any("predict_api_events_url empty" in msg for msg in debug_sink), debug_sink

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -24,14 +24,14 @@ Three pieces:
   - ``_sweep_pending_undelivered`` walks ``shared_state[PENDING_TASKS]``
     and RETURNS ``(events, swept_request_ids)`` for tasks past the local
     sweep age, without mutating the queue. All gated on
-    ``mech_events_enabled`` AND ``mech_events_sweep_pending_enabled``.
+    ``use_offchain`` AND ``mech_events_sweep_pending_enabled``.
   - ``_drop_swept_from_pending`` mutates ``PENDING_TASKS`` in place to
     drop the swept tasks. The caller only fires this after a confirmed
-    wildcard POST 2xx, so any of the six early-return paths in
-    ``_do_wildcard_write_best_effort`` (missing mech address, missing
+    predict-api POST 2xx, so any of the six early-return paths in
+    ``_do_predict_api_write_best_effort`` (missing mech address, missing
     marketplace, mixed chains, unconfigured chain id, digest failure,
     POST failure) leaves the tasks on the queue for a retry.
-  - ``_build_request_only_event`` shapes one entry into the wildcard
+  - ``_build_request_only_event`` shapes one entry into the predict-api
     event payload (``request`` half, ``response: None``,
     ``source: 'mech_onchain'``).
 
@@ -101,7 +101,7 @@ def _make_self(
 
     :param pending: value to stash under ``shared_state[PENDING_TASKS]``,
         or ``None`` to leave the key unset (simulates a fresh mech boot).
-    :param enabled: value for ``params.mech_events_enabled``.
+    :param enabled: value for ``params.use_offchain``.
     :param sweep_enabled: value for ``params.mech_events_sweep_pending_enabled``.
     :param max_age: value for ``params.mech_events_sweep_max_age_seconds``.
     :param chain_id: value for ``params.mech_events_chain_id``.
@@ -119,7 +119,7 @@ def _make_self(
             logger=_make_logger(),
         ),
         params=SimpleNamespace(
-            mech_events_enabled=enabled,
+            use_offchain=enabled,
             mech_events_sweep_pending_enabled=sweep_enabled,
             mech_events_sweep_max_age_seconds=max_age,
             mech_events_chain_id=chain_id,
@@ -165,7 +165,7 @@ def _make_pending_task(
 
 
 def test_sweep_returns_empty_when_mech_events_disabled() -> None:
-    """``mech_events_enabled=False`` short-circuits before any sweep."""
+    """``use_offchain=False`` short-circuits before any sweep."""
     self_ = _make_self(
         pending=[_make_pending_task("r-disabled", age_seconds=9999)],
         enabled=False,
@@ -246,7 +246,7 @@ def test_sweep_emits_for_stale_task_and_leaves_queue_untouched() -> None:
     """A stale task becomes a request-only event and its ``request_id`` is returned.
 
     The sweep itself does NOT mutate the queue — the caller drops the
-    swept tasks only after a confirmed wildcard POST 2xx (via
+    swept tasks only after a confirmed predict-api POST 2xx (via
     ``_drop_swept_from_pending``). The DB's ON CONFLICT (predict-api
     side) handles concurrent step-in, so the mech doesn't need to
     consult the contract to decide.
@@ -383,7 +383,7 @@ def test_drop_swept_from_pending_noop_when_pending_missing() -> None:
 def test_request_only_event_carries_expected_fields() -> None:
     """Event carries ``request.delivery_mech=None``, ``source='mech_onchain'``, ``response=None``.
 
-    Mirrors the shape the wildcard server's MechEvent model expects.
+    Mirrors the shape the predict-api server's MechEvent model expects.
     Mirrors the server-side validator in ``server/src/models/mech.py``:
     a request-only event with ``source='mech_offchain'`` would be
     rejected (an off-chain HTTP path doesn't produce undelivered events
@@ -412,7 +412,7 @@ def test_request_only_event_carries_expected_fields() -> None:
     assert req["requested_at"].endswith("Z")
     # delivery_rate stays a string (matches off-chain encoder).
     assert req["delivery_rate"] == str(10**16)
-    # Placeholder prompt/tool — wildcard requires them non-empty; the lake's
+    # Placeholder prompt/tool — predict-api requires them non-empty; the lake's
     # undelivered signal is the absent mech_responses row, not these fields.
     assert req["prompt"] == "[onchain undelivered]"
     assert req["tool"] == "unknown"
@@ -459,7 +459,7 @@ def test_request_only_event_skipped_for_missing_request_id() -> None:
     """Malformed pending entries (missing requestId / priorityMech /
 
     requester) return ``None`` so the sweep keeps the task on the queue
-    rather than emitting a wildcard 422-bait row.
+    rather than emitting a predict-api 422-bait row.
     """
     self_ = _make_self()
     bad = _make_pending_task("r-missing")
@@ -500,10 +500,10 @@ def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
 # Extract -----------------------------------------------------------------
 
 
-def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() -> None:
-    """The extractor keys on the presence of ``wildcard_event``, not on ``is_offchain``.
+def test_extract_offchain_events_includes_onchain_when_predict_api_event_present() -> None:
+    """The extractor keys on the presence of ``predict_api_event``, not on ``is_offchain``.
 
-    An on-chain marketplace task that carried a ``wildcard_event``
+    An on-chain marketplace task that carried a ``predict_api_event``
     (built by the task_execution finalize step) gets included in the
     batch.
     """
@@ -514,10 +514,10 @@ def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() 
         SimpleNamespace(
             synchronized_data=SimpleNamespace(
                 done_tasks=[
-                    {"is_offchain": True, "wildcard_event": {"src": "off"}},
-                    {"is_offchain": False, "wildcard_event": {"src": "on"}},
-                    {"is_offchain": False, "wildcard_event": None},  # skipped
-                    {"is_offchain": True, "wildcard_event": "not-a-dict"},  # skipped
+                    {"is_offchain": True, "predict_api_event": {"src": "off"}},
+                    {"is_offchain": False, "predict_api_event": {"src": "on"}},
+                    {"is_offchain": False, "predict_api_event": None},  # skipped
+                    {"is_offchain": True, "predict_api_event": "not-a-dict"},  # skipped
                 ]
             )
         ),
@@ -526,14 +526,14 @@ def test_extract_offchain_events_includes_onchain_when_wildcard_event_present() 
     assert events == [{"src": "off"}, {"src": "on"}]
 
 
-def test_extract_offchain_events_skips_tasks_without_wildcard_event() -> None:
-    """Done tasks without ``wildcard_event`` (e.g. on-chain non-marketplace legacy mech tasks) stay out of the batch."""
+def test_extract_offchain_events_skips_tasks_without_predict_api_event() -> None:
+    """Done tasks without ``predict_api_event`` (e.g. on-chain non-marketplace legacy mech tasks) stay out of the batch."""
     self_ = cast(
         PostTxSettlementBehaviour,
         SimpleNamespace(
             synchronized_data=SimpleNamespace(
                 done_tasks=[
-                    {"is_offchain": True},  # no wildcard_event at all
+                    {"is_offchain": True},  # no predict_api_event at all
                     {"is_offchain": False},
                 ]
             )

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -500,7 +500,9 @@ def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
 # Extract -----------------------------------------------------------------
 
 
-def test_extract_offchain_events_includes_onchain_when_predict_api_event_present() -> None:
+def test_extract_offchain_events_includes_onchain_when_predict_api_event_present() -> (
+    None
+):
     """The extractor keys on the presence of ``predict_api_event``, not on ``is_offchain``.
 
     An on-chain marketplace task that carried a ``predict_api_event``

--- a/packages/valory/skills/task_submission_abci/tests/test_predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_predict_api_events_client.py
@@ -17,9 +17,9 @@
 #
 # ------------------------------------------------------------------------------
 
-r"""Unit tests for the wildcard write client helpers.
+r"""Unit tests for the predict-api events client helpers.
 
-The server-side mirror lives at ``wildcard/server/src/mech_sig.py`` in
+The server-side mirror lives at ``server/src/mech_sig.py`` in
 predict-api#162; both sides must agree on the canonical-JSON encoding
 bit-for-bit. These tests pin the contract:
 
@@ -27,7 +27,7 @@ bit-for-bit. These tests pin the contract:
   separators, and keeps non-ASCII text as raw UTF-8 (so a prompt with
   emoji or accented characters hashes the same on both sides).
 * ``compute_batch_hash`` is order-sensitive: rearranging events in the
-  array yields a different hash (the wildcard server iterates left-to-
+  array yields a different hash (the predict-api server iterates left-to-
   right, so the mech can't shuffle the order after signing).
 * ``build_typed_data`` produces the exact shape the server expects:
   primary type ``MechEventBatch``, domain pinned to
@@ -37,7 +37,7 @@ bit-for-bit. These tests pin the contract:
 
 import json
 
-from packages.valory.skills.task_submission_abci.wildcard_write_client import (
+from packages.valory.skills.task_submission_abci.predict_api_events_client import (
     EVENTS_DOMAIN_NAME,
     EVENTS_DOMAIN_VERSION,
     EVENTS_PRIMARY_TYPE,
@@ -112,7 +112,7 @@ class TestComputeBatchHash:
         """Identical content with different declaration order yields same hash.
 
         Without this property, a serialisation that accidentally reordered
-        keys would invalidate the signature on the wildcard side.
+        keys would invalidate the signature on the predict-api side.
         """
         h1 = compute_batch_hash([{"x": 1, "y": 2}])
         h2 = compute_batch_hash([{"y": 2, "x": 1}])
@@ -122,7 +122,7 @@ class TestComputeBatchHash:
         """Single-character flip in the payload moves the hash entirely.
 
         This is the property that makes the signed batch_hash a real
-        tamper detector on the wildcard side.
+        tamper detector on the predict-api side.
         """
         h1 = compute_batch_hash([{"a": "real result"}])
         h2 = compute_batch_hash([{"a": "spoofed result"}])
@@ -131,7 +131,7 @@ class TestComputeBatchHash:
     def test_hash_is_order_sensitive_across_events(self) -> None:
         """Two events in different order yields different hashes.
 
-        The wildcard server iterates left-to-right when inserting, so the
+        The predict-api server iterates left-to-right when inserting, so the
         mech can't shuffle and still get a match.
         """
         events_a = [{"r": "first"}, {"r": "second"}]

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -356,7 +356,7 @@ class TestTaskSubmissionAbciApp:
 
         # Post-settlement leg: DONE leaves the skill via the new degenerate
         # final state, both NO_MAJORITY and ROUND_TIMEOUT loop back so a
-        # transient consensus dip doesn't crash the FSM (the wildcard write
+        # transient consensus dip doesn't crash the FSM (the predict-api write
         # itself is idempotent, so re-entry is safe).
         post_tx = TaskSubmissionAbciApp.transition_function[PostTxSettlementRound]
         assert post_tx[Event.DONE] is FinishedPostTxSettlementRound
@@ -470,7 +470,7 @@ class TestPostTxSettlementRound:
     """End-to-end behaviour pin for ``PostTxSettlementRound``.
 
     The round is a CollectSameUntilThresholdRound: it only needs consensus
-    on participation (the wildcard POST itself is fire-and-forget,
+    on participation (the predict-api POST itself is fire-and-forget,
     idempotent server-side). DONE on threshold, NO_MAJORITY only when
     consensus is impossible.
     """
@@ -524,7 +524,7 @@ class TestPostTxSettlementRound:
         no-op, and the same batch is re-delivered on every settlement
         cycle — the Safe tx succeeds but ``mech.deliverMulti`` reverts on
         the already-delivered ids, burning gas without emitting new
-        Deliver events. Any wildcard re-fire concern on self-loop must be
+        Deliver events. Any predict-api re-fire concern on self-loop must be
         guarded inside the behaviour, not by mutating this field.
         """
         tasks = [_make_task("req-1"), _make_task("req-2")]


### PR DESCRIPTION
## Summary

Companion to [valory-xyz/predict-api#166](https://github.com/valory-xyz/predict-api/pull/166) (which drops the server-side kill switch and seeds the production operator allowlist). This PR simplifies the client-side config surface to one flag with clear semantics and renames the wildcard-branded params.

### 1. Dual-purpose `use_offchain`, drop `mech_events_enabled`

The two flags now collapse into one:

- **`use_offchain=true`** — mech accepts offchain requests via the offchain HTTP handler AND writes settlement events (both offchain-settled and on-chain-settled) to the predict-api events endpoint from PostTxSettlement.
- **`use_offchain=false`** — offchain endpoint returns 503 AND no settlement events are written at all. Legacy on-chain + IPFS behaviour unchanged.

Default stays `false`. Writes require the mech to be in predict-api's `mech_operators_by_chain` allowlist. A mech is either part of the predict-api analytics pipeline or it isn't; there's no coherent state where ingress and egress diverge, so a single flag is sufficient.

`mech_events_enabled` is deleted from both `task_execution` and `task_submission_abci` `models.py` and `skill.yaml`. All gate points in `behaviours.py` now read `use_offchain`.

### 2. Rename `wildcard_*` → `predict_api_*`

Config params (defaults in the composed skill):

| Old | New | Default |
|---|---|---|
| `wildcard_events_url` | `predict_api_events_url` | `https://mpp.autonolas.tech/mech/events` |
| `wildcard_events_timeout_seconds` | `predict_api_events_timeout_seconds` | `5.0` |

Files (renamed via `git mv` — history preserved):

- `packages/valory/skills/task_submission_abci/wildcard_write_client.py` → `predict_api_events_client.py`
- `packages/valory/skills/task_submission_abci/tests/test_wildcard_write_client.py` → `tests/test_predict_api_events_client.py`

Internal helpers: `_post_wildcard_batch` → `_post_predict_api_batch`, `_build_wildcard_event` → `_build_predict_api_event`, `wildcard_source` → `predict_api_source`, `done_task[\"wildcard_event\"]` → `done_task[\"predict_api_event\"]`, `_do_wildcard_write_best_effort` → `_do_predict_api_write_best_effort`.

**On-wire EIP-712 domain constants (`Olas Mech Events`, `MechEventBatch`, `1`) stay exactly as-is — the server binds to them, do NOT rename.**

### 3. Behaviour-change note: `predict_api_events_url` default

The rename in §2 also flipped the default value for this param, so calling it out explicitly rather than burying under "rename":

| | Old default | New default |
|---|---|---|
| `wildcard_events_url` / `predict_api_events_url` | `""` (short-circuit — egress helper returned before any HTTP work) | `https://mpp.autonolas.tech/mech/events` |

Why this is safe under the flag semantics:
- The opt-in stays **`use_offchain`**, not the URL. A legacy mech upgrading with `use_offchain=false` sees zero behaviour change; the egress helper still short-circuits at the flag gate above the URL check.
- When `use_offchain=true`, the URL now auto-targets production. Deployments that want to point at a staging predict-api set `predict_api_events_url` in the composed skill's `params.args` block just as before.
- The empty-string sentinel path (URL-missing DEBUG log) still exists — flip the flag on with an empty URL and you get a quiet DEBUG line, not a WARNING, for staged rollouts where the endpoint isn't wired yet.

## Test plan

- [x] `autonomy packages lock` clean — skill → agent → service hashes cascade
- [x] 112 tests pass across `task_execution/tests/test_handlers.py`, `task_submission_abci/tests/test_predict_api_events_client.py`, `task_submission_abci/tests/test_onchain_write_path.py`
- [x] Ingress-gate coverage on `_finalize_done_task` (`use_offchain=True` off-chain HTTP + on-chain marketplace shapes, and the `use_offchain=False` dark-ship guarantee).
- [x] Egress-gate coverage on `_do_predict_api_write_best_effort` (`use_offchain=False` short-circuit, empty-URL DEBUG short-circuit, silent-divergence WARNING when the two flag copies drift).
- [ ] Full CI green
- [ ] Downstream (mech-predict / trader / optimus / basius / meme-ooorr) pick up the rename cleanly on the next `upstream_pins` bump

### Prometheus metric rename

`mech_wildcard_events_total` → `mech_predict_api_events_total`. No Grafana dashboard or alert rule keyed on the old name at time of merge (checked before shipping), so no dual-emit needed. If a consumer surfaces later, the counter is a straight rename with no label-shape change; migrating the query is a one-line find-and-replace on the metric name.

### Deployment coordination for the 4 mechs currently running `use_offchain=true`

The `predict_api_events_url` default changed from `""` (short-circuit) to `https://mpp.autonolas.tech/mech/events`. Any mech that ships with `use_offchain=true` and no explicit URL override will start POSTing settlement events to prod on its next upgrade. Handled operationally rather than in this PR: the 4 mechs already running `use_offchain=true` will have the flag set back to `false` in agent-deployments before the redeploy that picks up this change, so they explicitly re-enrol via config rather than silently upgrade into POSTing.

## Downstream migration

Any deployment currently setting `MECH_EVENTS_ENABLED=true` or `WILDCARD_EVENTS_URL=...` at the env-var layer will emit \"unknown param\" warnings from the aea loader after upgrade but will otherwise boot. In practice these envs are unset today (predict-api endpoint was never live in prod), so the rename is cost-free.

After merge: cut a new mech tag (v0.34.3 or similar) so downstreams have a pin.

