### PR TITLE
chore: deprecate TokenCounterCallback and the hardcoded TOKEN_PRICES table

### DIFF
--- a/packages/valory/skills/task_execution/utils/benchmarks.py
+++ b/packages/valory/skills/task_execution/utils/benchmarks.py
@@ -16,16 +16,40 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""Benchmarking for tools."""
+"""Benchmarking for tools.
+
+.. note::
+    ``TokenCounterCallback`` is **deprecated**. The hardcoded ``TOKEN_PRICES``
+    table is unsustainable as new models are released and conflicts with the
+    mech's role as a thin intermediary between clients and tools. Tool authors
+    should report their own pricing in the tool package instead. This module
+    remains importable for backwards compatibility and will emit
+    ``DeprecationWarning`` on instantiation; it will be removed in a future
+    release.
+"""
 
 import logging
+import warnings
 from typing import Any, Callable, Dict, Optional, Union
 
 PRICE_NUM_TOKENS = 1000
 
+_DEPRECATION_MSG = (
+    "TokenCounterCallback is deprecated and the hardcoded TOKEN_PRICES table "
+    "will be removed. Tool packages should report their own pricing rather "
+    "than relying on this central registry. See issue #319 for context."
+)
+
 
 class TokenCounterCallback:
-    """Callback to count the number of tokens used in a generation."""
+    """Callback to count the number of tokens used in a generation.
+
+    .. deprecated::
+        Use the tool package's own pricing metadata instead. This callback and
+        its ``TOKEN_PRICES`` table are no longer the right place for model
+        pricing -- they go stale as new models ship and grow unboundedly. See
+        issue #319 for the rationale and the planned replacement.
+    """
 
     TOKEN_PRICES = {
         "gpt-3.5-turbo": {"input": 0.0005, "output": 0.0015},
@@ -60,6 +84,7 @@ class TokenCounterCallback:
 
     def __init__(self) -> None:
         """Initialize the callback."""
+        warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
         self.actual_model: Optional[str] = None
         self.cost_dict: Dict[str, Union[int, float]] = {
             "input_tokens": 0,


### PR DESCRIPTION
## Summary

Closes #319

Deprecates `TokenCounterCallback` and its hardcoded `TOKEN_PRICES` table per the discussion on PR #318. The hardcoded price dict is unsustainable (goes stale as new models ship, grows unboundedly) and conflicts with the mech's intended role as a thin intermediary between clients and tools — pricing should live in each tool package instead.

## Changes

- Adds `import warnings` to `benchmarks.py`
- Adds a module-level deprecation note explaining the rationale
- Adds a `.. deprecated::` directive to the class docstring
- Adds a `_DEPRECATION_MSG` constant
- Emits `DeprecationWarning` on `__init__` (stacklevel=2)

## Backwards compatibility

- Class is **fully functional** — no behavior change
- All callers (`behaviours.py`, `test_benchmarks.py`) continue to work
- Existing tests still pass; they will emit `DeprecationWarning` at runtime
- `TOKEN_PRICES` table preserved (will be removed in a follow-up)

## Follow-up

A future PR should remove the class entirely once tool packages carry their own pricing metadata.