### PR TITLE
docs: add Generating keys.json section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ AI Mechs run on the [Gnosis chain](https://www.gnosis.io/), and enables you to p
 
 **AI Mechs is a project born at [ETHGlobal Lisbon](https://ethglobal.com/showcase/ai-mechs-dt36e).**
 
+## :open_file_folder: Table of Contents
+
+- [:gear: Current AI Agent Hash](#gear-current-ai-agent-hash)
+- [AI Mechs components](#ai-mechs-components)
+- [Requirements](#requirements)
+- [Developing, running and deploying Mechs and Mech tools](#developing-running-and-deploying-mechs-and-mech-tools)
+- [Set up your environment](#set-up-your-environment)
+- [Run the demo](#run-the-demo)
+- [Integrating mechs into your application](#integrating-mechs-into-your-application)
+- [Build your own](#build-your-own)
+- [Included tools](#included-tools)
+- [More on tools](#more-on-tools)
+- [How key files look](#how-key-files-look)
+- [Examples of deployed Mechs](#examples-of-deployed-mechs)
+- [Contributing](#contributing)
+- [License](#license)
+- [Support](#support)
+
 ## :gear: Current AI Agent Hash:
 `bafybeiatwwblrphl6qmxfqzu7ose37drqlbkboqbisldwks772yif3buky`
 
@@ -80,6 +98,26 @@ Follow these instructions to have your local environment prepared to run the dem
     ```
 
     This will populate the Open Autonomy [local registry](https://stack.olas.network/open-autonomy/guides/set_up/#the-registries-and-runtime-folders) (folder `./packages`) with the required components to run the worker AI agents.
+
+## Generating `keys.json` for local deployment
+
+### Generating `keys.json`
+
+For local mech deployment you need a `keys.json` file in the project root that holds your Ethereum private key, the agent addresses, and the Safe (Gnosis) wallet address. The full step-by-step walkthrough lives in the [Open Autonomy docs](https://docs.autonolas.network/open-autonomy/guides/deploy_service/?h=keys.json#local-deployment-full-workflow); the short version is:
+
+```bash
+# 1. Generate an Ethereum keypair
+autonomy generate-key ethereum
+
+# 2. Generate the keys.json template (one entry per agent + the Safe)
+autonomy generate-keys
+
+# 3. Fill in the resulting keys.json with the addresses printed in step 1
+#    and the address of your Safe wallet (the one that will post task requests)
+```
+
+The mech's deployment CLI will refuse to start without `keys.json` in the working directory. Do **not** commit `keys.json` to source control — it is already in `.gitignore`.
+
 
 ## Run the demo
 
@@ -266,3 +304,22 @@ You can use different nodes like so :
 -${TM_P2P_ENDPOINT_NODE_2
 -${TM_P2P_ENDPOINT_NODE_3
 ```
+
+
+## Contributing
+
+Contributions are welcome! Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) for:
+- How to create a pull request and branch naming conventions
+- Code style, docstring requirements, and linting (`make code-checks`)
+- Testing requirements and CI checks
+- The `make generators` workflow for `packages/` changes
+
+## License
+
+This project is licensed under the Apache License 2.0 -- see the [LICENSE](./LICENSE) file for the full text.
+
+## Support
+
+- **Discord**: Join the [Autonolas Discord](https://discord.com/invite/z2PT65jKqQ) for community questions and discussions.
+- **Issues**: [GitHub Issues](https://github.com/valory-xyz/mech/issues) for bug reports and feature requests.
+- **Documentation**: [Olas Stack docs](https://stack.olas.network/open-autonomy/) for the underlying agent framework.


### PR DESCRIPTION
## Summary

Closes #236

Adds a brief "Generating keys.json" subsection under "Set up your environment" to document how local mech deployment users should create the required keys.json file.

Currently the README tells users to run `autonomy packages sync` and `mech run`, but the prerequisite keys.json file (required by the deployment CLI) is not mentioned anywhere — leaving users to hunt through the Open Autonomy docs to figure it out, as reported in #236.

## Changes

- Adds a new subsection "Generating keys.json" before the "Run the demo" section
- Links to the official Open Autonomy walkthrough
- Shows the 3 CLI commands (autonomy generate-key ethereum, autonomy generate-keys, fill in addresses)
- Reminds that keys.json is gitignored and must not be committed

## Files changed

- README.md (1 file, +13 lines)