### PR TITLE
fix(task_execution): coerce off-chain requestId to int at ingress (fixes TaskPoolingRound crash)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeifeejhmevelmvwsazdttmlyokpfvw656uufcyto2aoevof5n46i4a",
+        "skill/valory/mech_abci/0.1.0": "bafybeigvzaz7bt6trflytxka7xznxk4vffhki2wcfznlvbklnoav5fyy6m",
         "skill/valory/task_execution/0.1.0": "bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifaa2m3fidrcl4xiadj627er4lu2c52sw26wrzzvu3les6ajyjsza",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiap5avfaitvmxcv7be7ocajakbcqx6bw4zpt6gkwczfubtkcjghl4",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeihkzpkchaotk3ayoecoq3iflc2bbszcpxplj3def66gostasjtvoa",
-        "service/valory/mech/0.1.0": "bafybeigapgy4x5ugj6mv3myigxp53sf2e6p2ky3xddjrkuo3aadhdg335y"
+        "agent/valory/mech/0.1.0": "bafybeiemxyi27p4ixdxgiyekqvkqoatgio7innr7bpda5fdff7m63mon2y",
+        "service/valory/mech/0.1.0": "bafybeidhfqr4cap4hysgqhverafzdssialnsadniqlpsopfvmzwl23safu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeiagmhiqhawm3hsiod6tg4i3izvmbqxrx7lzy3zkxxqrwzc7bgs7bm",
-        "skill/valory/task_execution/0.1.0": "bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibpqyppfz2gnoz6hsjzb7xoysjmfjfqavtpydbqba2tw7wznpss24",
+        "skill/valory/mech_abci/0.1.0": "bafybeib4vevge3xm4m2olykdfmh4ymzjbdmqb5dlfhniegi5lozrbceuwy",
+        "skill/valory/task_execution/0.1.0": "bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiebu75qpfumaf4i65bzlsdsniqinaixlz3yf5ecye7xm7rfgqtjq4",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiffzzralcn2tl25xoraioohcfani45ywqbouewx5fdlze2ylur7by",
-        "service/valory/mech/0.1.0": "bafybeiar7wx5ataqtrxsuy7ucjvo6zat3kcgwy2z6mfsvkzj6prjlgjloa"
+        "agent/valory/mech/0.1.0": "bafybeieigv7eo44zl6hkqmeyqwjhlv6sgipz4q5xpnhla4pmtcmpudt4uy",
+        "service/valory/mech/0.1.0": "bafybeiebjkaqzgxlnt7w2uebb6la6n36yym2dboakrr6pdmp3dtg47w7tq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeib3er437zyozihosae2nfryi3ohz5aaoqsjuxjtk3qdvq3jbw4yeu",
-        "skill/valory/task_execution/0.1.0": "bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidr5wqebxsafl6owypj6enpkgvicz3wjvqyasktmycljanjc6hl2u",
+        "skill/valory/mech_abci/0.1.0": "bafybeifeakx4i5kwk4o3u22r23td2765cfgv6xy5ssvizra7lwceoc3qhe",
+        "skill/valory/task_execution/0.1.0": "bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidwyekjim4d7qxquou3kmpbmvph7vv67aygjbxha4wu4q6x3uqhp4",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeigmubdpxfo6vxumjuuodjcowwtngn73wp7tuqrh32wxi5udpwwrmu",
-        "service/valory/mech/0.1.0": "bafybeibu2jgaezyfsozk4eubfah7xb2g25mayznvrcj4b5ajciigtwek5m"
+        "agent/valory/mech/0.1.0": "bafybeiberpbb2phvob7hdnjltvmfeezv5pqjmgmrjnpqzer3hikqwcf27a",
+        "service/valory/mech/0.1.0": "bafybeihv4adms6votnctj55ygx4p5t7whinlb7hkmppjicgrebzmcwddky"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeib4vevge3xm4m2olykdfmh4ymzjbdmqb5dlfhniegi5lozrbceuwy",
-        "skill/valory/task_execution/0.1.0": "bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiebu75qpfumaf4i65bzlsdsniqinaixlz3yf5ecye7xm7rfgqtjq4",
+        "skill/valory/mech_abci/0.1.0": "bafybeifzyu7qhiyeyetggwbk77wnr7r4usxi7am3ossymngumoij4a3kty",
+        "skill/valory/task_execution/0.1.0": "bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibmubbzm2qi7vd5ijxr3ybvb4o3daunl47hekypkqx6jgsdtwha64",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeieigv7eo44zl6hkqmeyqwjhlv6sgipz4q5xpnhla4pmtcmpudt4uy",
-        "service/valory/mech/0.1.0": "bafybeiebjkaqzgxlnt7w2uebb6la6n36yym2dboakrr6pdmp3dtg47w7tq"
+        "agent/valory/mech/0.1.0": "bafybeidzzddmpjkaiqyzkhae45i7jerfztw4n3f35lj7egj7pkfnl7uylu",
+        "service/valory/mech/0.1.0": "bafybeifikguy3yqzvozeqp6yqqqoqwows6c6w4h734mqf2ig3kkeonx4ya"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeib3ifb5uxddxdf26hzumhjw4tnaoebamzr3bgzaipg2bsqnab7ff4",
-        "skill/valory/task_execution/0.1.0": "bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidzz2tzottptzxwktq4km3exu2athbmdv75rdm7bxj5lbnbugjuli",
+        "skill/valory/mech_abci/0.1.0": "bafybeiagmhiqhawm3hsiod6tg4i3izvmbqxrx7lzy3zkxxqrwzc7bgs7bm",
+        "skill/valory/task_execution/0.1.0": "bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibpqyppfz2gnoz6hsjzb7xoysjmfjfqavtpydbqba2tw7wznpss24",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidb2g6g2b7iurdatmttmhbvsjj6ch2gupdbhhu3dpwciocnb5vbsq",
-        "service/valory/mech/0.1.0": "bafybeibc6negqtv25snkczuyawyxaiaskmndqab7kuaa237urubqfpk4ym"
+        "agent/valory/mech/0.1.0": "bafybeiffzzralcn2tl25xoraioohcfani45ywqbouewx5fdlze2ylur7by",
+        "service/valory/mech/0.1.0": "bafybeiar7wx5ataqtrxsuy7ucjvo6zat3kcgwy2z6mfsvkzj6prjlgjloa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeihmkuekxrgdyyvb66dsskam6d7bcaqb7g5nwzf5devl6hq3qum6y4",
-        "skill/valory/task_execution/0.1.0": "bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeic3kbudgmxfnexywpxkgj2vbrvxeh5reotuhvgjjvymgksjcah3ea",
+        "skill/valory/mech_abci/0.1.0": "bafybeib3er437zyozihosae2nfryi3ohz5aaoqsjuxjtk3qdvq3jbw4yeu",
+        "skill/valory/task_execution/0.1.0": "bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidr5wqebxsafl6owypj6enpkgvicz3wjvqyasktmycljanjc6hl2u",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeibw723ghvuxj7rqlmifqc5icsil54n7jugdgueakfs3azvhfnjt3u",
-        "service/valory/mech/0.1.0": "bafybeihfbjy7ojxsqnlzucnxquijxbznkfw7fu7aiobdvqycpkyqvkno3y"
+        "agent/valory/mech/0.1.0": "bafybeigmubdpxfo6vxumjuuodjcowwtngn73wp7tuqrh32wxi5udpwwrmu",
+        "service/valory/mech/0.1.0": "bafybeibu2jgaezyfsozk4eubfah7xb2g25mayznvrcj4b5ajciigtwek5m"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia",
-        "skill/valory/task_execution/0.1.0": "bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu",
+        "skill/valory/mech_abci/0.1.0": "bafybeifeejhmevelmvwsazdttmlyokpfvw656uufcyto2aoevof5n46i4a",
+        "skill/valory/task_execution/0.1.0": "bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifaa2m3fidrcl4xiadj627er4lu2c52sw26wrzzvu3les6ajyjsza",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiab7emnojt4uglfdpk7x6x26wmnqs5azf7favs7qw3o3yebmkydxa",
-        "service/valory/mech/0.1.0": "bafybeicjlkkltnpt4m3pse74e4fgq4lwbmbg7mx4ecdvmtsouzslmjbrxy"
+        "agent/valory/mech/0.1.0": "bafybeihkzpkchaotk3ayoecoq3iflc2bbszcpxplj3def66gostasjtvoa",
+        "service/valory/mech/0.1.0": "bafybeigapgy4x5ugj6mv3myigxp53sf2e6p2ky3xddjrkuo3aadhdg335y"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeifzyu7qhiyeyetggwbk77wnr7r4usxi7am3ossymngumoij4a3kty",
-        "skill/valory/task_execution/0.1.0": "bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibmubbzm2qi7vd5ijxr3ybvb4o3daunl47hekypkqx6jgsdtwha64",
+        "skill/valory/mech_abci/0.1.0": "bafybeihmkuekxrgdyyvb66dsskam6d7bcaqb7g5nwzf5devl6hq3qum6y4",
+        "skill/valory/task_execution/0.1.0": "bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeic3kbudgmxfnexywpxkgj2vbrvxeh5reotuhvgjjvymgksjcah3ea",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidzzddmpjkaiqyzkhae45i7jerfztw4n3f35lj7egj7pkfnl7uylu",
-        "service/valory/mech/0.1.0": "bafybeifikguy3yqzvozeqp6yqqqoqwows6c6w4h734mqf2ig3kkeonx4ya"
+        "agent/valory/mech/0.1.0": "bafybeibw723ghvuxj7rqlmifqc5icsil54n7jugdgueakfs3azvhfnjt3u",
+        "service/valory/mech/0.1.0": "bafybeihfbjy7ojxsqnlzucnxquijxbznkfw7fu7aiobdvqycpkyqvkno3y"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeifeakx4i5kwk4o3u22r23td2765cfgv6xy5ssvizra7lwceoc3qhe",
-        "skill/valory/task_execution/0.1.0": "bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidwyekjim4d7qxquou3kmpbmvph7vv67aygjbxha4wu4q6x3uqhp4",
+        "skill/valory/mech_abci/0.1.0": "bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma",
+        "skill/valory/task_execution/0.1.0": "bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiberpbb2phvob7hdnjltvmfeezv5pqjmgmrjnpqzer3hikqwcf27a",
-        "service/valory/mech/0.1.0": "bafybeihv4adms6votnctj55ygx4p5t7whinlb7hkmppjicgrebzmcwddky"
+        "agent/valory/mech/0.1.0": "bafybeic6bbexqkfh65skvagele4drkys4w3vg4l4ymtdocbafwdsgxiiga",
+        "service/valory/mech/0.1.0": "bafybeibytetwgjgnd5npgrwmfo3ydu2icthuiu2otqjvhczv6xlkyo7yz4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeigvzaz7bt6trflytxka7xznxk4vffhki2wcfznlvbklnoav5fyy6m",
-        "skill/valory/task_execution/0.1.0": "bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiap5avfaitvmxcv7be7ocajakbcqx6bw4zpt6gkwczfubtkcjghl4",
+        "skill/valory/mech_abci/0.1.0": "bafybeib3ifb5uxddxdf26hzumhjw4tnaoebamzr3bgzaipg2bsqnab7ff4",
+        "skill/valory/task_execution/0.1.0": "bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidzz2tzottptzxwktq4km3exu2athbmdv75rdm7bxj5lbnbugjuli",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiemxyi27p4ixdxgiyekqvkqoatgio7innr7bpda5fdff7m63mon2y",
-        "service/valory/mech/0.1.0": "bafybeidhfqr4cap4hysgqhverafzdssialnsadniqlpsopfvmzwl23safu"
+        "agent/valory/mech/0.1.0": "bafybeidb2g6g2b7iurdatmttmhbvsjj6ch2gupdbhhu3dpwciocnb5vbsq",
+        "service/valory/mech/0.1.0": "bafybeibc6negqtv25snkczuyawyxaiaskmndqab7kuaa237urubqfpk4ym"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeifeejhmevelmvwsazdttmlyokpfvw656uufcyto2aoevof5n46i4a
+- valory/mech_abci:0.1.0:bafybeigvzaz7bt6trflytxka7xznxk4vffhki2wcfznlvbklnoav5fyy6m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
 - valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
-- valory/task_submission_abci:0.1.0:bafybeifaa2m3fidrcl4xiadj627er4lu2c52sw26wrzzvu3les6ajyjsza
+- valory/task_submission_abci:0.1.0:bafybeiap5avfaitvmxcv7be7ocajakbcqx6bw4zpt6gkwczfubtkcjghl4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiagmhiqhawm3hsiod6tg4i3izvmbqxrx7lzy3zkxxqrwzc7bgs7bm
+- valory/mech_abci:0.1.0:bafybeib4vevge3xm4m2olykdfmh4ymzjbdmqb5dlfhniegi5lozrbceuwy
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi
-- valory/task_submission_abci:0.1.0:bafybeibpqyppfz2gnoz6hsjzb7xoysjmfjfqavtpydbqba2tw7wznpss24
+- valory/task_execution:0.1.0:bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa
+- valory/task_submission_abci:0.1.0:bafybeiebu75qpfumaf4i65bzlsdsniqinaixlz3yf5ecye7xm7rfgqtjq4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeifzyu7qhiyeyetggwbk77wnr7r4usxi7am3ossymngumoij4a3kty
+- valory/mech_abci:0.1.0:bafybeihmkuekxrgdyyvb66dsskam6d7bcaqb7g5nwzf5devl6hq3qum6y4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664
-- valory/task_submission_abci:0.1.0:bafybeibmubbzm2qi7vd5ijxr3ybvb4o3daunl47hekypkqx6jgsdtwha64
+- valory/task_execution:0.1.0:bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i
+- valory/task_submission_abci:0.1.0:bafybeic3kbudgmxfnexywpxkgj2vbrvxeh5reotuhvgjjvymgksjcah3ea
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia
+- valory/mech_abci:0.1.0:bafybeifeejhmevelmvwsazdttmlyokpfvw656uufcyto2aoevof5n46i4a
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
-- valory/task_submission_abci:0.1.0:bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu
+- valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
+- valory/task_submission_abci:0.1.0:bafybeifaa2m3fidrcl4xiadj627er4lu2c52sw26wrzzvu3les6ajyjsza
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeib3ifb5uxddxdf26hzumhjw4tnaoebamzr3bgzaipg2bsqnab7ff4
+- valory/mech_abci:0.1.0:bafybeiagmhiqhawm3hsiod6tg4i3izvmbqxrx7lzy3zkxxqrwzc7bgs7bm
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi
-- valory/task_submission_abci:0.1.0:bafybeidzz2tzottptzxwktq4km3exu2athbmdv75rdm7bxj5lbnbugjuli
+- valory/task_execution:0.1.0:bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi
+- valory/task_submission_abci:0.1.0:bafybeibpqyppfz2gnoz6hsjzb7xoysjmfjfqavtpydbqba2tw7wznpss24
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeib3er437zyozihosae2nfryi3ohz5aaoqsjuxjtk3qdvq3jbw4yeu
+- valory/mech_abci:0.1.0:bafybeifeakx4i5kwk4o3u22r23td2765cfgv6xy5ssvizra7lwceoc3qhe
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy
-- valory/task_submission_abci:0.1.0:bafybeidr5wqebxsafl6owypj6enpkgvicz3wjvqyasktmycljanjc6hl2u
+- valory/task_execution:0.1.0:bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay
+- valory/task_submission_abci:0.1.0:bafybeidwyekjim4d7qxquou3kmpbmvph7vv67aygjbxha4wu4q6x3uqhp4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeihmkuekxrgdyyvb66dsskam6d7bcaqb7g5nwzf5devl6hq3qum6y4
+- valory/mech_abci:0.1.0:bafybeib3er437zyozihosae2nfryi3ohz5aaoqsjuxjtk3qdvq3jbw4yeu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i
-- valory/task_submission_abci:0.1.0:bafybeic3kbudgmxfnexywpxkgj2vbrvxeh5reotuhvgjjvymgksjcah3ea
+- valory/task_execution:0.1.0:bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy
+- valory/task_submission_abci:0.1.0:bafybeidr5wqebxsafl6owypj6enpkgvicz3wjvqyasktmycljanjc6hl2u
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeib4vevge3xm4m2olykdfmh4ymzjbdmqb5dlfhniegi5lozrbceuwy
+- valory/mech_abci:0.1.0:bafybeifzyu7qhiyeyetggwbk77wnr7r4usxi7am3ossymngumoij4a3kty
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa
-- valory/task_submission_abci:0.1.0:bafybeiebu75qpfumaf4i65bzlsdsniqinaixlz3yf5ecye7xm7rfgqtjq4
+- valory/task_execution:0.1.0:bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664
+- valory/task_submission_abci:0.1.0:bafybeibmubbzm2qi7vd5ijxr3ybvb4o3daunl47hekypkqx6jgsdtwha64
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeifeakx4i5kwk4o3u22r23td2765cfgv6xy5ssvizra7lwceoc3qhe
+- valory/mech_abci:0.1.0:bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay
-- valory/task_submission_abci:0.1.0:bafybeidwyekjim4d7qxquou3kmpbmvph7vv67aygjbxha4wu4q6x3uqhp4
+- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
+- valory/task_submission_abci:0.1.0:bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigvzaz7bt6trflytxka7xznxk4vffhki2wcfznlvbklnoav5fyy6m
+- valory/mech_abci:0.1.0:bafybeib3ifb5uxddxdf26hzumhjw4tnaoebamzr3bgzaipg2bsqnab7ff4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
-- valory/task_submission_abci:0.1.0:bafybeiap5avfaitvmxcv7be7ocajakbcqx6bw4zpt6gkwczfubtkcjghl4
+- valory/task_execution:0.1.0:bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi
+- valory/task_submission_abci:0.1.0:bafybeidzz2tzottptzxwktq4km3exu2athbmdv75rdm7bxj5lbnbugjuli
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihkzpkchaotk3ayoecoq3iflc2bbszcpxplj3def66gostasjtvoa
+agent: valory/mech:0.1.0:bafybeiemxyi27p4ixdxgiyekqvkqoatgio7innr7bpda5fdff7m63mon2y
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeieigv7eo44zl6hkqmeyqwjhlv6sgipz4q5xpnhla4pmtcmpudt4uy
+agent: valory/mech:0.1.0:bafybeidzzddmpjkaiqyzkhae45i7jerfztw4n3f35lj7egj7pkfnl7uylu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidzzddmpjkaiqyzkhae45i7jerfztw4n3f35lj7egj7pkfnl7uylu
+agent: valory/mech:0.1.0:bafybeibw723ghvuxj7rqlmifqc5icsil54n7jugdgueakfs3azvhfnjt3u
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiffzzralcn2tl25xoraioohcfani45ywqbouewx5fdlze2ylur7by
+agent: valory/mech:0.1.0:bafybeieigv7eo44zl6hkqmeyqwjhlv6sgipz4q5xpnhla4pmtcmpudt4uy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiab7emnojt4uglfdpk7x6x26wmnqs5azf7favs7qw3o3yebmkydxa
+agent: valory/mech:0.1.0:bafybeihkzpkchaotk3ayoecoq3iflc2bbszcpxplj3def66gostasjtvoa
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeibw723ghvuxj7rqlmifqc5icsil54n7jugdgueakfs3azvhfnjt3u
+agent: valory/mech:0.1.0:bafybeigmubdpxfo6vxumjuuodjcowwtngn73wp7tuqrh32wxi5udpwwrmu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiemxyi27p4ixdxgiyekqvkqoatgio7innr7bpda5fdff7m63mon2y
+agent: valory/mech:0.1.0:bafybeidb2g6g2b7iurdatmttmhbvsjj6ch2gupdbhhu3dpwciocnb5vbsq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiberpbb2phvob7hdnjltvmfeezv5pqjmgmrjnpqzer3hikqwcf27a
+agent: valory/mech:0.1.0:bafybeic6bbexqkfh65skvagele4drkys4w3vg4l4ymtdocbafwdsgxiiga
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigmubdpxfo6vxumjuuodjcowwtngn73wp7tuqrh32wxi5udpwwrmu
+agent: valory/mech:0.1.0:bafybeiberpbb2phvob7hdnjltvmfeezv5pqjmgmrjnpqzer3hikqwcf27a
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidb2g6g2b7iurdatmttmhbvsjj6ch2gupdbhhu3dpwciocnb5vbsq
+agent: valory/mech:0.1.0:bafybeiffzzralcn2tl25xoraioohcfani45ywqbouewx5fdlze2ylur7by
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiebu75qpfumaf4i65bzlsdsniqinaixlz3yf5ecye7xm7rfgqtjq4
+- valory/task_submission_abci:0.1.0:bafybeibmubbzm2qi7vd5ijxr3ybvb4o3daunl47hekypkqx6jgsdtwha64
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa
+- valory/task_execution:0.1.0:bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeidzz2tzottptzxwktq4km3exu2athbmdv75rdm7bxj5lbnbugjuli
+- valory/task_submission_abci:0.1.0:bafybeibpqyppfz2gnoz6hsjzb7xoysjmfjfqavtpydbqba2tw7wznpss24
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi
+- valory/task_execution:0.1.0:bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeidr5wqebxsafl6owypj6enpkgvicz3wjvqyasktmycljanjc6hl2u
+- valory/task_submission_abci:0.1.0:bafybeidwyekjim4d7qxquou3kmpbmvph7vv67aygjbxha4wu4q6x3uqhp4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy
+- valory/task_execution:0.1.0:bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu
+- valory/task_submission_abci:0.1.0:bafybeifaa2m3fidrcl4xiadj627er4lu2c52sw26wrzzvu3les6ajyjsza
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
+- valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,7 +30,7 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeifaa2m3fidrcl4xiadj627er4lu2c52sw26wrzzvu3les6ajyjsza
+- valory/task_submission_abci:0.1.0:bafybeiap5avfaitvmxcv7be7ocajakbcqx6bw4zpt6gkwczfubtkcjghl4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiap5avfaitvmxcv7be7ocajakbcqx6bw4zpt6gkwczfubtkcjghl4
+- valory/task_submission_abci:0.1.0:bafybeidzz2tzottptzxwktq4km3exu2athbmdv75rdm7bxj5lbnbugjuli
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
+- valory/task_execution:0.1.0:bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeibmubbzm2qi7vd5ijxr3ybvb4o3daunl47hekypkqx6jgsdtwha64
+- valory/task_submission_abci:0.1.0:bafybeic3kbudgmxfnexywpxkgj2vbrvxeh5reotuhvgjjvymgksjcah3ea
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664
+- valory/task_execution:0.1.0:bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeic3kbudgmxfnexywpxkgj2vbrvxeh5reotuhvgjjvymgksjcah3ea
+- valory/task_submission_abci:0.1.0:bafybeidr5wqebxsafl6owypj6enpkgvicz3wjvqyasktmycljanjc6hl2u
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i
+- valory/task_execution:0.1.0:bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeidwyekjim4d7qxquou3kmpbmvph7vv67aygjbxha4wu4q6x3uqhp4
+- valory/task_submission_abci:0.1.0:bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay
+- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeibpqyppfz2gnoz6hsjzb7xoysjmfjfqavtpydbqba2tw7wznpss24
+- valory/task_submission_abci:0.1.0:bafybeiebu75qpfumaf4i65bzlsdsniqinaixlz3yf5ecye7xm7rfgqtjq4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi
+- valory/task_execution:0.1.0:bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -451,8 +451,20 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         return self.last_status_check_time
 
     @property
-    def request_id_to_delivery_rate_info(self) -> Dict[str, int]:
-        """Get request_id_to_delivery_rate_info."""
+    def request_id_to_delivery_rate_info(self) -> Dict[int, int]:
+        """Get request_id_to_delivery_rate_info.
+
+        Both writer (``_prepare_task``) and reader (tool-price gate in
+        ``check_offchain_task_can_pay``) key by ``executing_task["requestId"]``
+        which is ``int`` for both on-chain (``int.from_bytes(bytes32, "big")``)
+        and off-chain (``int(request_id)`` from the ingress coercion in
+        ``task_execution.handlers._enqueue_offchain_request``) tasks. The
+        annotation used to be ``Dict[str, int]`` — self-consistent at
+        runtime but wrong on paper.
+
+        :return: the shared-state dict mapping ``requestId`` (``int``) to
+            the requester-signed ``delivery_rate`` (``int``).
+        """
         return self.context.shared_state[REQUEST_ID_TO_DELIVERY_RATE_INFO]
 
     def _should_poll(self, req_type: str) -> bool:
@@ -1667,9 +1679,15 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # directly (the original code) returned ``None`` for both fields,
         # forcing every completed task to be tagged ``status="failed"`` in
         # the analytics row.
+        # ``OFFCHAIN_REQUEST_RESPONSES`` is written under ``str(req_id)`` by
+        # ``_handle_done_task`` and ``_record_offchain_failure``; ``req_id``
+        # is ``int`` for off-chain tasks post-ingress coercion. Read with the
+        # ``str`` key too or the analytics row is tagged ``status="failed"``
+        # for every successful off-chain delivery, silently, because the
+        # poller sees the right answer but the lake row does not.
         response_envelope_raw = self.context.shared_state.get(
             OFFCHAIN_REQUEST_RESPONSES, {}
-        ).get(req_id, {})
+        ).get(request_id_str, {})
         response_envelope = (
             response_envelope_raw if isinstance(response_envelope_raw, dict) else {}
         )

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -927,14 +927,28 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             "executed_at": executed_at,
         }
         task_executor = self.context.agent_address
+        # ``**executing_task`` is spread first so the explicit keys below
+        # override any duplicates that were previously spread from the
+        # off-chain HTTP body (in particular ``request_id`` — the body
+        # carries the raw wire-format decimal string, and downstream sort
+        # / equality in :mod:`task_submission_abci` requires the same
+        # ``int`` type the on-chain path uses so ``done_tasks`` stays
+        # sortable and matchable across a mixed-source batch — see the
+        # ingress coercion comment in
+        # :meth:`task_execution.handlers._enqueue_offchain_request`).
+        # Every explicit value below matches what the previous
+        # spread-wins ordering would have picked for on-chain tasks
+        # (the on-chain pending task carries none of these keys, so the
+        # explicit values always applied), so this reorder is a no-op
+        # for on-chain flows.
         self._done_task = {
+            **executing_task,
             "request_id": req_id,
             "mech_address": mech_address,
             "task_executor_address": task_executor,
             "tool": tool,
             "request_id_nonce": request_id_nonce,
             "is_offchain": is_offchain,
-            **executing_task,
         }
 
         # compute tool execution duration before building metadata

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -927,28 +927,14 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             "executed_at": executed_at,
         }
         task_executor = self.context.agent_address
-        # ``**executing_task`` is spread first so the explicit keys below
-        # override any duplicates that were previously spread from the
-        # off-chain HTTP body (in particular ``request_id`` — the body
-        # carries the raw wire-format decimal string, and downstream sort
-        # / equality in :mod:`task_submission_abci` requires the same
-        # ``int`` type the on-chain path uses so ``done_tasks`` stays
-        # sortable and matchable across a mixed-source batch — see the
-        # ingress coercion comment in
-        # :meth:`task_execution.handlers._enqueue_offchain_request`).
-        # Every explicit value below matches what the previous
-        # spread-wins ordering would have picked for on-chain tasks
-        # (the on-chain pending task carries none of these keys, so the
-        # explicit values always applied), so this reorder is a no-op
-        # for on-chain flows.
         self._done_task = {
-            **executing_task,
             "request_id": req_id,
             "mech_address": mech_address,
             "task_executor_address": task_executor,
             "tool": tool,
             "request_id_nonce": request_id_nonce,
             "is_offchain": is_offchain,
+            **executing_task,
         }
 
         # compute tool execution duration before building metadata
@@ -1044,7 +1030,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 # but failed" delivery must be distinguishable from a successful
                 # one — otherwise the client accepts and pays for a failure.
                 self._record_offchain_failure(
-                    cast(str, req_id),
+                    str(req_id),
                     cast(str, response.get("result") or "task execution failed"),
                 )
                 return
@@ -1072,7 +1058,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                     f"Off-chain CID computation failed for request {req_id}: {exc}"
                 )
                 self._record_offchain_failure(
-                    cast(str, req_id), f"cid computation failed: {exc}"
+                    str(req_id), f"cid computation failed: {exc}"
                 )
                 return
             self.context.logger.info(
@@ -1086,10 +1072,20 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             # content_cid are envelope fields kept outside it so they don't
             # perturb the hash. Without this the poll falls back to the done_task,
             # which carries the CID/multihash but not the result/prompt/cost_dict.
+            # ``req_id`` is now an ``int`` for off-chain tasks (see the
+            # ingress-coercion comment in
+            # :mod:`task_execution.handlers._enqueue_offchain_request`),
+            # so the previous ``cast(str, req_id)`` was a runtime no-op
+            # that let an ``int`` land as the key of a ``str``-typed
+            # dict — ``/fetch_offchain_info`` then couldn't find the
+            # response and the requester polled ``{}`` forever while
+            # ``deliverWithSignatures`` still charged them on chain.
+            # ``str(req_id)`` performs the real conversion.
+            request_id_str = str(req_id)
             self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
-                cast(str, req_id)
+                request_id_str
             ] = {
-                "request_id": cast(str, req_id),
+                "request_id": request_id_str,
                 "status": "ok",
                 "content_cid": local_cid,
                 "response": response,
@@ -1101,7 +1097,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             # unless preimage retention is enabled; failures are logged but
             # don't block the in-memory return channel above.
             self._buffer_preimage_settlement(
-                cast(str, req_id),
+                request_id_str,
                 content_bytes.decode("utf-8", errors="replace"),
                 local_cid,
                 preimage_buffer.STATUS_DELIVERED,
@@ -1521,7 +1517,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 # On-chain has other fallbacks; off-chain the polling client would
                 # otherwise never learn this failed, so emit a definitive
                 # rejection (which also resets the task slot).
-                self._record_offchain_failure(req_id, "invalid done task")
+                self._record_offchain_failure(str(req_id), "invalid done task")
                 return
             self._reset_executing_task()
             return
@@ -1587,7 +1583,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # Off-chain success: drop the buffered request metadata so it can't grow
         # unbounded (on-chain tasks never populate it, so this is a no-op there).
         # .get keeps this safe if the handler-owned key was never initialised.
-        self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(req_id, None)
+        # ``req_id`` is ``int`` post ingress coercion; the buffer is
+        # ``str``-keyed by the handler (``Dict[str, str]`` at
+        # ``handlers.py:776``), so the pop needs the ``str`` form or it
+        # silently misses and leaks the full request JSON.
+        self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(str(req_id), None)
         self._reset_executing_task()
 
     def _build_predict_api_event(
@@ -1625,8 +1625,14 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         """
         req_id = done_task["request_id"]
         request_id_str = str(req_id)
+        # ``IN_MEMORY_REQUESTS`` is ``str``-keyed by the handler; ``req_id``
+        # is ``int`` for off-chain tasks (see ingress coercion in
+        # ``task_execution.handlers._enqueue_offchain_request``). Use the
+        # ``str`` key or the get returns ``{}`` and the analytics row loses
+        # the prompt / tool params / requested_at, falling back to safe
+        # placeholders.
         request_data_raw = self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).get(
-            req_id, {}
+            request_id_str, {}
         )
         # IPFS_DATA can land as either a parsed dict (normal handler path)
         # or a JSON-encoded string (some test fixtures and the historical

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -454,10 +454,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
     def request_id_to_delivery_rate_info(self) -> Dict[int, int]:
         """Get request_id_to_delivery_rate_info.
 
-        Both writer (``_prepare_task``) and reader (tool-price gate in
-        ``check_offchain_task_can_pay``) key by ``executing_task["requestId"]``
-        which is ``int`` for both on-chain (``int.from_bytes(bytes32, "big")``)
-        and off-chain (``int(request_id)`` from the ingress coercion in
+        Both writer (``_prepare_task``) and reader (tool-price gate
+        inside ``_handle_get_task``, the
+        ``req_id_delivery_rate < tool_pricing`` check) key by
+        ``executing_task["requestId"]`` which is ``int`` for both
+        on-chain (``int.from_bytes(bytes32, "big")``) and off-chain
+        (``int(request_id)`` from the ingress coercion in
         ``task_execution.handlers._enqueue_offchain_request``) tasks. The
         annotation used to be ``Dict[str, int]`` — self-consistent at
         runtime but wrong on paper.

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -897,12 +897,21 @@ class MechHttpHandler(AbstractResponseHandler):
             )
             self._handle_bad_request(http_msg, http_dialogue)
             return
-        # Regex constrains the alphabet; the uint256 upper bound has to be
-        # checked separately. The 78-digit cap on ``MAX_REQUEST_ID`` keeps
-        # the ``int()`` itself safe (well under the 4300-digit CPython
-        # cap), and rejecting a >uint256 id here matches the range check
+        # Regex constrains the alphabet; the magnitude has to be checked
+        # separately. The length branch MUST short-circuit before the
+        # ``int()`` call: on CPython 3.11+, ``int()`` on a string longer
+        # than ``sys.get_int_max_str_digits()`` (4300 by default) raises
+        # ``ValueError`` — a 5000-digit canonical decimal would pass
+        # ``fullmatch`` but blow up here, outside any ``try/except``, and
+        # bypass this handler's own 400 return. ``len(str(MAX_REQUEST_ID))``
+        # is 78, well under the CPython cap, so the length branch is the
+        # cheap guard that makes the value branch safe. Rejecting a
+        # >uint256 id here matches the range check
         # ``request_delivery_rate`` already gets below.
-        if int(request_id) > MAX_REQUEST_ID:
+        if (
+            len(request_id) > len(str(MAX_REQUEST_ID))
+            or int(request_id) > MAX_REQUEST_ID
+        ):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id!r}: "
                 f"request_id exceeds uint256 upper bound "

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -1343,13 +1343,40 @@ class MechHttpHandler(AbstractResponseHandler):
         # and matched against the caller-visible response body. Only the
         # value that flows into the pending-task dict (and from there
         # into ``done_tasks``) is coerced.
+        # ``reserved_keys`` also covers three keys the behaviour later reads
+        # off ``_executing_task`` (``mech_address``, ``task_executor_address``,
+        # ``request_id_nonce``) and the ``tool`` used for pricing / metrics.
+        # The behaviour re-spreads ``**executing_task`` when it builds
+        # ``done_task`` in ``_handle_done_task``, so any of these leaking in
+        # from a client body would ride all the way to consensus and either
+        # (a) reroute the on-chain delivery (``mech_address``), (b)
+        # misattribute the executor for karma accounting
+        # (``task_executor_address``), (c) desync the on-chain signature
+        # (``request_id_nonce``, read as ``requestIdWithNonce`` upstream), or
+        # (d) point the tool-price gate at the wrong tool.
         reserved_keys = {
             RequestKey.REQUEST_ID.value,
             RequestKey.REQUEST_ID_CAMEL.value,
             RequestKey.IS_OFFCHAIN.value,
             BodyKey.DATA.value,
             RequestKey.REQUEST_DELIVERY_RATE.value,
+            "mech_address",
+            "task_executor_address",
+            "request_id_nonce",
+            "requestIdWithNonce",
+            "tool",
         }
+        dropped_keys = [k for k in data.keys() if k in reserved_keys]
+        if dropped_keys:
+            # Log at info: dropping is the safe outcome, but an integration
+            # sending one of these needs a way to notice their field was
+            # ignored rather than silently accepted.
+            self.context.logger.info(
+                "Dropping client-supplied reserved keys from offchain "
+                "request %r: %s",
+                request_id,
+                sorted(dropped_keys),
+            )
         req = {
             RequestKey.REQUEST_ID_CAMEL.value: int(request_id),
             BodyKey.DATA.value: bytes.fromhex(ipfs_hash[2:]),

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -854,6 +854,24 @@ class MechHttpHandler(AbstractResponseHandler):
             self._handle_bad_request(http_msg, http_dialogue)
             return
 
+        # ``request_id`` on the wire is the decimal encoding of the uint256
+        # marketplace ``getRequestId`` return, so it must be an unsigned
+        # decimal integer. Validate here alongside the other body-shape
+        # checks so a non-numeric id is rejected with a specific log line
+        # rather than surfacing later as an opaque ``ValueError`` inside
+        # :meth:`_enqueue_offchain_request`'s ``int(request_id)`` coercion.
+        # The coercion still lives at the enqueue site because that's
+        # where the invariant matters — this validation just gives the
+        # operator a distinguishable rejection cause in the log.
+        if not request_id or not request_id.isdigit():
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id!r}: "
+                f"request_id must be a non-empty decimal string "
+                f"(len={len(request_id) if request_id else 0})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+
         if not IPFS_HASH_RE.match(ipfs_hash):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id}: invalid ipfs_hash "
@@ -981,7 +999,14 @@ class MechHttpHandler(AbstractResponseHandler):
 
         self.context.logger.info(f"Fetching offchain info for {request_id=}.")
 
-        stored_response = self.offchain_request_responses.get(request_id)
+        # ``OFFCHAIN_REQUEST_RESPONSES`` is ``str``-keyed on the writer
+        # side (see :mod:`task_execution.behaviours._handle_done_task`
+        # and ``_record_offchain_failure`` — both convert the coerced
+        # ``int`` ``req_id`` back to ``str`` before writing). ``request_id``
+        # from the GET body is already ``str``, but wrap in ``str(...)``
+        # so a future writer regression that lands an ``int`` key is
+        # still findable by the requester.
+        stored_response = self.offchain_request_responses.get(str(request_id))
         if stored_response is not None:
             self._send_ok_response(
                 http_msg,
@@ -992,10 +1017,14 @@ class MechHttpHandler(AbstractResponseHandler):
 
         done_tasks_list = self.done_tasks
 
+        # Same reason as above: ``done_task["request_id"]`` is ``int`` for
+        # off-chain tasks post the ingress coercion, but ``request_id``
+        # from the GET body is ``str``. Normalize both sides so the
+        # fallback scan doesn't silently miss.
         requested_done_tasks_list = [
             item
             for item in done_tasks_list
-            if item.get(RequestKey.REQUEST_ID.value) == request_id
+            if str(item.get(RequestKey.REQUEST_ID.value)) == str(request_id)
         ]
 
         self._send_ok_response(
@@ -1275,40 +1304,48 @@ class MechHttpHandler(AbstractResponseHandler):
         # content commitment on chain still comes from the locally-computed
         # CID (response side), so the mech's on-chain receipt is unchanged.
         #
-        # ``requestId`` is normalized to ``int`` at ingress so that off-chain
-        # and on-chain tasks agree on the type once they land in
-        # ``shared_state[DONE_TASKS]``. The on-chain side already stores
-        # ``requestId`` as ``int`` (via ``int.from_bytes(bytes32, "big")``
-        # in :mod:`task_execution.behaviours`); before this normalization,
-        # off-chain tasks stored the wire-format decimal string. A mixed-
-        # type list then crashed :meth:`task_submission_abci.rounds.
-        # TaskPoolingRound.end_block` at its ``sorted(..., key=lambda x:
-        # x["request_id"])`` call — Python 3 refuses to compare ``int`` and
-        # ``str`` and raises ``TypeError``. It also silently broke the
-        # ``submitted["request_id"] == done["request_id"]`` equality check
-        # in :meth:`FundsSplittingBehaviour.remove_tasks`, which would
-        # leave delivered tasks in ``done_tasks`` and re-emit them next
-        # cycle. Coercing here fixes both call sites without touching
-        # either downstream module.
+        # ``requestId`` is normalized to ``int`` so on-chain tasks (already
+        # ``int`` via ``int.from_bytes(bytes32, "big")`` in
+        # :mod:`task_execution.behaviours`) and off-chain tasks agree on
+        # the type once they land in ``shared_state[DONE_TASKS]``. Without
+        # this, ``TaskPoolingRound.end_block`` crashed on
+        # ``sorted(..., key=lambda x: x["request_id"])`` and
+        # ``TaskExecutionBaseBehaviour.remove_tasks`` silently failed its
+        # equality check on a mixed-type batch.
+        #
+        # The client-supplied body (``data``) is stripped of any key we
+        # own before merge, so a request carrying ``request_id=...``,
+        # ``is_offchain=...``, ``data=...``, or ``request_delivery_rate=...``
+        # can't override the trusted values above. This closes two
+        # separate problems: (a) a body-supplied ``request_id`` would
+        # re-plant the wire-format ``str`` and defeat the coercion, and
+        # (b) a body-supplied ``request_delivery_rate`` would land in
+        # ``request_id_to_delivery_rate_info`` and bypass the tool-
+        # minimum-price gate in
+        # :meth:`task_execution.behaviours.check_offchain_task_can_pay`.
+        # The signature verifies the request-id and delivery-rate at the
+        # marketplace on chain, not here, so pre-settlement trust in
+        # ``data`` values other than these four must be nil.
         #
         # The local ``request_id`` variable stays ``str`` — it is used as
         # a dict key in ``in_memory_requests`` and
         # ``offchain_request_responses`` (both typed ``Dict[str, ...]``)
         # and matched against the caller-visible response body. Only the
         # value that flows into the pending-task dict (and from there
-        # into ``done_tasks``) is coerced. The str ``request_id`` from
-        # the HTTP body (added via ``**data`` below) is also present in
-        # the pending task, but the on-chain-shaped merge into
-        # ``_done_task`` in :meth:`task_execution.behaviours.
-        # _handle_done_task` puts the explicit ``request_id`` line after
-        # the ``**executing_task`` spread so the trailing int override
-        # wins.
+        # into ``done_tasks``) is coerced.
+        reserved_keys = {
+            RequestKey.REQUEST_ID.value,
+            RequestKey.REQUEST_ID_CAMEL.value,
+            RequestKey.IS_OFFCHAIN.value,
+            BodyKey.DATA.value,
+            RequestKey.REQUEST_DELIVERY_RATE.value,
+        }
         req = {
             RequestKey.REQUEST_ID_CAMEL.value: int(request_id),
             BodyKey.DATA.value: bytes.fromhex(ipfs_hash[2:]),
             RequestKey.IS_OFFCHAIN.value: True,
             RequestKey.REQUEST_DELIVERY_RATE.value: request_delivery_rate,
-            **data,
+            **{k: v for k, v in data.items() if k not in reserved_keys},
         }
         try:
             self.pending_tasks.append(req)

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -93,7 +93,21 @@ IPFS_HASH_RE = re.compile(r"^0x([0-9a-fA-F]{64}|[0-9a-fA-F]{68})$")
 # rejected so ``str(int(x)) == x`` holds for every accepted value; this
 # keeps the wire ``request_id`` collision-free with the writer's
 # ``str(int(request_id))`` key.
-REQUEST_ID_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+#
+# The end anchor is ``\Z``, NOT ``$``: Python's ``$`` matches immediately
+# before a trailing ``\n``, so ``re.match(r"^...$", "42\n")`` would pass
+# while ``int("42\n") == 42`` — the same roundtrip divergence the guard
+# exists to close. The call site also uses ``.fullmatch()``, both to
+# make full consumption explicit and as a defense against a future
+# accidental ``.match()``.
+REQUEST_ID_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
+# uint256 upper bound on ``request_id``. ``REQUEST_ID_RE`` bounds the
+# alphabet but not the magnitude: on CPython 3.11+ ``int()`` raises
+# ``ValueError`` for a decimal string longer than 4300 digits, which
+# would fire deep inside ``_enqueue_offchain_request`` and reintroduce
+# the "opaque ``ValueError`` at the coercion site" outcome the upfront
+# guard exists to close. Mirrors ``MAX_DELIVERY_RATE``.
+MAX_REQUEST_ID = 2**256 - 1
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -866,18 +880,33 @@ class MechHttpHandler(AbstractResponseHandler):
 
         # ``request_id`` on the wire is the decimal encoding of the uint256
         # marketplace ``getRequestId`` return, so it must be canonical ASCII
-        # decimal (see ``REQUEST_ID_RE``). Validate here alongside the other
-        # body-shape checks so a non-canonical id is rejected with a
-        # specific log line rather than surfacing later as an opaque
-        # ``ValueError`` inside :meth:`_enqueue_offchain_request`'s
+        # decimal (see ``REQUEST_ID_RE``) AND fit in uint256. Validate here
+        # alongside the other body-shape checks so a non-canonical id is
+        # rejected with a specific log line rather than surfacing later as
+        # an opaque ``ValueError`` inside :meth:`_enqueue_offchain_request`'s
         # ``int(request_id)`` coercion, or — worse — passing coercion via
         # ``int('๔๒')`` and desynchronising the writer's
         # ``str(int(request_id))`` key from the wire ``request_id``.
-        if not REQUEST_ID_RE.match(request_id or ""):
+        # ``fullmatch`` (vs ``match``) rejects a trailing ``\n`` that ``$``
+        # would let through — see ``REQUEST_ID_RE`` docstring.
+        if not REQUEST_ID_RE.fullmatch(request_id or ""):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id!r}: "
                 f"request_id must be a canonical ASCII decimal "
                 f"(len={len(request_id) if request_id else 0})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+        # Regex constrains the alphabet; the uint256 upper bound has to be
+        # checked separately. The 78-digit cap on ``MAX_REQUEST_ID`` keeps
+        # the ``int()`` itself safe (well under the 4300-digit CPython
+        # cap), and rejecting a >uint256 id here matches the range check
+        # ``request_delivery_rate`` already gets below.
+        if int(request_id) > MAX_REQUEST_ID:
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id!r}: "
+                f"request_id exceeds uint256 upper bound "
+                f"(MAX_REQUEST_ID={MAX_REQUEST_ID})."
             )
             self._handle_bad_request(http_msg, http_dialogue)
             return
@@ -1332,7 +1361,8 @@ class MechHttpHandler(AbstractResponseHandler):
         # (b) a body-supplied ``request_delivery_rate`` would land in
         # ``request_id_to_delivery_rate_info`` and bypass the tool-
         # minimum-price gate in
-        # :meth:`task_execution.behaviours.check_offchain_task_can_pay`.
+        # :meth:`task_execution.behaviours.TaskExecutionBehaviour._handle_get_task`
+        # (see the ``req_id_delivery_rate < tool_pricing`` check).
         # The signature verifies the request-id and delivery-rate at the
         # marketplace on chain, not here, so pre-settlement trust in
         # ``data`` values other than these four must be nil.
@@ -1366,7 +1396,15 @@ class MechHttpHandler(AbstractResponseHandler):
             "requestIdWithNonce",
             "tool",
         }
-        dropped_keys = [k for k in data.keys() if k in reserved_keys]
+        # ``RequestKey.REQUEST_ID.value`` is mandatory on the body (read at
+        # ``_handle_signed_requests`` and 400 on missing), so it is present
+        # on every accepted request; excluding it here keeps the log
+        # a real anomaly signal instead of firing on 100% of requests.
+        dropped_keys = [
+            k
+            for k in data.keys()
+            if k in reserved_keys and k != RequestKey.REQUEST_ID.value
+        ]
         if dropped_keys:
             # Log at info: dropping is the safe outcome, but an integration
             # sending one of these needs a way to notice their field was

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -1223,10 +1223,17 @@ class MechHttpHandler(AbstractResponseHandler):
 
     def _rollback_offchain_enqueue(self, request_id: str) -> None:
         """Rollback a partial off-chain enqueue in case of unexpected failure."""
+        # The pending task's ``requestId`` is stored as ``int`` after the
+        # ingress coercion in :meth:`_enqueue_offchain_request`; the local
+        # ``request_id`` here is still the wire-format ``str`` used as the
+        # in-memory dict key. Compare on ``int`` so the filter actually
+        # matches — a mixed ``str`` vs ``int`` comparison would silently
+        # leave the partial entry in the queue and defeat the rollback.
+        target_id_int = int(request_id)
         self.context.shared_state[PENDING_TASKS] = [
             req
             for req in self.pending_tasks
-            if req.get(RequestKey.REQUEST_ID_CAMEL.value) != request_id
+            if req.get(RequestKey.REQUEST_ID_CAMEL.value) != target_id_int
         ]
         self.in_memory_requests.pop(request_id, None)
         self.context.logger.error(
@@ -1267,8 +1274,37 @@ class MechHttpHandler(AbstractResponseHandler):
         # request JSON in process memory under ``in_memory_requests``. The
         # content commitment on chain still comes from the locally-computed
         # CID (response side), so the mech's on-chain receipt is unchanged.
+        #
+        # ``requestId`` is normalized to ``int`` at ingress so that off-chain
+        # and on-chain tasks agree on the type once they land in
+        # ``shared_state[DONE_TASKS]``. The on-chain side already stores
+        # ``requestId`` as ``int`` (via ``int.from_bytes(bytes32, "big")``
+        # in :mod:`task_execution.behaviours`); before this normalization,
+        # off-chain tasks stored the wire-format decimal string. A mixed-
+        # type list then crashed :meth:`task_submission_abci.rounds.
+        # TaskPoolingRound.end_block` at its ``sorted(..., key=lambda x:
+        # x["request_id"])`` call — Python 3 refuses to compare ``int`` and
+        # ``str`` and raises ``TypeError``. It also silently broke the
+        # ``submitted["request_id"] == done["request_id"]`` equality check
+        # in :meth:`FundsSplittingBehaviour.remove_tasks`, which would
+        # leave delivered tasks in ``done_tasks`` and re-emit them next
+        # cycle. Coercing here fixes both call sites without touching
+        # either downstream module.
+        #
+        # The local ``request_id`` variable stays ``str`` — it is used as
+        # a dict key in ``in_memory_requests`` and
+        # ``offchain_request_responses`` (both typed ``Dict[str, ...]``)
+        # and matched against the caller-visible response body. Only the
+        # value that flows into the pending-task dict (and from there
+        # into ``done_tasks``) is coerced. The str ``request_id`` from
+        # the HTTP body (added via ``**data`` below) is also present in
+        # the pending task, but the on-chain-shaped merge into
+        # ``_done_task`` in :meth:`task_execution.behaviours.
+        # _handle_done_task` puts the explicit ``request_id`` line after
+        # the ``**executing_task`` spread so the trailing int override
+        # wins.
         req = {
-            RequestKey.REQUEST_ID_CAMEL.value: request_id,
+            RequestKey.REQUEST_ID_CAMEL.value: int(request_id),
             BodyKey.DATA.value: bytes.fromhex(ipfs_hash[2:]),
             RequestKey.IS_OFFCHAIN.value: True,
             RequestKey.REQUEST_DELIVERY_RATE.value: request_delivery_rate,

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -84,6 +84,16 @@ MIN_DELIVERY_RATE = 0  # 0 allowed for free tasks; rejects only negatives
 MAX_DELIVERY_RATE = 2**256 - 1  # uint256 upper bound
 # 0x + 32-byte (64 hex) or 34-byte multihash (68 hex) payload
 IPFS_HASH_RE = re.compile(r"^0x([0-9a-fA-F]{64}|[0-9a-fA-F]{68})$")
+# Canonical ASCII decimal for uint256 ``request_id``: single ``0`` OR a
+# non-zero leading digit followed by ASCII decimals. ``str.isdigit()``
+# alone admits non-canonical decimals (Unicode superscripts, Arabic-Indic
+# digits, Thai digits, etc.) that ``int()`` may accept and re-stringify
+# to something entirely different — reopening the very silent-money-loss
+# path this file's coercion sweep is meant to close. Leading zeros are
+# rejected so ``str(int(x)) == x`` holds for every accepted value; this
+# keeps the wire ``request_id`` collision-free with the writer's
+# ``str(int(request_id))`` key.
+REQUEST_ID_RE = re.compile(r"^(0|[1-9][0-9]*)$")
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -855,18 +865,18 @@ class MechHttpHandler(AbstractResponseHandler):
             return
 
         # ``request_id`` on the wire is the decimal encoding of the uint256
-        # marketplace ``getRequestId`` return, so it must be an unsigned
-        # decimal integer. Validate here alongside the other body-shape
-        # checks so a non-numeric id is rejected with a specific log line
-        # rather than surfacing later as an opaque ``ValueError`` inside
-        # :meth:`_enqueue_offchain_request`'s ``int(request_id)`` coercion.
-        # The coercion still lives at the enqueue site because that's
-        # where the invariant matters — this validation just gives the
-        # operator a distinguishable rejection cause in the log.
-        if not request_id or not request_id.isdigit():
+        # marketplace ``getRequestId`` return, so it must be canonical ASCII
+        # decimal (see ``REQUEST_ID_RE``). Validate here alongside the other
+        # body-shape checks so a non-canonical id is rejected with a
+        # specific log line rather than surfacing later as an opaque
+        # ``ValueError`` inside :meth:`_enqueue_offchain_request`'s
+        # ``int(request_id)`` coercion, or — worse — passing coercion via
+        # ``int('๔๒')`` and desynchronising the writer's
+        # ``str(int(request_id))`` key from the wire ``request_id``.
+        if not REQUEST_ID_RE.match(request_id or ""):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id!r}: "
-                f"request_id must be a non-empty decimal string "
+                f"request_id must be a canonical ASCII decimal "
                 f"(len={len(request_id) if request_id else 0})."
             )
             self._handle_bad_request(http_msg, http_dialogue)

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,15 +7,15 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeih5m2c4hlvgb2cg6vg423ceomy7g3mghuyjpxjrbkax4e5vyon2oe
+  behaviours.py: bafybeicfi7xny6m2neur4sfakaayrminacq3a5cm4joa4hxc7u32xpibqq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeicz3axowdpihmlsn3662xapzyn6x623utb4qpz6rcuc7gbaf35qpy
+  handlers.py: bafybeifvx7qvq6fzp5hbpsgsm6soxvhr2gs5jeq3p3bo47gql3t54ueatm
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeic77w2y6n3b3pmhdivehsykoit5z3ngk3b3knuynlrrzvqg34berm
+  tests/test_handlers.py: bafybeig3emewtz4xsuvkqcurcny5wpj6jsndmejwqudrkqwd37i6ef6it4
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeifpb6onxroyrqld7vot2hlppapqlspmnomqw7mmaxbr4cbj7rtrxq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeige7crmvk7mmmdiouhiop4sdutlbvdtvjvbf7moky7titvkjg6udi
+  handlers.py: bafybeibe6cfgilchkwn4u4zrtoutdank7y2sdfhlq363phyqmv72mmflfa
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeif64oibfyg4mtclqlkbpzxbcyoi4uhkx4eqoigbu35ryov4acxx4e
+  tests/test_handlers.py: bafybeifxq7ennozyocfafyhws5ldn2pfvejg54eoqj6fhacauz7n7awuji
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeig3emewtz4xsuvkqcurcny5wpj6jsndmejwqudrkqwd37i6ef6it4
+  tests/test_handlers.py: bafybeidxejynz3xiv5ndfqikpzpw4thp72poynm7oxbcgfcmy3ucv4fsvq
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,15 +7,15 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeicfi7xny6m2neur4sfakaayrminacq3a5cm4joa4hxc7u32xpibqq
+  behaviours.py: bafybeifpb6onxroyrqld7vot2hlppapqlspmnomqw7mmaxbr4cbj7rtrxq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeifvx7qvq6fzp5hbpsgsm6soxvhr2gs5jeq3p3bo47gql3t54ueatm
+  handlers.py: bafybeige7crmvk7mmmdiouhiop4sdutlbvdtvjvbf7moky7titvkjg6udi
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeif33dy3cjjaxlrqn3gibpmkeakll3nm5ucmc7xy5ex26au3roajo4
+  tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeiegx675zpdub7r5ts6m2ujz4ixeughy35atmxzo5bnpq7txzmul3a
+  tests/test_handlers.py: bafybeif64oibfyg4mtclqlkbpzxbcyoi4uhkx4eqoigbu35ryov4acxx4e
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,15 +7,15 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifpb6onxroyrqld7vot2hlppapqlspmnomqw7mmaxbr4cbj7rtrxq
+  behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeibe6cfgilchkwn4u4zrtoutdank7y2sdfhlq363phyqmv72mmflfa
+  handlers.py: bafybeielqi73gdhoxhczscj56emcvxez67xvgfuhvpisjqrmpshwlhppee
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeifxq7ennozyocfafyhws5ldn2pfvejg54eoqj6fhacauz7n7awuji
+  tests/test_handlers.py: bafybeidn444kmrqvs6eqqc76qxubtjvnfvw5ftwtagkfzdejh6r2i4rpha
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa
+  tests/test_behaviours.py: bafybeif33dy3cjjaxlrqn3gibpmkeakll3nm5ucmc7xy5ex26au3roajo4
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeiegx675zpdub7r5ts6m2ujz4ixeughy35atmxzo5bnpq7txzmul3a
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,15 +7,15 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeihatg4ggqhrimoqbbgghiq7fbnenjbmgc6osxswplcingk3kg5bjm
+  behaviours.py: bafybeih5m2c4hlvgb2cg6vg423ceomy7g3mghuyjpxjrbkax4e5vyon2oe
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeih6bh6mxxxvi2fs4dgvgmw4ovvwmwh7r57u7nuzqdv5q4unvggc2i
+  handlers.py: bafybeicz3axowdpihmlsn3662xapzyn6x623utb4qpz6rcuc7gbaf35qpy
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeic7jdqovcajvvw5s6kgo7nlpkpkiibpwfgnctpfurunyu4f7is2yi
+  tests/test_handlers.py: bafybeic77w2y6n3b3pmhdivehsykoit5z3ngk3b3knuynlrrzvqg34berm
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeiezgysiwi54hbsoktrzhvktaolst4rkszyu57p7ezrjev7c3ckroa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeidxejynz3xiv5ndfqikpzpw4thp72poynm7oxbcgfcmy3ucv4fsvq
+  tests/test_handlers.py: bafybeiegx675zpdub7r5ts6m2ujz4ixeughy35atmxzo5bnpq7txzmul3a
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeielqi73gdhoxhczscj56emcvxez67xvgfuhvpisjqrmpshwlhppee
+  handlers.py: bafybeiepqusgfa4tmiixe352cohuukf2wqlipwpal2yngahegmqlhj4oou
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeidn444kmrqvs6eqqc76qxubtjvnfvw5ftwtagkfzdejh6r2i4rpha
+  tests/test_handlers.py: bafybeiedeuegyn27xv4ejlv5li45fpz3yd4mf7wbogud4yzpg556vc7paa
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1746,9 +1746,11 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     # offchain_request_responses so /fetch_offchain_info can serve it. The
     # response never hit public IPFS, and the done_task fallback carries the
     # CID but not the result/prompt/cost_dict.
-    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES][11]
+    # Post-fix, the writer stores under ``str(req_id)`` so the /fetch_offchain_info
+    # str-typed wire ``request_id`` resolves against the same key type.
+    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["11"]
     assert stored["status"] == "ok"
-    assert stored["request_id"] == 11
+    assert stored["request_id"] == "11"
     assert isinstance(stored["content_cid"], str) and stored["content_cid"]
     # The committed object is served verbatim under "response" (envelope fields
     # hang outside it), and it carries the real tool result.

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1761,6 +1761,18 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     recomputed = beh_mod.compute_cidv1(json.dumps(stored["response"]).encode("utf-8"))
     assert recomputed == stored["content_cid"]
 
+    # The predict-api analytics event must be tagged ``complete`` and carry
+    # the real tool result. Pre-fix, ``_build_predict_api_event`` looked
+    # up ``OFFCHAIN_REQUEST_RESPONSES`` with the coerced ``int`` req_id but
+    # the writer stores under ``str(req_id)``, so every successful off-chain
+    # delivery landed in the lake as ``status="failed"``, ``result=None``.
+    # Silent failure: the poller still saw the right answer.
+    done_event = done.get("predict_api_event")
+    assert isinstance(done_event, dict), done
+    inner = done_event.get("response", {})
+    assert inner.get("status") == "complete", done_event
+    assert inner.get("result") == "prediction: yes", done_event
+
 
 def test_handle_done_task_offchain_invalid_request_recorded_as_failure(
     behaviour: Any,
@@ -1910,6 +1922,42 @@ def test_handle_done_task_offchain_clears_in_memory_request(
     behaviour._handle_done_task(task_result=_make_success_result())
 
     assert "req-14" not in shared_state[beh_mod.IN_MEMORY_REQUESTS]
+    assert behaviour._executing_task is None
+
+
+def test_handle_done_task_offchain_clears_str_keyed_in_memory_request_with_int_req_id(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """Post-ingress coercion: the pop must ``str(req_id)`` or the buffer leaks.
+
+    The HTTP handler writes ``in_memory_requests[str(request_id)]``
+    (``handlers.py`` — ``Dict[str, str]``), while ``_executing_task``
+    now carries ``requestId`` as ``int`` for off-chain tasks (ingress
+    coercion at ``handlers._enqueue_offchain_request``). The pop in
+    ``_finalize_done_task`` therefore has to ``str(req_id)`` — a bare
+    ``req_id`` (``int``) silently misses on a ``str``-keyed dict and
+    every off-chain request leaks its full request JSON into shared
+    state for the process lifetime.
+
+    :param behaviour: TaskExecutionBehaviour fixture.
+    :param params_stub: params fixture.
+    :param shared_state: shared_state fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    _seed_executing_task(behaviour, params_stub, is_offchain=True, req_id=1400)
+    # Handler-side shape: str key, ipfs_data value.
+    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {"1400": "buffered-ipfs-data"}
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=_make_success_result())
+
+    assert shared_state[beh_mod.IN_MEMORY_REQUESTS] == {}
     assert behaviour._executing_task is None
 
 

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -493,6 +493,17 @@ def test_signed_requests_bad_request(
         "²²",
         "042",
         "01",
+        # Python's ``$`` matches immediately before a trailing ``\n``, so
+        # ``re.match(r"...$", "42\n")`` would pass while ``int("42\n") == 42``
+        # — the same roundtrip divergence that lets ``in_memory_requests``
+        # and ``preimage_buffer`` accept records leak on a paid delivery.
+        # ``fullmatch`` (or the ``\Z`` end-anchor on the pattern) closes it.
+        "42\n",
+        "\n42",
+        # A magnitude above uint256 must also 400 up front (documented
+        # promise: the ingress guard means ``int(request_id)`` cannot raise
+        # deep in the enqueue helper). ``2**256`` is one over the bound.
+        str(2**256),
     ],
     ids=[
         "alpha",
@@ -506,6 +517,9 @@ def test_signed_requests_bad_request(
         "superscript_digits",
         "leading_zero_padded",
         "leading_zero_two_char",
+        "trailing_newline",
+        "leading_newline",
+        "above_uint256",
     ],
 )
 def test_signed_requests_rejects_non_numeric_request_id(

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -476,28 +476,62 @@ def test_signed_requests_bad_request(
 
 @pytest.mark.parametrize(
     "bad_request_id",
-    ["req-1", "", "0x123", "42abc", "42.0", " 42"],
-    ids=["alpha", "empty", "hex", "trailing_alpha", "dotted", "whitespace"],
+    [
+        "req-1",
+        "",
+        "0x123",
+        "42abc",
+        "42.0",
+        " 42",
+        # Non-canonical decimals ``str.isdigit()`` would accept but the
+        # coercion + writer contract would silently break: Unicode digits
+        # (Thai, Arabic-Indic, superscript) that ``int()`` may re-stringify
+        # to something else, and leading zeros that would desynchronise
+        # the wire ``request_id`` from the writer's ``str(int(...))`` key.
+        "๔๒",
+        "٤٢",
+        "²²",
+        "042",
+        "01",
+    ],
+    ids=[
+        "alpha",
+        "empty",
+        "hex",
+        "trailing_alpha",
+        "dotted",
+        "whitespace",
+        "thai_digits",
+        "arabic_indic_digits",
+        "superscript_digits",
+        "leading_zero_padded",
+        "leading_zero_two_char",
+    ],
 )
 def test_signed_requests_rejects_non_numeric_request_id(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any, bad_request_id: str
 ) -> None:
-    """Non-decimal ``request_id`` is rejected with 400 before any state mutation.
+    """Non-canonical ``request_id`` is rejected with 400 before any state mutation.
 
-    The ingress coercion in ``_enqueue_offchain_request`` requires a
-    valid ``int()`` input; the upfront ``request_id.isdigit()`` check in
-    ``_handle_signed_requests`` gives the operator a distinguishable log
-    line ("request_id must be a non-empty decimal string") rather than
-    letting the ``ValueError`` from the coercion surface as an opaque
-    "Error enqueuing offchain request ...: invalid literal for int()".
-    ``int()`` is also lenient about whitespace, ``0x`` prefixes, and
-    underscore separators; ``str.isdigit()`` rejects all of them, so
-    the decimal-uint256 contract on the wire is enforced strictly.
+    The ingress coercion in ``_enqueue_offchain_request`` requires
+    ``int(request_id)`` to parse AND ``str(int(request_id)) == request_id``
+    to hold — the writer keys ``OFFCHAIN_REQUEST_RESPONSES`` /
+    ``in_memory_requests`` / preimage buffer by ``str(int(request_id))``,
+    so any input where the round trip diverges silently splits
+    ``/fetch_offchain_info`` from the writer and reopens the
+    poll-forever-while-charged path.
+
+    ``REQUEST_ID_RE`` (``^(0|[1-9][0-9]*)$``) enforces canonical ASCII
+    decimal, which is stricter than both ``int()`` (accepts whitespace,
+    ``0x`` prefix, underscores, non-ASCII Unicode digits) and
+    ``str.isdigit()`` (accepts Thai / Arabic-Indic / superscript
+    digits). This test pins that stricter contract with cases from
+    all three failure modes.
 
     :param handler_context: pytest fixture, mech HTTP handler test context.
     :param http_dialogue: pytest fixture, HTTP dialogue stub.
     :param monkeypatch: pytest fixture, per-test monkeypatch helper.
-    :param bad_request_id: parametrized invalid ``request_id`` string.
+    :param bad_request_id: parametrized non-canonical ``request_id`` string.
     """
     mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
@@ -1970,13 +2004,20 @@ def test_signed_requests_rejects_oversized_http_body(
 
 
 @pytest.mark.parametrize(
-    "bad_hash,case_id",
+    "bad_hash",
     [
-        ("0xabc", "too_short"),
-        ("0x" + "ab" * 33, "wrong_length_66_byte_hex"),
-        ("0x" + "ab" * 64, "far_too_long"),
-        ("ab" * 32, "missing_0x_prefix"),
-        ("0x" + "z" * 64, "non_hex_chars"),
+        "0xabc",
+        "0x" + "ab" * 33,
+        "0x" + "ab" * 64,
+        "ab" * 32,
+        "0x" + "z" * 64,
+    ],
+    ids=[
+        "too_short",
+        "wrong_length_66_byte_hex",
+        "far_too_long",
+        "missing_0x_prefix",
+        "non_hex_chars",
     ],
 )
 def test_signed_requests_rejects_invalid_ipfs_hash(
@@ -1984,7 +2025,6 @@ def test_signed_requests_rejects_invalid_ipfs_hash(
     http_dialogue: Any,
     monkeypatch: Any,
     bad_hash: str,
-    case_id: str,
 ) -> None:
     """Malformed ipfs_hash strings are rejected with 400, nothing enqueued."""
     mh = MechHttpHandler(name="http", skill_context=handler_context)
@@ -1992,7 +2032,11 @@ def test_signed_requests_rejects_invalid_ipfs_hash(
     _install_balance_ok(mh, monkeypatch)
     mh.setup()
 
-    body = _make_signed_request_body(ipfs_hash=bad_hash, request_id=f"req-{case_id}")
+    # Numeric request_id keeps this test aimed at the ipfs_hash validator.
+    # A non-numeric one would short-circuit on the new upfront REQUEST_ID_RE
+    # guard at :meth:`_handle_signed_requests` and the ipfs_hash branch
+    # would never run — 400 for the wrong reason.
+    body = _make_signed_request_body(ipfs_hash=bad_hash, request_id="1")
     http_msg: Any = make_http_msg(body)
     mh._handle_signed_requests(http_msg, http_dialogue)
 
@@ -2002,18 +2046,18 @@ def test_signed_requests_rejects_invalid_ipfs_hash(
 
 
 @pytest.mark.parametrize(
-    "delivery_rate_str,case_id",
+    "delivery_rate_str",
     [
-        ("-1", "negative"),
-        (str(hmod.MAX_DELIVERY_RATE + 1), "above_uint256"),
+        "-1",
+        str(hmod.MAX_DELIVERY_RATE + 1),
     ],
+    ids=["negative", "above_uint256"],
 )
 def test_signed_requests_rejects_out_of_range_delivery_rate(
     handler_context: Any,
     http_dialogue: Any,
     monkeypatch: Any,
     delivery_rate_str: str,
-    case_id: str,
 ) -> None:
     """Delivery rate outside [MIN_DELIVERY_RATE, MAX_DELIVERY_RATE] is rejected."""
     mh = MechHttpHandler(name="http", skill_context=handler_context)
@@ -2021,9 +2065,9 @@ def test_signed_requests_rejects_out_of_range_delivery_rate(
     _install_balance_ok(mh, monkeypatch)
     mh.setup()
 
-    body = _make_signed_request_body(
-        delivery_rate=delivery_rate_str, request_id=f"req-{case_id}"
-    )
+    # Numeric request_id keeps this aimed at the delivery-rate range check;
+    # a non-numeric one would short-circuit at the REQUEST_ID_RE guard.
+    body = _make_signed_request_body(delivery_rate=delivery_rate_str, request_id="1")
     http_msg: Any = make_http_msg(body)
     mh._handle_signed_requests(http_msg, http_dialogue)
 
@@ -2048,6 +2092,62 @@ def test_signed_requests_accepts_zero_delivery_rate(
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.OK_CODE.value
     assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_enqueue_offchain_request_reserved_keys_filter_blocks_body_overrides(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Client-supplied body keys can not override trusted enqueue-time fields.
+
+    ``_enqueue_offchain_request`` merges the parsed HTTP body via ``**data``
+    into the pending task dict. Without the ``reserved_keys`` filter, a
+    request carrying an extra ``requestId`` / ``request_id`` /
+    ``is_offchain`` / ``data`` / ``request_delivery_rate`` key would
+    silently overwrite the trusted values the handler just set. That
+    would (a) re-plant the wire-format ``str`` ``request_id`` and defeat
+    the ``int(request_id)`` coercion at ingress, (b) let the client route
+    an off-chain task down the on-chain IPFS-GET branch by flipping
+    ``is_offchain`` to False, (c) replace the trusted content-hash bytes
+    with attacker-controlled payload bytes, and (d) plant a
+    ``request_delivery_rate`` that bypasses the tool-minimum-price gate
+    while the on-chain-signed rate the requester is actually charged
+    stays untouched.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    _install_balance_ok(mh, monkeypatch)
+    mh.setup()
+
+    body = _make_signed_request_body(delivery_rate="123", request_id="42")
+    # Every reserved-keys entry, poisoned with a value that would break the
+    # invariant if it landed on the pending task.
+    body["requestId"] = "999999"
+    body["is_offchain"] = "false"
+    body["data"] = "0x" + "de" * 32
+    body["request_delivery_rate"] = "0"
+    # Plus a benign key that must survive the filter untouched, so the
+    # test also pins that non-reserved keys still flow through.
+    body["signature"] = "0xdead"
+
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    pending = handler_context.shared_state["pending_tasks"]
+    assert len(pending) == 1
+    task = pending[0]
+    # Trusted values won on every reserved key.
+    assert task[hmod.RequestKey.REQUEST_ID_CAMEL.value] == 42
+    assert task[hmod.RequestKey.IS_OFFCHAIN.value] is True
+    assert task[hmod.BodyKey.DATA.value] == bytes.fromhex("ab" * 32)
+    assert task[hmod.RequestKey.REQUEST_DELIVERY_RATE.value] == 123
+    # Non-reserved key still flows through.
+    assert task["signature"] == "0xdead"
 
 
 # --- guard tests for the defensive paths added in the remediation -----------

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -352,7 +352,12 @@ def make_http_msg(body_dict: Dict[str, str], headers: str = "") -> SimpleNamespa
         pytest.param(
             "ok",
             1,
-            "req-1",
+            # Numeric decimal string — matches the wire format mech-client
+            # sends (``getRequestId`` returns a uint256; mech-client
+            # form-encodes it to decimal). Post the ingress coercion in
+            # ``_enqueue_offchain_request`` non-numeric placeholders like
+            # ``"req-1"`` no longer round-trip: ``int("req-1")`` raises.
+            "1",
             HttpCode.OK_CODE.value,
             True,
             None,
@@ -362,7 +367,7 @@ def make_http_msg(body_dict: Dict[str, str], headers: str = "") -> SimpleNamespa
         pytest.param(
             "ok",
             -1,
-            "req-insufficient",
+            "2",
             HttpCode.PAYMENT_REQUIRED_CODE.value,
             False,
             "rejected",
@@ -372,7 +377,7 @@ def make_http_msg(body_dict: Dict[str, str], headers: str = "") -> SimpleNamespa
         pytest.param(
             "unavailable",
             -123,
-            "req-unavailable",
+            "3",
             HttpCode.SERVICE_UNAVAILABLE_CODE.value,
             False,
             "rejected",
@@ -435,7 +440,11 @@ def test_signed_requests_balance_scenarios(
         # off-chain flow no longer publishes request metadata to IPFS.
         assert len(pend) == 1 and ipfsq == [] and len(in_mem) == 1
         assert pend[0]["is_offchain"] is True
-        assert pend[0]["requestId"] == request_id
+        # ``requestId`` is stored as ``int`` post the ingress coercion
+        # in ``_enqueue_offchain_request``; the ``in_memory_requests``
+        # dict is still str-keyed since the local ``request_id`` variable
+        # in the handler stays str for the HTTP-state lookups.
+        assert pend[0]["requestId"] == int(request_id)
         assert in_mem[request_id] == '{"foo":"bar"}'
     else:
         assert pend == [] and ipfsq == [] and in_mem == {}
@@ -569,7 +578,9 @@ def test_signed_requests_rollback_partial_enqueue(
     ipfs_hash: str = "0x" + "ab" * 32
     body: Dict[str, str] = {
         "ipfs_hash": ipfs_hash,
-        "request_id": "req-rollback",
+        # Numeric — the ingress coercion in ``_enqueue_offchain_request``
+        # runs before the buffer-write attempt this test simulates.
+        "request_id": "6",
         "ipfs_data": '{"foo":"bar"}',
         "delivery_rate": "123",
         "sender": "0x0000000000000000000000000000000000000001",
@@ -694,7 +705,7 @@ def test_200_emits_payment_receipt_header(
 ) -> None:
     """200 response carries a Payment-Receipt header with valid base64-encoded JSON."""
     mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=10)
-    resp = _send_signed_request(mh, http_dialogue, request_id="req-200-receipt")
+    resp = _send_signed_request(mh, http_dialogue, request_id="200")
 
     assert resp.status_code == HttpCode.OK_CODE.value
     receipt_line = next(
@@ -704,7 +715,10 @@ def test_200_emits_payment_receipt_header(
     import base64 as _b64
 
     receipt = json.loads(_b64.b64decode(encoded).decode("utf-8"))
-    assert receipt["request_id"] == "req-200-receipt"
+    # ``receipt["request_id"]`` is written from the local ``request_id``
+    # variable in the handler, which stays ``str`` (the ingress coercion
+    # only touches the value that flows into the pending task).
+    assert receipt["request_id"] == "200"
     assert receipt["accepted_amount"] == "123"
     assert receipt["settlement_status"] == "pending"
     # ISO 8601 UTC with trailing Z. Loose check that it parses as a date.
@@ -718,10 +732,10 @@ def test_200_body_unchanged_for_legacy_clients(
 ) -> None:
     """200 body shape is unchanged. Receipt only goes in the header."""
     mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=10)
-    resp = _send_signed_request(mh, http_dialogue, request_id="req-200-body")
+    resp = _send_signed_request(mh, http_dialogue, request_id="201")
 
     payload = json.loads(resp.body.decode("utf-8"))
-    assert payload == {"request_id": "req-200-body"}
+    assert payload == {"request_id": "201"}
 
 
 def test_offchain_request_buffered_in_memory_not_in_ipfs_tasks(
@@ -732,11 +746,13 @@ def test_offchain_request_buffered_in_memory_not_in_ipfs_tasks(
     # no longer written from the offchain path. A future refactor that flipped
     # the flag back without us noticing would fail this test.
     mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=10)
-    _send_signed_request(mh, http_dialogue, request_id="req-in-mem")
+    _send_signed_request(mh, http_dialogue, request_id="5")
 
     assert handler_context.shared_state["ipfs_tasks"] == []
     assert handler_context.shared_state["in_memory_requests"] == {
-        "req-in-mem": '{"foo":"bar"}'
+        # ``in_memory_requests`` stays str-keyed (the ingress coercion
+        # only touches the pending-task value, not the local dict keys).
+        "5": '{"foo":"bar"}'
     }
 
 
@@ -1901,7 +1917,7 @@ def test_signed_requests_accepts_zero_delivery_rate(
     _install_balance_ok(mh, monkeypatch)
     mh.setup()
 
-    body = _make_signed_request_body(delivery_rate="0", request_id="req-zero-rate")
+    body = _make_signed_request_body(delivery_rate="0", request_id="7")
     http_msg: Any = make_http_msg(body)
     mh._handle_signed_requests(http_msg, http_dialogue)
 

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -493,6 +493,11 @@ def test_signed_requests_rejects_non_numeric_request_id(
     ``int()`` is also lenient about whitespace, ``0x`` prefixes, and
     underscore separators; ``str.isdigit()`` rejects all of them, so
     the decimal-uint256 contract on the wire is enforced strictly.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param bad_request_id: parametrized invalid ``request_id`` string.
     """
     mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
@@ -825,6 +830,10 @@ def test_fetch_offchain_request_info_str_key_matches_wire_id(
     Pre-fix (``cast(str, req_id)`` — a runtime no-op), the writer wrote
     an ``int`` key and this lookup returned ``{}``; the requester paid
     on chain via ``deliverWithSignatures`` and polled empty forever.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
     """
     mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
@@ -861,6 +870,10 @@ def test_fetch_offchain_request_info_fallback_scan_normalizes_types(
     the ``str()`` normalization added to the equality check the scan
     silently misses on the very same batch that just delivered the
     task, and the requester never gets a definitive answer.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
     """
     mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -474,6 +474,42 @@ def test_signed_requests_bad_request(
     assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
 
 
+@pytest.mark.parametrize(
+    "bad_request_id",
+    ["req-1", "", "0x123", "42abc", "42.0", " 42"],
+    ids=["alpha", "empty", "hex", "trailing_alpha", "dotted", "whitespace"],
+)
+def test_signed_requests_rejects_non_numeric_request_id(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any, bad_request_id: str
+) -> None:
+    """Non-decimal ``request_id`` is rejected with 400 before any state mutation.
+
+    The ingress coercion in ``_enqueue_offchain_request`` requires a
+    valid ``int()`` input; the upfront ``request_id.isdigit()`` check in
+    ``_handle_signed_requests`` gives the operator a distinguishable log
+    line ("request_id must be a non-empty decimal string") rather than
+    letting the ``ValueError`` from the coercion surface as an opaque
+    "Error enqueuing offchain request ...: invalid literal for int()".
+    ``int()`` is also lenient about whitespace, ``0x`` prefixes, and
+    underscore separators; ``str.isdigit()`` rejects all of them, so
+    the decimal-uint256 contract on the wire is enforced strictly.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    _install_balance_ok(mh, monkeypatch)
+    mh.setup()
+
+    body = _make_signed_request_body(request_id=bad_request_id)
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    # No partial state mutation.
+    assert handler_context.shared_state["pending_tasks"] == []
+    assert handler_context.shared_state["in_memory_requests"] == {}
+
+
 def test_signed_requests_offchain_disabled_returns_503(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
@@ -520,7 +556,7 @@ def test_fetch_offchain_request_info_returns_insufficient_balance_response(
     )
     mh.setup()
 
-    request_id = "req-insufficient-fetch"
+    request_id = "1003"
     ipfs_hash: str = "0x" + "ab" * 32
     send_msg: Any = make_http_msg(
         {
@@ -651,7 +687,7 @@ def test_402_body_includes_structured_challenge(
         handler_context, monkeypatch, available_offset=-50
     )
 
-    resp = _send_signed_request(mh, http_dialogue, request_id="req-402-schema")
+    resp = _send_signed_request(mh, http_dialogue, request_id="402")
     assert resp.status_code == HttpCode.PAYMENT_REQUIRED_CODE.value
 
     payload = json.loads(resp.body.decode("utf-8"))
@@ -677,7 +713,7 @@ def test_402_emits_www_authenticate_header(
 ) -> None:
     """402 response carries the WWW-Authenticate header keyed by mech address."""
     mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=-1)
-    resp = _send_signed_request(mh, http_dialogue, request_id="req-402-header")
+    resp = _send_signed_request(mh, http_dialogue, request_id="4021")
 
     assert resp.status_code == HttpCode.PAYMENT_REQUIRED_CODE.value
     assert (
@@ -694,7 +730,7 @@ def test_402_native_asset_when_payment_type_unmapped(
     # treat the payment as a native-asset deposit.
     handler_context.params.payment_type_to_asset_address = {}
     mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=-1)
-    resp = _send_signed_request(mh, http_dialogue, request_id="req-402-native")
+    resp = _send_signed_request(mh, http_dialogue, request_id="4022")
 
     payload = json.loads(resp.body.decode("utf-8"))
     assert payload["asset"] == "0x0000000000000000000000000000000000000000"
@@ -775,6 +811,81 @@ def test_fetch_offchain_request_info_found(
     resp: SimpleNamespace = handler_context.outbox.sent[-1]
     payload: Dict[str, Any] = json.loads(resp.body.decode("utf-8"))
     assert payload["request_id"] == "abc" and payload["value"] == 7
+
+
+def test_fetch_offchain_request_info_str_key_matches_wire_id(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The primary lookup path resolves the wire ``str`` against the writer's ``str`` key.
+
+    ``task_execution.behaviours._handle_done_task`` computes the key as
+    ``str(req_id)`` where ``req_id`` is the ``int`` from the ingress
+    coercion, so a wire-format ``request_id="42"`` posted by the
+    requester must resolve to the ``"42"`` key the writer produces.
+    Pre-fix (``cast(str, req_id)`` — a runtime no-op), the writer wrote
+    an ``int`` key and this lookup returned ``{}``; the requester paid
+    on chain via ``deliverWithSignatures`` and polled empty forever.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    stored = {
+        "request_id": "42",
+        "status": "ok",
+        "content_cid": "bafyexamplecid",
+        "response": {"result": "computed"},
+    }
+    # Match what the writer produces: str-keyed under the same value.
+    handler_context.shared_state.setdefault(hmod.OFFCHAIN_REQUEST_RESPONSES, {})[
+        "42"
+    ] = stored
+
+    http_msg: Any = make_http_msg({"request_id": "42"})
+    mh._handle_offchain_request_info(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    payload: Dict[str, Any] = json.loads(resp.body.decode("utf-8"))
+    assert payload == stored
+
+
+def test_fetch_offchain_request_info_fallback_scan_normalizes_types(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The fallback ``done_tasks`` scan normalizes ``str`` vs ``int`` types.
+
+    The response cache miss path scans ``shared_state[DONE_TASKS]``.
+    Off-chain ``done_tasks`` carry ``request_id`` as ``int`` post the
+    ingress coercion; the GET body has the wire-format ``str``. Without
+    the ``str()`` normalization added to the equality check the scan
+    silently misses on the very same batch that just delivered the
+    task, and the requester never gets a definitive answer.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    # ``OFFCHAIN_REQUEST_RESPONSES`` intentionally empty so we go through
+    # the fallback path.
+    handler_context.shared_state[hmod.OFFCHAIN_REQUEST_RESPONSES] = {}
+    done_task = {
+        "request_id": 42,  # int, as the ingress coercion produces
+        "is_offchain": True,
+        "tool": "prediction-offline-v1",
+    }
+    handler_context.shared_state[hmod.DONE_TASKS] = [done_task]
+
+    http_msg: Any = make_http_msg({"request_id": "42"})
+    mh._handle_offchain_request_info(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    # ``_handle_offchain_request_info`` returns the first matching
+    # done_task dict verbatim (or ``{}`` when no match).
+    assert payload == done_task, payload
+    assert payload != {}, "fallback scan missed — str/int mismatch regressed"
 
 
 def test_fetch_offchain_request_info_not_found(
@@ -2027,7 +2138,7 @@ def test_handler_replies_500_when_402_build_fails(
     )
     mh = _http_handler(handler_context, monkeypatch)
     http_msg: Any = make_http_msg(
-        _make_signed_request_body(delivery_rate="1", request_id="req-500")
+        _make_signed_request_body(delivery_rate="1", request_id="500")
     )
     mh._handle_signed_requests(http_msg, http_dialogue)
 

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -504,6 +504,13 @@ def test_signed_requests_bad_request(
         # promise: the ingress guard means ``int(request_id)`` cannot raise
         # deep in the enqueue helper). ``2**256`` is one over the bound.
         str(2**256),
+        # CPython 3.11+ raises ``ValueError`` on ``int()`` for a decimal
+        # string longer than ``sys.get_int_max_str_digits()`` (4300
+        # default). The length check on ``MAX_REQUEST_ID`` MUST
+        # short-circuit before ``int()`` runs, otherwise a 5000-digit
+        # canonical decimal blows up outside the handler's ``try/except``
+        # and skips the 400 path entirely. This case pins that.
+        "9" * 5000,
     ],
     ids=[
         "alpha",
@@ -520,6 +527,7 @@ def test_signed_requests_bad_request(
         "trailing_newline",
         "leading_newline",
         "above_uint256",
+        "above_cpython_int_str_digits_limit",
     ],
 )
 def test_signed_requests_rejects_non_numeric_request_id(

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -2123,12 +2123,26 @@ def test_enqueue_offchain_request_reserved_keys_filter_blocks_body_overrides(
     mh.setup()
 
     body = _make_signed_request_body(delivery_rate="123", request_id="42")
-    # Every reserved-keys entry, poisoned with a value that would break the
-    # invariant if it landed on the pending task.
+    # ``body["request_id"]`` (snake) IS the source of truth read by
+    # ``_handle_signed_requests`` — the reserved_keys filter's job is to
+    # stop it from ALSO surviving as a snake-case dupe on the pending
+    # task alongside the trusted ``requestId`` (camel) int. So the
+    # source-of-truth ``"42"`` stays; camel + everything else is poisoned.
     body["requestId"] = "999999"
     body["is_offchain"] = "false"
     body["data"] = "0x" + "de" * 32
     body["request_delivery_rate"] = "0"
+    # Round-3 additions: reserved_keys was extended to cover the four keys
+    # ``_handle_done_task`` re-spreads via ``**executing_task`` and the
+    # ``tool`` used for pricing / metrics. A body value here would
+    # otherwise ride through executing_task → done_task → consensus and
+    # reroute delivery, misattribute the executor, desync the on-chain
+    # signature, or point the tool-price gate at the wrong tool.
+    body["mech_address"] = "0xATTACKERMECH"
+    body["task_executor_address"] = "0xATTACKEREXECUTOR"
+    body["request_id_nonce"] = "999"
+    body["requestIdWithNonce"] = "999"
+    body["tool"] = "attacker-tool"
     # Plus a benign key that must survive the filter untouched, so the
     # test also pins that non-reserved keys still flow through.
     body["signature"] = "0xdead"
@@ -2146,6 +2160,21 @@ def test_enqueue_offchain_request_reserved_keys_filter_blocks_body_overrides(
     assert task[hmod.RequestKey.IS_OFFCHAIN.value] is True
     assert task[hmod.BodyKey.DATA.value] == bytes.fromhex("ab" * 32)
     assert task[hmod.RequestKey.REQUEST_DELIVERY_RATE.value] == 123
+    # Snake-case ``request_id`` must never appear on the pending task:
+    # ``_handle_done_task`` spreads ``**executing_task`` into ``done_task``
+    # and this key would silently overwrite the canonical int, resurrecting
+    # the mixed-type ``sorted()`` crash + str/int keying divergence the
+    # PR chain closes.
+    assert hmod.RequestKey.REQUEST_ID.value not in task
+    # Round-3 keys must not leak into the pending task either.
+    for reserved in (
+        "mech_address",
+        "task_executor_address",
+        "request_id_nonce",
+        "requestIdWithNonce",
+        "tool",
+    ):
+        assert reserved not in task, f"reserved key {reserved!r} leaked from body"
     # Non-reserved key still flows through.
     assert task["signature"] == "0xdead"
 

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -234,10 +234,20 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
         with self.done_tasks_lock():
             done_tasks = self.done_tasks
             not_submitted = []
+            # Normalize both sides to ``str`` before comparing so a mix of
+            # ``int`` (on-chain requestId) and ``str`` (pre-ingress-fix
+            # off-chain requestId) doesn't silently fail equality and leave
+            # a delivered task stuck in ``done_tasks`` for the next round to
+            # re-emit. Post the :mod:`task_execution.handlers` ingress fix
+            # both sides are ``int`` and the ``str`` cast is a no-op; the
+            # cast is retained for the same restart-transition reason
+            # called out in :meth:`task_submission_abci.rounds.
+            # TaskPoolingRound.end_block`.
             for done_task in done_tasks:
+                done_key = str(done_task["request_id"])
                 is_submitted = False
                 for submitted_task in submitted_tasks:
-                    if submitted_task["request_id"] == done_task["request_id"]:
+                    if str(submitted_task["request_id"]) == done_key:
                         is_submitted = True
                         break
                 if not is_submitted:

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -101,27 +101,38 @@ class TaskPoolingRound(CollectionRound):
                 done_tasks = json.loads(done_tasks_str)
                 all_done_tasks.extend(done_tasks)
 
-            # Set to store unique request_ids
-            unique_ids = set()
+            # Deduplicate and sort by the same ``str``-normalized key so
+            # a mixed-type ``done_tasks`` list (an on-chain ``int``
+            # ``request_id`` next to an off-chain ``str`` — happens on
+            # the old-code → new-code restart transition where an agent
+            # resumes with pre-ingress-fix state in shared memory)
+            # produces one canonical row per logical request and doesn't
+            # raise ``TypeError: '<' not supported between instances of
+            # 'int' and 'str'`` on the sort. Post ingress coercion in
+            # :mod:`task_execution.handlers` all new writes are ``int``
+            # and the cast is a no-op, but leaving the two sites
+            # un-normalized would let the same request slip through
+            # dedup as both ``42`` and ``"42"`` and get submitted twice
+            # in the same multisend — a costlier failure than the crash
+            # itself. The dedup key and the sort key MUST use the same
+            # normalization, otherwise the two disagree on which entries
+            # collide.
+            unique_ids: set = set()
             unique_objects = []
-
-            # filter out the tasks that have duplicate ids
             for obj in all_done_tasks:
-                request_id = obj.get("request_id")
-                if request_id not in unique_ids:
-                    unique_ids.add(request_id)
+                request_id_key = str(obj.get("request_id", ""))
+                if request_id_key not in unique_ids:
+                    unique_ids.add(request_id_key)
                     unique_objects.append(obj)
 
-            # Stringify the sort key so a mixed-type list (e.g. an on-chain
-            # ``request_id`` stored as ``int`` next to an off-chain one
-            # stored as ``str``) doesn't raise ``TypeError: '<' not
-            # supported between instances of 'int' and 'str'`` in Python 3.
-            # The ingress path in :mod:`task_execution.handlers` now
-            # coerces off-chain ``requestId`` to ``int`` so this normally
-            # never happens, but a mech that carried mixed-type
-            # ``done_tasks`` across an old-code → new-code restart would
-            # still hit the crash on the first pooling round without this
-            # cast. The sort result is unchanged when types already agree.
+            # Note on ordering: the ``str`` sort key means int
+            # ``request_id``s land in lexicographic order (``[9, 10]``
+            # sorts as ``[10, 9]``). This is stable and deterministic —
+            # every agent applies the same rule — so consensus is not at
+            # risk. The order changes vs. the numeric sort that would
+            # apply if all ids were guaranteed ``int``, but consumers
+            # downstream do not depend on the specific order (they iterate
+            # or index-by-id, not by position).
             unique_done_tasks = sorted(
                 unique_objects, key=lambda x: str(x.get("request_id", ""))
             )

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -112,8 +112,18 @@ class TaskPoolingRound(CollectionRound):
                     unique_ids.add(request_id)
                     unique_objects.append(obj)
 
+            # Stringify the sort key so a mixed-type list (e.g. an on-chain
+            # ``request_id`` stored as ``int`` next to an off-chain one
+            # stored as ``str``) doesn't raise ``TypeError: '<' not
+            # supported between instances of 'int' and 'str'`` in Python 3.
+            # The ingress path in :mod:`task_execution.handlers` now
+            # coerces off-chain ``requestId`` to ``int`` so this normally
+            # never happens, but a mech that carried mixed-type
+            # ``done_tasks`` across an old-code → new-code restart would
+            # still hit the crash on the first pooling round without this
+            # cast. The sort result is unchanged when types already agree.
             unique_done_tasks = sorted(
-                unique_objects, key=lambda x: x.get("request_id", "")
+                unique_objects, key=lambda x: str(x.get("request_id", ""))
             )
             synchronized_data = self.synchronized_data.update(
                 synchronized_data_class=SynchronizedData,

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -117,10 +117,27 @@ class TaskPoolingRound(CollectionRound):
             # itself. The dedup key and the sort key MUST use the same
             # normalization, otherwise the two disagree on which entries
             # collide.
+            # A falsy ``request_id`` (missing, ``None``, ``""``) would
+            # otherwise dedup all such rows to the same ``""`` / ``"None"``
+            # bucket and silently drop legitimate rows from other agents —
+            # ``all_done_tasks`` is a bag of every participant's payloads
+            # with no schema validation, so a single misbehaving or
+            # out-of-version agent can introduce one. Skip and warn: this
+            # agent's own pipeline should never produce a falsy id (both
+            # writers set it explicitly), so hitting this branch is a real
+            # protocol violation worth surfacing.
             unique_ids: set = set()
             unique_objects = []
             for obj in all_done_tasks:
-                request_id_key = str(obj.get("request_id", ""))
+                raw_request_id = obj.get("request_id")
+                if not raw_request_id and raw_request_id != 0:
+                    self.context.logger.warning(
+                        "Skipping done_task with falsy request_id in "
+                        "TaskPoolingRound dedup: %r",
+                        obj,
+                    )
+                    continue
+                request_id_key = str(raw_request_id)
                 if request_id_key not in unique_ids:
                     unique_ids.add(request_id_key)
                     unique_objects.append(obj)

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -150,12 +150,23 @@ class TaskPoolingRound(CollectionRound):
 
             # Note on ordering: the ``str`` sort key means int
             # ``request_id``s land in lexicographic order (``[9, 10]``
-            # sorts as ``[10, 9]``). This is stable and deterministic —
-            # every agent applies the same rule — so consensus is not at
-            # risk. The order changes vs. the numeric sort that would
-            # apply if all ids were guaranteed ``int``, but consumers
-            # downstream do not depend on the specific order (they iterate
-            # or index-by-id, not by position).
+            # sorts as ``[10, 9]``). This is stable and deterministic
+            # *within a uniform fleet* — every agent applies the same
+            # rule — so consensus holds. It does NOT hold across a mixed
+            # old-code / new-code fleet mid-upgrade: pre-fix agents dedup
+            # ``42`` and ``"42"`` as distinct and sort numerically, so an
+            # old and new agent computing ``done_tasks`` off the same
+            # collected payloads produce different content, different
+            # row count, and different order.
+            # ``TransactionPreparationRound`` is a
+            # ``CollectSameUntilThresholdRound`` keyed on
+            # ``most_voted_payload`` and requires 2/3+ byte-identical
+            # payloads, so a mixed fleet ``NO_MAJORITY``-stalls until
+            # versions converge. This is why the service hash bump has
+            # to be atomic across all agents in a service (not rolling)
+            # — see the PR's rollout notes. Consumers downstream of the
+            # sort do not depend on the specific order (they iterate or
+            # index-by-id, not by position).
             unique_done_tasks = sorted(
                 unique_objects, key=lambda x: str(x.get("request_id", ""))
             )

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -130,10 +130,16 @@ class TaskPoolingRound(CollectionRound):
             unique_objects = []
             for obj in all_done_tasks:
                 raw_request_id = obj.get("request_id")
-                if not raw_request_id and raw_request_id != 0:
+                # Skip "genuinely absent" (missing key, None, empty string)
+                # without the boolean/float overlap ``not x`` gives:
+                # ``not False`` and ``not 0.0`` are both True in Python, so
+                # ``if not raw_request_id`` would drop a JSON ``false`` or
+                # ``0.0`` id — both malformed but distinguishable from
+                # missing. Legit ``0`` (int) is deliberately kept.
+                if raw_request_id is None or raw_request_id == "":
                     self.context.logger.warning(
-                        "Skipping done_task with falsy request_id in "
-                        "TaskPoolingRound dedup: %r",
+                        "Skipping done_task with missing/empty request_id "
+                        "in TaskPoolingRound dedup: %r",
                         obj,
                     )
                     continue

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa
+- valory/task_execution:0.1.0:bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
-  rounds.py: bafybeiggk5v5iybppwqnux4g74kxyqlmel7emiqvy5torzdcqveb527stq
+  rounds.py: bafybeiam7xceouyqewqmlkbfkityzziz7kv42eo3wx3a6fzcey65v5qviq
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -26,7 +26,7 @@ fingerprint:
   tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
-  tests/test_rounds.py: bafybeieehhlqooxg57k7esk3jddsfumxtohrb7fobdyh7nx7mrp5p7rqo4
+  tests/test_rounds.py: bafybeigzbclqwozy2itqi4bs3tr6w2xghw3wb7ie3zyrteytptd5jtsywu
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i
+- valory/task_execution:0.1.0:bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,14 +8,14 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeihe5i2uh7rlyxgdf24vijxzngc55k3yi7vxq7rb2v6z3aqzxbyuui
+  behaviours.py: bafybeigamyrgbijjz7ud2zebrafqpadgd7cxlpycnz3pxolm3dzatpcz3i
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
-  rounds.py: bafybeifyjanb7hbqolgxsudzhr27otlaozgttjwufmqit6w5rgb2xc53yu
+  rounds.py: bafybeihmd7fcw3jxblfrf4ajjtvquxdjqapc2efs4ck3thbq4h6otvby7a
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -26,7 +26,7 @@ fingerprint:
   tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
-  tests/test_rounds.py: bafybeibervh4zm6a2fmfwcxsi4jl6vfc7owfl3474nhobiijf73fswul3e
+  tests/test_rounds.py: bafybeigugqbdo7hfezfycyceipwzi3p3uei7xyygqm7qqoz5fzulu3xygi
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
+- valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -19,14 +19,14 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeidgbn64q6oyxphwhcgkff5z34z7ncqnmpcbjy2ix64yfwbzwj7ogy
+  tests/test_behaviours.py: bafybeihcxzh3drnwdxjbjxw5owqqyqq7cihbqqjzgfzrdzng3sp5mvahem
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
   tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
-  tests/test_rounds.py: bafybeib2b55utll674fblcaanyw7z5h663uyud67vlk3o5kerx7c7eqwk4
+  tests/test_rounds.py: bafybeieehhlqooxg57k7esk3jddsfumxtohrb7fobdyh7nx7mrp5p7rqo4
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi
+- valory/task_execution:0.1.0:bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
-  rounds.py: bafybeiam7xceouyqewqmlkbfkityzziz7kv42eo3wx3a6fzcey65v5qviq
+  rounds.py: bafybeia23igp6apuspfoj5dspbrswyyq6t2lu45nvvcrd7pon44i36t6la
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeihig3ha4yt4kwivctnsimvnftt6hybij4fgt3z2kg6ii5guzxrwzy
+- valory/task_execution:0.1.0:bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeif5cudvaq2dlwnwse3jrj4tgjhbqmcoylvnerhczujg3hyl7tujsi
+- valory/task_execution:0.1.0:bafybeieffhg7slahqiczkbaki3ju6kt3g4crwtu4hjophbqpvt2vya7mqa
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
-  rounds.py: bafybeia23igp6apuspfoj5dspbrswyyq6t2lu45nvvcrd7pon44i36t6la
+  rounds.py: bafybeidt43y5ohj4so67dvs57w7hotnezlc22kvixquvkqeumtzivwd74y
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeihvofdooot5qq75bl5wedkzomrzjs3ovrvz4ugm3qxsz745dlfoay
+- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -26,7 +26,7 @@ fingerprint:
   tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
-  tests/test_rounds.py: bafybeigugqbdo7hfezfycyceipwzi3p3uei7xyygqm7qqoz5fzulu3xygi
+  tests/test_rounds.py: bafybeickm2ymbxtd6swtdt2p3ttbmrdkgkmqwgjjk3rqm6fdbqc5fjzsfm
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -15,18 +15,18 @@ fingerprint:
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
-  rounds.py: bafybeihmd7fcw3jxblfrf4ajjtvquxdjqapc2efs4ck3thbq4h6otvby7a
+  rounds.py: bafybeiggk5v5iybppwqnux4g74kxyqlmel7emiqvy5torzdcqveb527stq
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeieimcrlz5w5sl5gwlukjjzo4lcntula6ggfdeq7hdl2s2wfjq45c4
+  tests/test_behaviours.py: bafybeidgbn64q6oyxphwhcgkff5z34z7ncqnmpcbjy2ix64yfwbzwj7ogy
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
   tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
-  tests/test_rounds.py: bafybeickm2ymbxtd6swtdt2p3ttbmrdkgkmqwgjjk3rqm6fdbqc5fjzsfm
+  tests/test_rounds.py: bafybeib2b55utll674fblcaanyw7z5h663uyud67vlk3o5kerx7c7eqwk4
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeidx4rbnf2tj7unk4royemoz2x3vw7phqsjkaiccdol2xvlwc5plni
+- valory/task_execution:0.1.0:bafybeieze2owvfl4mzx4amoxsaewlb7hoyw5e4tkapbp4h3su5nxk74mdi
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeickz656mdv5riki522oxlbfvxkui6ph5xtdqludjgmx4iz2mtr664
+- valory/task_execution:0.1.0:bafybeibnqj6ruy23zj6oqx6fgzntlpu5wlhgngygttqdmfc4elny5ijd4i
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -22,7 +22,7 @@ import contextlib
 import json
 import time
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, Generator, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -215,6 +215,36 @@ class TestRemoveTasks:
         ctx = _make_ctx(done_tasks=tasks)
         b = _DummyBase(name="b", skill_context=ctx)
         b.remove_tasks(tasks)
+        assert ctx.shared_state[DONE_TASKS] == []
+
+    def test_remove_submitted_task_mixed_types(self) -> None:
+        """``remove_tasks`` matches across the ``str`` / ``int`` split.
+
+        Post the ingress coercion in :mod:`task_execution.handlers`,
+        off-chain ``done_tasks`` carry ``request_id`` as ``int``. But a
+        mech resuming with pre-fix off-chain rows in shared state at
+        redeploy time would have ``str`` there, while the newly-emitted
+        ``submitted_tasks`` for the same round carry ``int``. Without
+        the ``str()`` normalization added to the equality check in
+        :meth:`TaskExecutionBaseBehaviour.remove_tasks`, the pre-fix
+        ``str`` row would silently escape removal and be re-emitted next
+        round — the same class of silent-double-delivery bug the dedup
+        normalization in :mod:`task_submission_abci.rounds` prevents.
+        """
+        # Pre-fix ``str`` row survives from an old boot; new
+        # ``submitted_tasks`` for the same request_id comes back as
+        # ``int``.
+        done_tasks_str: List[Dict[str, Any]] = [{"request_id": "5"}]
+        ctx = _make_ctx(done_tasks=done_tasks_str)
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks([{"request_id": 5}])
+        assert ctx.shared_state[DONE_TASKS] == []
+
+        # Same, other direction.
+        done_tasks_int: List[Dict[str, Any]] = [{"request_id": 5}]
+        ctx = _make_ctx(done_tasks=done_tasks_int)
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks([{"request_id": "5"}])
         assert ctx.shared_state[DONE_TASKS] == []
 
 

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -19,7 +19,7 @@
 """Tests for task_submission_abci.rounds."""
 
 import json
-from typing import Any, cast
+from typing import Any, Union, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -66,11 +66,13 @@ def _make_sync_data(**extra: Any) -> SynchronizedData:
     return SynchronizedData(_make_db(**extra))
 
 
-def _make_task(request_id: Any) -> dict:
-    # ``Any`` so tests can pass both ``str`` (off-chain wire format) and
-    # ``int`` (on-chain bytes32 → int conversion) to exercise the mixed-
-    # type sort path — see
-    # ``test_mixed_int_and_str_request_ids_do_not_crash``.
+def _make_task(request_id: Union[int, str]) -> dict:
+    # ``Union[int, str]`` so tests can pass both ``str`` (off-chain wire
+    # format) and ``int`` (on-chain bytes32 → int conversion) to exercise
+    # the mixed-type sort / dedup path — see
+    # ``test_mixed_int_and_str_request_ids_do_not_crash``. Narrower than
+    # ``Any``: rejects ``None`` / ``float`` / ``list`` which
+    # ``request_id`` can't legitimately be.
     return {"request_id": request_id, "result": "ok"}
 
 
@@ -220,7 +222,7 @@ class TestTaskPoolingRound:
         assert request_ids == sorted(request_ids)
 
     def test_mixed_int_and_str_request_ids_do_not_crash(self) -> None:
-        """A batch with both ``int`` and ``str`` request_ids sorts cleanly.
+        """A batch with both ``int`` and ``str`` request_ids sorts + dedups cleanly.
 
         Regression guard for the crash observed in prod when an off-chain
         (``str`` request_id from the HTTP body) and an on-chain (``int``
@@ -228,16 +230,27 @@ class TestTaskPoolingRound:
         same pooling batch. Pre-fix, ``sorted(..., key=lambda x:
         x["request_id"])`` raised ``TypeError: '<' not supported between
         instances of 'int' and 'str'`` and restarted the aea container.
+        The same restart-transition state also let the un-normalized
+        dedup set treat ``42`` and ``"42"`` as distinct — pre-fix the
+        batch would then have delivered the same request twice in one
+        multisend (a costlier failure than the crash itself).
 
         The ingress fix in :mod:`task_execution.handlers` coerces
         off-chain request_ids to ``int`` so this shape never happens in
-        new writes, but a mech resuming with a pre-fix mixed
+        new writes, but a mech resuming with pre-fix mixed
         ``done_tasks`` in shared state at redeploy time would still hit
-        the crash on the first pooling round without the ``str`` cast on
-        the sort key. This test locks in that safety net.
+        both bugs on the first pooling round without the ``str`` cast on
+        the dedup + sort keys. This test locks in that safety net.
+
+        Agent-0 emits both ``42`` (int) and ``"100"`` (str) — the mixed
+        types that used to crash the sort. Agent-1 emits ``7`` and
+        ``"42"`` — a same-value cross-type duplicate of Agent-0's ``42``
+        which used to slip through dedup. Agent-2 emits ``"500"``. Post
+        the two normalizations we expect exactly 4 canonical rows (not
+        5) in a deterministic str-sorted order.
         """
         tasks_agent0 = [_make_task(42), _make_task("100")]
-        tasks_agent1 = [_make_task(7)]
+        tasks_agent1 = [_make_task(7), _make_task("42")]
         tasks_agent2 = [_make_task("500")]
         payloads = {
             "agent-0": _payload_for("agent-0", tasks_agent0),
@@ -251,12 +264,15 @@ class TestTaskPoolingRound:
         data, event = result
         assert event == Event.DONE
         sd = cast(SynchronizedData, data)
-        # Sort is by str(request_id); assert the order matches str-sorting
-        # of the mix so any future re-implementation stays observable.
+        # Dedup collapses ``42`` and ``"42"`` into one row (whichever the
+        # iteration order encountered first — Agent-0's int ``42``).
+        # Total canonical rows: {42, "100", "500", 7} = 4, not 5.
+        assert len(sd.done_tasks) == 4, sd.done_tasks
+        # Pin the literal str-sorted order so a future change of the
+        # sort key (e.g. back to numeric) is observable as a test
+        # failure rather than silently passing.
         request_ids = [t["request_id"] for t in sd.done_tasks]
-        assert [str(r) for r in request_ids] == sorted(
-            str(r) for r in request_ids
-        ), request_ids
+        assert request_ids == ["100", 42, "500", 7], request_ids
 
     def test_collection_threshold_reached_property_true(self) -> None:
         """Test collection_threshold_reached is True when threshold is met."""

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -274,6 +274,60 @@ class TestTaskPoolingRound:
         request_ids = [t["request_id"] for t in sd.done_tasks]
         assert request_ids == ["100", 42, "500", 7], request_ids
 
+    def test_falsy_request_id_is_skipped_and_does_not_collide_with_none(self) -> None:
+        """Falsy ``request_id`` rows are dropped, not folded into a shared bucket.
+
+        ``all_done_tasks`` is a bag of every participant's payloads with
+        no schema validation, so a misbehaving or out-of-version agent
+        could inject a row with a missing / ``None`` / ``""`` ``request_id``.
+        Pre-fix, ``str(obj.get("request_id", ""))`` mapped missing to
+        ``""`` and explicit ``None`` to ``"None"`` — two entries in either
+        bucket would silently drop the second row from ``unique_objects``,
+        including a legitimate row from another agent that happened to
+        stringify to the same key. Post-fix the falsy rows are dropped
+        with a warning and cannot collide.
+        """
+        agent0 = [{"request_id": 42, "task_result": "cid42"}]  # legit
+        # Two agents inject junk; three participants total so consensus can form.
+        agent1 = [
+            {"task_result": "no-id"},  # missing key
+            {"request_id": None, "task_result": "none-id"},  # explicit None
+            {"request_id": "", "task_result": "empty-str"},  # explicit empty
+        ]
+        agent2 = [{"request_id": 100, "task_result": "cid100"}]  # legit
+        payloads = {
+            "agent-0": _payload_for("agent-0", agent0),
+            "agent-1": _payload_for("agent-1", agent1),
+            "agent-2": _payload_for("agent-2", agent2),
+        }
+        round_ = _make_pooling_round(payloads)
+        result = round_.end_block()
+        assert result is not None
+        data, event = result
+        assert event == Event.DONE
+        sd = cast(SynchronizedData, data)
+        # The two legit rows survive; the three falsy rows are dropped.
+        request_ids = [t["request_id"] for t in sd.done_tasks]
+        assert request_ids == [100, 42], request_ids
+
+    def test_request_id_zero_int_is_kept(self) -> None:
+        """``request_id=0`` (a legitimate int) is not treated as falsy."""
+        payloads = {
+            "agent-0": _payload_for("agent-0", [_make_task(0)]),
+            "agent-1": _payload_for("agent-1", [_make_task(1)]),
+            "agent-2": _payload_for("agent-2", []),
+        }
+        round_ = _make_pooling_round(payloads)
+        result = round_.end_block()
+        assert result is not None
+        data, event = result
+        assert event == Event.DONE
+        sd = cast(SynchronizedData, data)
+        request_ids = [t["request_id"] for t in sd.done_tasks]
+        # Both survive dedup — 0 is a valid uint256 id and must not be
+        # swept into the falsy-skip branch.
+        assert sorted(str(r) for r in request_ids) == ["0", "1"]
+
     def test_collection_threshold_reached_property_true(self) -> None:
         """Test collection_threshold_reached is True when threshold is met."""
         payloads = {
@@ -445,8 +499,14 @@ class TestTaskPoolingRoundDeduplication:
         ids = [t["request_id"] for t in sd.done_tasks]
         assert ids == ["r1", "r2", "r3"]
 
-    def test_task_missing_request_id_still_sorted(self) -> None:
-        """Task without 'request_id' key uses .get() fallback (empty string)."""
+    def test_task_missing_request_id_is_skipped(self) -> None:
+        """Task without ``request_id`` is skipped rather than folded into the ``""`` bucket.
+
+        Round-3: falsy ``request_id`` rows are dropped with a warning so
+        that two malformed rows can't collide on the shared ``""`` /
+        ``"None"`` key and silently drop a legitimate row from another
+        agent. Previously they were sorted with an empty-string fallback.
+        """
         task_no_id = {"result": "ok"}
         payloads = {
             "agent-0": _payload_for("agent-0", [_make_task("b"), task_no_id]),
@@ -457,9 +517,9 @@ class TestTaskPoolingRoundDeduplication:
         result = round_.end_block()
         assert result is not None
         sd = cast(SynchronizedData, result[0])
-        # None-id task sorts first (empty string < "a"), then "a", then "b"
+        # Falsy-id row dropped; the two legit rows sort alphabetically.
         ids = [t.get("request_id") for t in sd.done_tasks]
-        assert ids == [None, "a", "b"]
+        assert ids == ["a", "b"]
 
     def test_single_agent_all_unique(self) -> None:
         """One agent submits all tasks; others submit nothing → no dedup needed."""

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -66,7 +66,11 @@ def _make_sync_data(**extra: Any) -> SynchronizedData:
     return SynchronizedData(_make_db(**extra))
 
 
-def _make_task(request_id: str) -> dict:
+def _make_task(request_id: Any) -> dict:
+    # ``Any`` so tests can pass both ``str`` (off-chain wire format) and
+    # ``int`` (on-chain bytes32 → int conversion) to exercise the mixed-
+    # type sort path — see
+    # ``test_mixed_int_and_str_request_ids_do_not_crash``.
     return {"request_id": request_id, "result": "ok"}
 
 
@@ -214,6 +218,45 @@ class TestTaskPoolingRound:
         sd = cast(SynchronizedData, data)
         request_ids = [t["request_id"] for t in sd.done_tasks]
         assert request_ids == sorted(request_ids)
+
+    def test_mixed_int_and_str_request_ids_do_not_crash(self) -> None:
+        """A batch with both ``int`` and ``str`` request_ids sorts cleanly.
+
+        Regression guard for the crash observed in prod when an off-chain
+        (``str`` request_id from the HTTP body) and an on-chain (``int``
+        request_id from ``bytes32.from_bytes``) done_task landed in the
+        same pooling batch. Pre-fix, ``sorted(..., key=lambda x:
+        x["request_id"])`` raised ``TypeError: '<' not supported between
+        instances of 'int' and 'str'`` and restarted the aea container.
+
+        The ingress fix in :mod:`task_execution.handlers` coerces
+        off-chain request_ids to ``int`` so this shape never happens in
+        new writes, but a mech resuming with a pre-fix mixed
+        ``done_tasks`` in shared state at redeploy time would still hit
+        the crash on the first pooling round without the ``str`` cast on
+        the sort key. This test locks in that safety net.
+        """
+        tasks_agent0 = [_make_task(42), _make_task("100")]
+        tasks_agent1 = [_make_task(7)]
+        tasks_agent2 = [_make_task("500")]
+        payloads = {
+            "agent-0": _payload_for("agent-0", tasks_agent0),
+            "agent-1": _payload_for("agent-1", tasks_agent1),
+            "agent-2": _payload_for("agent-2", tasks_agent2),
+        }
+        round_ = _make_pooling_round(payloads)
+        # Must not raise TypeError.
+        result = round_.end_block()
+        assert result is not None
+        data, event = result
+        assert event == Event.DONE
+        sd = cast(SynchronizedData, data)
+        # Sort is by str(request_id); assert the order matches str-sorting
+        # of the mix so any future re-implementation stays observable.
+        request_ids = [t["request_id"] for t in sd.done_tasks]
+        assert [str(r) for r in request_ids] == sorted(
+            str(r) for r in request_ids
+        ), request_ids
 
     def test_collection_threshold_reached_property_true(self) -> None:
         """Test collection_threshold_reached is True when threshold is met."""


### PR DESCRIPTION
## Summary

Fixes the aea container restart Marc reported on `mech_mm_predict_clone`:

```
File "/home/agent/vendor/valory/skills/task_submission_abci/rounds.py", line 115, in end_block
    unique_done_tasks = sorted(
TypeError: '<' not supported between instances of 'int' and 'str'
```

Root cause: on-chain `done_tasks` store `request_id` as `int` (via `bytes32 → int.from_bytes` in the marketplace-read path), off-chain `done_tasks` store `request_id` as `str` (raw HTTP body value, no coercion). Once a batch mixes both, `sorted(..., key=lambda x: x["request_id"])` in `TaskPoolingRound.end_block` triggers Python 3's cross-type comparison guard and blows up. The same mismatch also silently breaks `FundsSplittingBehaviour.remove_tasks`'s `==` equality check, which would leave delivered tasks in `done_tasks` and re-emit them next round (never blew up loudly — only the sort did).

Neither call site is a recent change; `sorted()` has been there since April 2024 (`61ab20bf`). What changed is us starting to route offchain traffic to gnosis predict mechs (agent-deployments#313, #316, #317) which introduced the mixed-type input for the first time.

## Change

Deep normalization at ingress + defense-in-depth at both consumers:

1. **`task_execution/handlers.py::_enqueue_offchain_request`** — coerce `request_id` to `int` when it lands in the pending task. The handler's local `request_id` variable stays `str` (it's used as a key into `in_memory_requests` / `offchain_request_responses`, both typed `Dict[str, ...]`, and matched against the caller-visible response body). Only the value that flows into the pending-task dict is coerced.
2. **`task_execution/behaviours.py::_handle_done_task`** — reorder the `_done_task` dict literal so `**executing_task` spreads first and the explicit `request_id` line trails-overrides. Off-chain pending tasks carry both a snake_case `request_id` (from the raw HTTP body via `**data` in the enqueue) and a camelCase `requestId` (the int the ingress fix wrote); the previous ordering would re-plant the str version. Every other explicit key already matches what the spread would have provided, so this reorder is a no-op for on-chain flows.
3. **`task_execution/handlers.py::_rollback_offchain_enqueue`** — compare pending-task `requestId` against `int(request_id)` for the same reason (a mixed `str` vs `int` filter would leave the partial entry queued and silently defeat the rollback).
4. **`task_submission_abci/rounds.py::TaskPoolingRound.end_block`** — stringify the sort key. Post the ingress fix the sort input is already type-consistent, but a mech resuming with a pre-fix mixed `done_tasks` in shared state at redeploy would still hit the crash on the first pooling round without this cast.
5. **`task_submission_abci/behaviours.py::FundsSplittingBehaviour.remove_tasks`** — normalize both sides to `str` before equality comparison for the same restart-transition reason.

## Tests

- **`test_mixed_int_and_str_request_ids_do_not_crash` (new)** — end-to-end regression guard for the exact crash shape: a `TaskPoolingRound` receiving both `int` and `str` request_ids across agent payloads must not raise `TypeError` and must produce a deterministically-ordered `done_tasks`.
- **`test_signed_requests_balance_scenarios[success]`, `test_200_emits_payment_receipt_header`, `test_200_body_unchanged_for_legacy_clients`, `test_offchain_request_buffered_in_memory_not_in_ipfs_tasks`, `test_signed_requests_rollback_partial_enqueue`, `test_signed_requests_accepts_zero_delivery_rate`** — updated placeholder `request_id` values from non-numeric labels (`"req-1"`, `"req-200-receipt"`, etc.) to decimal strings (`"1"`, `"200"`, etc.). Post the ingress fix, `int("req-1")` raises before the task is enqueued; the placeholders were a shortcut that hid the type mismatch this PR fixes. Assertions updated accordingly: `pend[0]["requestId"] == int(request_id)` on the pending-task side, and the response-body / in-memory-dict side still compares against the original `str` (those code paths use the handler's local `request_id` variable which stays `str`).
- **`_make_task` in `test_rounds.py`** widened from `str` to `Any` so the new mixed-type test can pass both int and str.

## Test plan

- [ ] CI passes (all `common_checks` green locally except `liccheck`, which fails identically on `main` due to cffi 2.1.0's `MIT-0` license — unrelated to this diff, verified via `git stash + rerun`).
- [ ] After merge + a mech tag, mech-predict version bump PR pulls the new skill hashes.
- [ ] After the mech-predict bump ripples into agent-deployments, redeploy a mech that previously crashed (e.g. `mech_mm_predict_clone`) and verify no more `TypeError: '<' not supported...` in the logs when offchain and on-chain traffic overlap.
- [ ] Regression test `test_mixed_int_and_str_request_ids_do_not_crash` locks the crash shape into CI so a future refactor that flips one side back to raw type gets caught pre-merge.

## Rollout notes for the follow-up mech-predict + agent-deployments bumps

- Bump `PROPEL_SERVICE_HASH_ID` on every predict mech in agent-deployments to the new mech-predict service hash.
- The optimism `USE_OFFCHAIN='true'` blocker in `agent-deployments#317`'s caveat (mech returns 503 "offchain path disabled" because `params.use_offchain` is False on the pre-v0.21.13 hash) resolves in the same rippling bump, so optimism-195 can finally accept offchain requests without a separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)