### PR TITLE
feat(offchain): verify request signatures on /send_signed_requests

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigvvwqz2a57f3iz6vnujt5n5fsymfvbuzfbqfowcxj64sm2hy76gm",
-        "skill/valory/task_execution/0.1.0": "bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihtnnjk4qfn3o7dz3cycib3jfvvtkifg2l5vu6yk6tkr4n57hnn4q",
+        "skill/valory/mech_abci/0.1.0": "bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm",
+        "skill/valory/task_execution/0.1.0": "bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiaqacjnhysu4yhm7krhemdl7jz3eju6tm2qgxplpwlzn2rfy66m3m",
-        "service/valory/mech/0.1.0": "bafybeifcuct4nfxqwfnxo7rad3nmje732n4vpiqzonb6k7uxqmejl7z3yi"
+        "agent/valory/mech/0.1.0": "bafybeihvzdx6mlaib4ucfygp7ujg3a37opexdz3vefunedkpqaithaq5py",
+        "service/valory/mech/0.1.0": "bafybeigs2myih7nasouv5z7dikcystgykz4i2njeu57wvczlbmxi2canhy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeibat7achqf2wntzqxd4ebuxexnzik62srrlu452rhejc7zn4owezy",
-        "skill/valory/task_execution/0.1.0": "bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeih5rgsjycdufrkqoo2muxiwpmw63cixvpa6u2wsbdcysjvv6jroua",
+        "skill/valory/mech_abci/0.1.0": "bafybeiaxzhuw3mqjn644dnp3z755bxkyuatppzrsuxkprv7q7gh4ofb7ie",
+        "skill/valory/task_execution/0.1.0": "bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicvk5e6h7ucjrc5jhnv4qhqjucg6abdig6n4waconethh53uksbii",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeifxm255lp5xcjxhxg54wj7t2zqbrmagvmkfhzvgu6hmquxtlsdx3u",
-        "service/valory/mech/0.1.0": "bafybeihod6o6viqi4sahdhmijtdyy2xufueeygukes447yes2yhxci6a3m"
+        "agent/valory/mech/0.1.0": "bafybeidalmknato3fcxehy6kb4ab2alcnwd2gq3geyerwdwipue4rkoyne",
+        "service/valory/mech/0.1.0": "bafybeigi5rqhxun2jplf4e3h66ellwcnggcheskfjebgglq6gxjgo5oar4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiciinn7rkufhauzg6k6l4jzpofaxm37dmpy6qvmrr6qzq6rtmiqfa",
-        "skill/valory/task_execution/0.1.0": "bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiasz7rioybpqadkvd4e6nmxx2pvoeca4h5zdezflr4o5dr5godz7a",
+        "skill/valory/mech_abci/0.1.0": "bafybeigvvwqz2a57f3iz6vnujt5n5fsymfvbuzfbqfowcxj64sm2hy76gm",
+        "skill/valory/task_execution/0.1.0": "bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihtnnjk4qfn3o7dz3cycib3jfvvtkifg2l5vu6yk6tkr4n57hnn4q",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeic5fvvxecyfrrau25zjwmcpqtaa2y65j4esstgiq6s7bge5enacqm",
-        "service/valory/mech/0.1.0": "bafybeiciwdv4jli5c4rjmkfj6u7iwlejixogd66bwlu2rycnte6skggham"
+        "agent/valory/mech/0.1.0": "bafybeiaqacjnhysu4yhm7krhemdl7jz3eju6tm2qgxplpwlzn2rfy66m3m",
+        "service/valory/mech/0.1.0": "bafybeifcuct4nfxqwfnxo7rad3nmje732n4vpiqzonb6k7uxqmejl7z3yi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,14 +7,14 @@
         "contract/valory/hash_checkpoint/0.1.0": "bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m",
         "contract/valory/olas_mech/0.1.0": "bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
-        "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeiaxzhuw3mqjn644dnp3z755bxkyuatppzrsuxkprv7q7gh4ofb7ie",
-        "skill/valory/task_execution/0.1.0": "bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicvk5e6h7ucjrc5jhnv4qhqjucg6abdig6n4waconethh53uksbii",
-        "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidalmknato3fcxehy6kb4ab2alcnwd2gq3geyerwdwipue4rkoyne",
-        "service/valory/mech/0.1.0": "bafybeigi5rqhxun2jplf4e3h66ellwcnggcheskfjebgglq6gxjgo5oar4"
+        "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae",
+        "skill/valory/mech_abci/0.1.0": "bafybeihwqqrahoumb2gzeqno22fskal6ebrejrqf4vpchuwn64sic4mseu",
+        "skill/valory/task_execution/0.1.0": "bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeigvk6vrawvvsswcujciempa6usumogedaeaqc4pjlr3ztfmq5hw7a",
+        "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
+        "agent/valory/mech/0.1.0": "bafybeigulg2nqvc7cbgsb5dmp76xjfyyfqr4f63o77s456t5bvp3rs4b3m",
+        "service/valory/mech/0.1.0": "bafybeihnonypf3sgh7fjmrnklojllzqjd5zdzf63jl6jce4en6lzsehkyq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -34,17 +34,17 @@
         "contract/valory/erc20/0.1.0": "bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq",
         "contract/valory/mech_marketplace/0.1.0": "bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
-        "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
-        "connection/valory/ledger/0.19.0": "bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4",
-        "connection/valory/http_server/0.22.0": "bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle",
+        "connection/valory/p2p_libp2p_client/0.1.0": "bafybeif2pr4vrh2e24enjdymb4ortqkqmvcaq22tlzl5nfccvftomggjiu",
+        "connection/valory/ledger/0.19.0": "bafybeidrfb2ixgsmoy73izeuq43npynkot324iayslipogfulcgshq33iu",
+        "connection/valory/http_server/0.22.0": "bafybeihjuoo45sk6dktxktqgfhyk2t5qsomztmsfzgv3vt3bq7updg3piq",
         "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
         "connection/valory/ipfs/0.1.0": "bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa",
         "connection/valory/kv_store/0.1.0": "bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4",
         "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m",
-        "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
-        "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi"
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m",
+        "skill/valory/registration_abci/0.1.0": "bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga",
+        "skill/valory/termination_abci/0.1.0": "bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigzcbvsznsrsu6n5s3f5piqghuhugz7yvirc3hd6j6gsuaospzgny",
-        "skill/valory/task_execution/0.1.0": "bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiayhuho5dyqqng6vgwtajyu737ambdsgf24for6jgkrvo35wbgfay",
+        "skill/valory/mech_abci/0.1.0": "bafybeielkevbgog6duam5oos2zc3qfc4uepopdmz3mkyh7xixqrpekoxwy",
+        "skill/valory/task_execution/0.1.0": "bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifxsikjyebutrq43jznpo4s2dkpiynwgwry6pr5b2l2wqbezwbdli",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeih3pgsgtek6igk7cb5fwerfiaepbr5pahnugspga6fdoilzlwixmy",
-        "service/valory/mech/0.1.0": "bafybeihacj5qsp7rup5dlmswl7x4s7i6lytnh6ffkyb4rwpnqux5rlcdwq"
+        "agent/valory/mech/0.1.0": "bafybeifq55zy72ewlhlqqvqpswuu2splzswy47wyilfnsq2t4yzxw4vxae",
+        "service/valory/mech/0.1.0": "bafybeiattpmp3csofmk74fzzaebhnkhke37f5etwbdego44canyatrbq4u"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeielkevbgog6duam5oos2zc3qfc4uepopdmz3mkyh7xixqrpekoxwy",
-        "skill/valory/task_execution/0.1.0": "bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifxsikjyebutrq43jznpo4s2dkpiynwgwry6pr5b2l2wqbezwbdli",
+        "skill/valory/mech_abci/0.1.0": "bafybeif4v5ah7kmxqzv7ou7327uwbjw5j74ayfxfgv6mjquvnjpynjhqqm",
+        "skill/valory/task_execution/0.1.0": "bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidz3nidtvdbk67fn3epxcottuwfycund3tiwkyba6eqshdkbjefmu",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeifq55zy72ewlhlqqvqpswuu2splzswy47wyilfnsq2t4yzxw4vxae",
-        "service/valory/mech/0.1.0": "bafybeiattpmp3csofmk74fzzaebhnkhke37f5etwbdego44canyatrbq4u"
+        "agent/valory/mech/0.1.0": "bafybeicgn2xqktxfmsvpyr72cebvnaa3ycaf55vuky5bshoco4rocvgtoq",
+        "service/valory/mech/0.1.0": "bafybeie7q4ul4cfrvsn5eowk5gknlohoma7wx4ypiffgwno2v3gwmdlbqe"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiheabhgqfwze7nolgnrl7oam3iqzim7wtsly4tz6pgxejrprk4uvm",
-        "skill/valory/task_execution/0.1.0": "bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiclu2huy25ghuemnbpua6ut5b5opsc4o3c5jdqbuqkruabsqfdfhe",
+        "skill/valory/mech_abci/0.1.0": "bafybeiciinn7rkufhauzg6k6l4jzpofaxm37dmpy6qvmrr6qzq6rtmiqfa",
+        "skill/valory/task_execution/0.1.0": "bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiasz7rioybpqadkvd4e6nmxx2pvoeca4h5zdezflr4o5dr5godz7a",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihnnyvwtjofuyge6dcbrkt5qsmeinv3zjx4fm24lxap2brvaht6ha",
-        "service/valory/mech/0.1.0": "bafybeiapxm5ltznhj7boxylqjusd5svndwkqx2ysq5dmbwsyyjpqbr3hby"
+        "agent/valory/mech/0.1.0": "bafybeic5fvvxecyfrrau25zjwmcpqtaa2y65j4esstgiq6s7bge5enacqm",
+        "service/valory/mech/0.1.0": "bafybeiciwdv4jli5c4rjmkfj6u7iwlejixogd66bwlu2rycnte6skggham"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeicvzbdfpacpgbpvdel7ox2omfidnmy3seiqdxdynb5pbuicy4mu2q",
-        "skill/valory/task_execution/0.1.0": "bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiehmrgd5umd22g56jsdk3gxayd6myx6ufhj6jkl5j2ajvhlkaoycu",
+        "skill/valory/mech_abci/0.1.0": "bafybeieupxvuzovrjyfpackkncfgmgw4a73mstnwmrfpp4tax6n2775d2q",
+        "skill/valory/task_execution/0.1.0": "bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiff6a6p2swb7e6m6nmhn5mn4m5a76knnsnzgdaakcbo3j36mcunau",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeidwjrlxrsbfoosr6zuvgm22fyy5vcltrviz6ijmw6in2e4cbg6zjq",
-        "service/valory/mech/0.1.0": "bafybeigjqbs64n2jf5ocd6fdixune7vwvfdi5ino7bvkqnxoxfzewsur6q"
+        "agent/valory/mech/0.1.0": "bafybeiaqa7kuubtrjjpbby3exsy3yedbxkqh3zvzhw5uuoohbvtxdrsdvu",
+        "service/valory/mech/0.1.0": "bafybeibg3s3dp3kuzbln4apphvajs4vabebnbmm52qhepe7tjzdejpai4m"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeidwew2zu3gw3vsm3qz7av7gxcqxgnpx5skadzmczcbpr3cjvfvpym",
-        "skill/valory/task_execution/0.1.0": "bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidvjxawskjuu43bzju2mobjgll3jzkdebmy7xhdfr644dtud7bkoa",
+        "skill/valory/mech_abci/0.1.0": "bafybeiheabhgqfwze7nolgnrl7oam3iqzim7wtsly4tz6pgxejrprk4uvm",
+        "skill/valory/task_execution/0.1.0": "bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiclu2huy25ghuemnbpua6ut5b5opsc4o3c5jdqbuqkruabsqfdfhe",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeigqaxmov5hcqoltqpoectabf3tbr3bltqwjasp352msbb7nrd4kku",
-        "service/valory/mech/0.1.0": "bafybeigr562ngb5sjip2bqlw7jaxwbzuzn2etlj2idqdsqigctcrxtebpm"
+        "agent/valory/mech/0.1.0": "bafybeihnnyvwtjofuyge6dcbrkt5qsmeinv3zjx4fm24lxap2brvaht6ha",
+        "service/valory/mech/0.1.0": "bafybeiapxm5ltznhj7boxylqjusd5svndwkqx2ysq5dmbwsyyjpqbr3hby"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,13 +8,13 @@
         "contract/valory/olas_mech/0.1.0": "bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
-        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae",
-        "skill/valory/mech_abci/0.1.0": "bafybeiafgped7muki75dci6yzg2xpwks4a3izupctr6hhb5vd5l6zprikm",
-        "skill/valory/task_execution/0.1.0": "bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihmvdk4wxzbwoehztin7zosiqykq6egyc4eixnfbyvfv4hfnru3de",
+        "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
+        "skill/valory/mech_abci/0.1.0": "bafybeigzcbvsznsrsu6n5s3f5piqghuhugz7yvirc3hd6j6gsuaospzgny",
+        "skill/valory/task_execution/0.1.0": "bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiayhuho5dyqqng6vgwtajyu737ambdsgf24for6jgkrvo35wbgfay",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiflb4kh7l7y4myia5zkw2jvetu53vamknrythw5x3deucyn7vnr5e",
-        "service/valory/mech/0.1.0": "bafybeieaa7vjn247hxkhfv6b4z4fbvbzf3wtuvefigummqhuuyiwz3fupa"
+        "agent/valory/mech/0.1.0": "bafybeih3pgsgtek6igk7cb5fwerfiaepbr5pahnugspga6fdoilzlwixmy",
+        "service/valory/mech/0.1.0": "bafybeihacj5qsp7rup5dlmswl7x4s7i6lytnh6ffkyb4rwpnqux5rlcdwq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -34,17 +34,17 @@
         "contract/valory/erc20/0.1.0": "bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq",
         "contract/valory/mech_marketplace/0.1.0": "bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
-        "connection/valory/p2p_libp2p_client/0.1.0": "bafybeif2pr4vrh2e24enjdymb4ortqkqmvcaq22tlzl5nfccvftomggjiu",
-        "connection/valory/ledger/0.19.0": "bafybeidrfb2ixgsmoy73izeuq43npynkot324iayslipogfulcgshq33iu",
-        "connection/valory/http_server/0.22.0": "bafybeihjuoo45sk6dktxktqgfhyk2t5qsomztmsfzgv3vt3bq7updg3piq",
+        "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
+        "connection/valory/ledger/0.19.0": "bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4",
+        "connection/valory/http_server/0.22.0": "bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle",
         "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
         "connection/valory/ipfs/0.1.0": "bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa",
         "connection/valory/kv_store/0.1.0": "bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4",
         "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m",
-        "skill/valory/registration_abci/0.1.0": "bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga",
-        "skill/valory/termination_abci/0.1.0": "bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi"
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m",
+        "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
+        "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae",
-        "skill/valory/mech_abci/0.1.0": "bafybeihwqqrahoumb2gzeqno22fskal6ebrejrqf4vpchuwn64sic4mseu",
-        "skill/valory/task_execution/0.1.0": "bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeigvk6vrawvvsswcujciempa6usumogedaeaqc4pjlr3ztfmq5hw7a",
+        "skill/valory/mech_abci/0.1.0": "bafybeiafgped7muki75dci6yzg2xpwks4a3izupctr6hhb5vd5l6zprikm",
+        "skill/valory/task_execution/0.1.0": "bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihmvdk4wxzbwoehztin7zosiqykq6egyc4eixnfbyvfv4hfnru3de",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeigulg2nqvc7cbgsb5dmp76xjfyyfqr4f63o77s456t5bvp3rs4b3m",
-        "service/valory/mech/0.1.0": "bafybeihnonypf3sgh7fjmrnklojllzqjd5zdzf63jl6jce4en6lzsehkyq"
+        "agent/valory/mech/0.1.0": "bafybeiflb4kh7l7y4myia5zkw2jvetu53vamknrythw5x3deucyn7vnr5e",
+        "service/valory/mech/0.1.0": "bafybeieaa7vjn247hxkhfv6b4z4fbvbzf3wtuvefigummqhuuyiwz3fupa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeif4v5ah7kmxqzv7ou7327uwbjw5j74ayfxfgv6mjquvnjpynjhqqm",
-        "skill/valory/task_execution/0.1.0": "bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidz3nidtvdbk67fn3epxcottuwfycund3tiwkyba6eqshdkbjefmu",
+        "skill/valory/mech_abci/0.1.0": "bafybeidwew2zu3gw3vsm3qz7av7gxcqxgnpx5skadzmczcbpr3cjvfvpym",
+        "skill/valory/task_execution/0.1.0": "bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidvjxawskjuu43bzju2mobjgll3jzkdebmy7xhdfr644dtud7bkoa",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeicgn2xqktxfmsvpyr72cebvnaa3ycaf55vuky5bshoco4rocvgtoq",
-        "service/valory/mech/0.1.0": "bafybeie7q4ul4cfrvsn5eowk5gknlohoma7wx4ypiffgwno2v3gwmdlbqe"
+        "agent/valory/mech/0.1.0": "bafybeigqaxmov5hcqoltqpoectabf3tbr3bltqwjasp352msbb7nrd4kku",
+        "service/valory/mech/0.1.0": "bafybeigr562ngb5sjip2bqlw7jaxwbzuzn2etlj2idqdsqigctcrxtebpm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeieupxvuzovrjyfpackkncfgmgw4a73mstnwmrfpp4tax6n2775d2q",
-        "skill/valory/task_execution/0.1.0": "bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiff6a6p2swb7e6m6nmhn5mn4m5a76knnsnzgdaakcbo3j36mcunau",
+        "skill/valory/mech_abci/0.1.0": "bafybeibat7achqf2wntzqxd4ebuxexnzik62srrlu452rhejc7zn4owezy",
+        "skill/valory/task_execution/0.1.0": "bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeih5rgsjycdufrkqoo2muxiwpmw63cixvpa6u2wsbdcysjvv6jroua",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeiaqa7kuubtrjjpbby3exsy3yedbxkqh3zvzhw5uuoohbvtxdrsdvu",
-        "service/valory/mech/0.1.0": "bafybeibg3s3dp3kuzbln4apphvajs4vabebnbmm52qhepe7tjzdejpai4m"
+        "agent/valory/mech/0.1.0": "bafybeifxm255lp5xcjxhxg54wj7t2zqbrmagvmkfhzvgu6hmquxtlsdx3u",
+        "service/valory/mech/0.1.0": "bafybeihod6o6viqi4sahdhmijtdyy2xufueeygukes447yes2yhxci6a3m"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma",
-        "skill/valory/task_execution/0.1.0": "bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a",
+        "skill/valory/mech_abci/0.1.0": "bafybeibxp5brwt5zlxnmpdmzouusvzwr44kirb4i74j7s3aw5vzlxf4ac4",
+        "skill/valory/task_execution/0.1.0": "bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicigscuv6gdsw5v54cc63qkhtho3236seiqibylg37cielufagrfe",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeic6bbexqkfh65skvagele4drkys4w3vg4l4ymtdocbafwdsgxiiga",
-        "service/valory/mech/0.1.0": "bafybeibytetwgjgnd5npgrwmfo3ydu2icthuiu2otqjvhczv6xlkyo7yz4"
+        "agent/valory/mech/0.1.0": "bafybeicel3x56aql6ni3xanmx6yvurvb6hqt4yxq7xgbbx7n35sae7kpje",
+        "service/valory/mech/0.1.0": "bafybeihrxhnfa2swdxzp2pjzh6sawnd447b7haf22v7vnvfi43x2vy77xq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeibxp5brwt5zlxnmpdmzouusvzwr44kirb4i74j7s3aw5vzlxf4ac4",
-        "skill/valory/task_execution/0.1.0": "bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicigscuv6gdsw5v54cc63qkhtho3236seiqibylg37cielufagrfe",
+        "skill/valory/mech_abci/0.1.0": "bafybeicvzbdfpacpgbpvdel7ox2omfidnmy3seiqdxdynb5pbuicy4mu2q",
+        "skill/valory/task_execution/0.1.0": "bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiehmrgd5umd22g56jsdk3gxayd6myx6ufhj6jkl5j2ajvhlkaoycu",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
-        "agent/valory/mech/0.1.0": "bafybeicel3x56aql6ni3xanmx6yvurvb6hqt4yxq7xgbbx7n35sae7kpje",
-        "service/valory/mech/0.1.0": "bafybeihrxhnfa2swdxzp2pjzh6sawnd447b7haf22v7vnvfi43x2vy77xq"
+        "agent/valory/mech/0.1.0": "bafybeidwjrlxrsbfoosr6zuvgm22fyy5vcltrviz6ijmw6in2e4cbg6zjq",
+        "service/valory/mech/0.1.0": "bafybeigjqbs64n2jf5ocd6fdixune7vwvfdi5ino7bvkqnxoxfzewsur6q"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma
+- valory/mech_abci:0.1.0:bafybeibxp5brwt5zlxnmpdmzouusvzwr44kirb4i74j7s3aw5vzlxf4ac4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
-- valory/task_submission_abci:0.1.0:bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a
+- valory/task_execution:0.1.0:bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq
+- valory/task_submission_abci:0.1.0:bafybeicigscuv6gdsw5v54cc63qkhtho3236seiqibylg37cielufagrfe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeibxp5brwt5zlxnmpdmzouusvzwr44kirb4i74j7s3aw5vzlxf4ac4
+- valory/mech_abci:0.1.0:bafybeicvzbdfpacpgbpvdel7ox2omfidnmy3seiqdxdynb5pbuicy4mu2q
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq
-- valory/task_submission_abci:0.1.0:bafybeicigscuv6gdsw5v54cc63qkhtho3236seiqibylg37cielufagrfe
+- valory/task_execution:0.1.0:bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm
+- valory/task_submission_abci:0.1.0:bafybeiehmrgd5umd22g56jsdk3gxayd6myx6ufhj6jkl5j2ajvhlkaoycu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae
-- valory/mech_abci:0.1.0:bafybeihwqqrahoumb2gzeqno22fskal6ebrejrqf4vpchuwn64sic4mseu
+- valory/mech_abci:0.1.0:bafybeiafgped7muki75dci6yzg2xpwks4a3izupctr6hhb5vd5l6zprikm
 - valory/registration_abci:0.1.0:bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e
 - valory/reset_pause_abci:0.1.0:bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga
-- valory/task_execution:0.1.0:bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq
-- valory/task_submission_abci:0.1.0:bafybeigvk6vrawvvsswcujciempa6usumogedaeaqc4pjlr3ztfmq5hw7a
+- valory/task_execution:0.1.0:bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi
+- valory/task_submission_abci:0.1.0:bafybeihmvdk4wxzbwoehztin7zosiqykq6egyc4eixnfbyvfv4hfnru3de
 - valory/termination_abci:0.1.0:bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi
 - valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicvzbdfpacpgbpvdel7ox2omfidnmy3seiqdxdynb5pbuicy4mu2q
+- valory/mech_abci:0.1.0:bafybeieupxvuzovrjyfpackkncfgmgw4a73mstnwmrfpp4tax6n2775d2q
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm
-- valory/task_submission_abci:0.1.0:bafybeiehmrgd5umd22g56jsdk3gxayd6myx6ufhj6jkl5j2ajvhlkaoycu
+- valory/task_execution:0.1.0:bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m
+- valory/task_submission_abci:0.1.0:bafybeiff6a6p2swb7e6m6nmhn5mn4m5a76knnsnzgdaakcbo3j36mcunau
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -9,22 +9,22 @@ fingerprint_ignore_patterns: []
 connections:
 - valory/abci:0.1.0:bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi
 - valory/http_client:0.23.0:bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4
-- valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
+- valory/http_server:0.22.0:bafybeihjuoo45sk6dktxktqgfhyk2t5qsomztmsfzgv3vt3bq7updg3piq
 - valory/ipfs:0.1.0:bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa
-- valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
-- valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
+- valory/ledger:0.19.0:bafybeidrfb2ixgsmoy73izeuq43npynkot324iayslipogfulcgshq33iu
+- valory/p2p_libp2p_client:0.1.0:bafybeif2pr4vrh2e24enjdymb4ortqkqmvcaq22tlzl5nfccvftomggjiu
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea
 contracts:
-- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
+- valory/balance_tracker:0.1.0:bafybeiayyxl643qfpw57vopytxgyd6flxxmwassswuxen7myekqaxdxxvi
 - valory/complementary_service_metadata:0.1.0:bafybeihukaditdbnvhkxnt2bfqtclfnniw6l2dwks4dx3hhzlvt46ilduq
+- valory/erc20:0.1.0:bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq
 - valory/gnosis_safe:0.1.0:bafybeiek7zs3r5c4wspwwuvnhunc2ddvccbsuy3xccedbjffju5eywp3ju
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeigr6ugkp6bxwnbkecktotekcjihabb6eudh3bgcnjfdorwosygile
 - valory/hash_checkpoint:0.1.0:bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m
-- valory/multisend:0.1.0:bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi
-- valory/service_registry:0.1.0:bafybeicbfffywnaaehptzasxsdoyguuurpleirsnor5xf7rqk57isjkury
 - valory/mech_marketplace:0.1.0:bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu
-- valory/balance_tracker:0.1.0:bafybeiayyxl643qfpw57vopytxgyd6flxxmwassswuxen7myekqaxdxxvi
-- valory/erc20:0.1.0:bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq
+- valory/multisend:0.1.0:bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi
+- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
+- valory/service_registry:0.1.0:bafybeicbfffywnaaehptzasxsdoyguuurpleirsnor5xf7rqk57isjkury
 protocols:
 - open_aea/signing:1.0.0:bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye
 - valory/abci:0.1.0:bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte
@@ -38,17 +38,17 @@ protocols:
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
 skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
-- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeiaxzhuw3mqjn644dnp3z755bxkyuatppzrsuxkprv7q7gh4ofb7ie
-- valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
-- valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu
-- valory/task_submission_abci:0.1.0:bafybeicvk5e6h7ucjrc5jhnv4qhqjucg6abdig6n4waconethh53uksbii
-- valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
+- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
+- valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
+- valory/delivery_rate_abci:0.1.0:bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae
+- valory/mech_abci:0.1.0:bafybeihwqqrahoumb2gzeqno22fskal6ebrejrqf4vpchuwn64sic4mseu
+- valory/registration_abci:0.1.0:bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e
+- valory/reset_pause_abci:0.1.0:bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga
+- valory/task_execution:0.1.0:bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq
+- valory/task_submission_abci:0.1.0:bafybeigvk6vrawvvsswcujciempa6usumogedaeaqc4pjlr3ztfmq5hw7a
+- valory/termination_abci:0.1.0:bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi
+- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
+- valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -79,6 +79,8 @@ logging_config:
       - console
       propagate: true
 dependencies:
+  PyYAML:
+    version: '>=6'
   aiohttp:
     version: <4.0.0,>=3.8.5
   asn1crypto:
@@ -115,8 +117,6 @@ dependencies:
     version: <10,>=8.2
   pytest-asyncio:
     version: '>=1.3'
-  PyYAML:
-    version: '>=6'
   requests:
     version: '>=2.32.5'
   web3:

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeif4v5ah7kmxqzv7ou7327uwbjw5j74ayfxfgv6mjquvnjpynjhqqm
+- valory/mech_abci:0.1.0:bafybeidwew2zu3gw3vsm3qz7av7gxcqxgnpx5skadzmczcbpr3cjvfvpym
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq
-- valory/task_submission_abci:0.1.0:bafybeidz3nidtvdbk67fn3epxcottuwfycund3tiwkyba6eqshdkbjefmu
+- valory/task_execution:0.1.0:bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi
+- valory/task_submission_abci:0.1.0:bafybeidvjxawskjuu43bzju2mobjgll3jzkdebmy7xhdfr644dtud7bkoa
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -9,10 +9,10 @@ fingerprint_ignore_patterns: []
 connections:
 - valory/abci:0.1.0:bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi
 - valory/http_client:0.23.0:bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4
-- valory/http_server:0.22.0:bafybeihjuoo45sk6dktxktqgfhyk2t5qsomztmsfzgv3vt3bq7updg3piq
+- valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
 - valory/ipfs:0.1.0:bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa
-- valory/ledger:0.19.0:bafybeidrfb2ixgsmoy73izeuq43npynkot324iayslipogfulcgshq33iu
-- valory/p2p_libp2p_client:0.1.0:bafybeif2pr4vrh2e24enjdymb4ortqkqmvcaq22tlzl5nfccvftomggjiu
+- valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
+- valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea
 contracts:
 - valory/balance_tracker:0.1.0:bafybeiayyxl643qfpw57vopytxgyd6flxxmwassswuxen7myekqaxdxxvi
@@ -38,16 +38,16 @@ protocols:
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
 skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
-- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
+- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
-- valory/delivery_rate_abci:0.1.0:bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae
-- valory/mech_abci:0.1.0:bafybeiafgped7muki75dci6yzg2xpwks4a3izupctr6hhb5vd5l6zprikm
-- valory/registration_abci:0.1.0:bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e
-- valory/reset_pause_abci:0.1.0:bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga
-- valory/task_execution:0.1.0:bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi
-- valory/task_submission_abci:0.1.0:bafybeihmvdk4wxzbwoehztin7zosiqykq6egyc4eixnfbyvfv4hfnru3de
-- valory/termination_abci:0.1.0:bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi
-- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
+- valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
+- valory/mech_abci:0.1.0:bafybeigzcbvsznsrsu6n5s3f5piqghuhugz7yvirc3hd6j6gsuaospzgny
+- valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
+- valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
+- valory/task_execution:0.1.0:bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly
+- valory/task_submission_abci:0.1.0:bafybeiayhuho5dyqqng6vgwtajyu737ambdsgf24for6jgkrvo35wbgfay
+- valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
+- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeieupxvuzovrjyfpackkncfgmgw4a73mstnwmrfpp4tax6n2775d2q
+- valory/mech_abci:0.1.0:bafybeibat7achqf2wntzqxd4ebuxexnzik62srrlu452rhejc7zn4owezy
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m
-- valory/task_submission_abci:0.1.0:bafybeiff6a6p2swb7e6m6nmhn5mn4m5a76knnsnzgdaakcbo3j36mcunau
+- valory/task_execution:0.1.0:bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm
+- valory/task_submission_abci:0.1.0:bafybeih5rgsjycdufrkqoo2muxiwpmw63cixvpa6u2wsbdcysjvv6jroua
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeidwew2zu3gw3vsm3qz7av7gxcqxgnpx5skadzmczcbpr3cjvfvpym
+- valory/mech_abci:0.1.0:bafybeiheabhgqfwze7nolgnrl7oam3iqzim7wtsly4tz6pgxejrprk4uvm
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi
-- valory/task_submission_abci:0.1.0:bafybeidvjxawskjuu43bzju2mobjgll3jzkdebmy7xhdfr644dtud7bkoa
+- valory/task_execution:0.1.0:bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise
+- valory/task_submission_abci:0.1.0:bafybeiclu2huy25ghuemnbpua6ut5b5opsc4o3c5jdqbuqkruabsqfdfhe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeibat7achqf2wntzqxd4ebuxexnzik62srrlu452rhejc7zn4owezy
+- valory/mech_abci:0.1.0:bafybeiaxzhuw3mqjn644dnp3z755bxkyuatppzrsuxkprv7q7gh4ofb7ie
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm
-- valory/task_submission_abci:0.1.0:bafybeih5rgsjycdufrkqoo2muxiwpmw63cixvpa6u2wsbdcysjvv6jroua
+- valory/task_execution:0.1.0:bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu
+- valory/task_submission_abci:0.1.0:bafybeicvk5e6h7ucjrc5jhnv4qhqjucg6abdig6n4waconethh53uksbii
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeigvvwqz2a57f3iz6vnujt5n5fsymfvbuzfbqfowcxj64sm2hy76gm
+- valory/mech_abci:0.1.0:bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai
-- valory/task_submission_abci:0.1.0:bafybeihtnnjk4qfn3o7dz3cycib3jfvvtkifg2l5vu6yk6tkr4n57hnn4q
+- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
+- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiciinn7rkufhauzg6k6l4jzpofaxm37dmpy6qvmrr6qzq6rtmiqfa
+- valory/mech_abci:0.1.0:bafybeigvvwqz2a57f3iz6vnujt5n5fsymfvbuzfbqfowcxj64sm2hy76gm
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy
-- valory/task_submission_abci:0.1.0:bafybeiasz7rioybpqadkvd4e6nmxx2pvoeca4h5zdezflr4o5dr5godz7a
+- valory/task_execution:0.1.0:bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai
+- valory/task_submission_abci:0.1.0:bafybeihtnnjk4qfn3o7dz3cycib3jfvvtkifg2l5vu6yk6tkr4n57hnn4q
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeielkevbgog6duam5oos2zc3qfc4uepopdmz3mkyh7xixqrpekoxwy
+- valory/mech_abci:0.1.0:bafybeif4v5ah7kmxqzv7ou7327uwbjw5j74ayfxfgv6mjquvnjpynjhqqm
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu
-- valory/task_submission_abci:0.1.0:bafybeifxsikjyebutrq43jznpo4s2dkpiynwgwry6pr5b2l2wqbezwbdli
+- valory/task_execution:0.1.0:bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq
+- valory/task_submission_abci:0.1.0:bafybeidz3nidtvdbk67fn3epxcottuwfycund3tiwkyba6eqshdkbjefmu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeigzcbvsznsrsu6n5s3f5piqghuhugz7yvirc3hd6j6gsuaospzgny
+- valory/mech_abci:0.1.0:bafybeielkevbgog6duam5oos2zc3qfc4uepopdmz3mkyh7xixqrpekoxwy
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly
-- valory/task_submission_abci:0.1.0:bafybeiayhuho5dyqqng6vgwtajyu737ambdsgf24for6jgkrvo35wbgfay
+- valory/task_execution:0.1.0:bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu
+- valory/task_submission_abci:0.1.0:bafybeifxsikjyebutrq43jznpo4s2dkpiynwgwry6pr5b2l2wqbezwbdli
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiheabhgqfwze7nolgnrl7oam3iqzim7wtsly4tz6pgxejrprk4uvm
+- valory/mech_abci:0.1.0:bafybeiciinn7rkufhauzg6k6l4jzpofaxm37dmpy6qvmrr6qzq6rtmiqfa
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise
-- valory/task_submission_abci:0.1.0:bafybeiclu2huy25ghuemnbpua6ut5b5opsc4o3c5jdqbuqkruabsqfdfhe
+- valory/task_execution:0.1.0:bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy
+- valory/task_submission_abci:0.1.0:bafybeiasz7rioybpqadkvd4e6nmxx2pvoeca4h5zdezflr4o5dr5godz7a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidwjrlxrsbfoosr6zuvgm22fyy5vcltrviz6ijmw6in2e4cbg6zjq
+agent: valory/mech:0.1.0:bafybeiaqa7kuubtrjjpbby3exsy3yedbxkqh3zvzhw5uuoohbvtxdrsdvu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeic6bbexqkfh65skvagele4drkys4w3vg4l4ymtdocbafwdsgxiiga
+agent: valory/mech:0.1.0:bafybeicel3x56aql6ni3xanmx6yvurvb6hqt4yxq7xgbbx7n35sae7kpje
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigulg2nqvc7cbgsb5dmp76xjfyyfqr4f63o77s456t5bvp3rs4b3m
+agent: valory/mech:0.1.0:bafybeiflb4kh7l7y4myia5zkw2jvetu53vamknrythw5x3deucyn7vnr5e
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeih3pgsgtek6igk7cb5fwerfiaepbr5pahnugspga6fdoilzlwixmy
+agent: valory/mech:0.1.0:bafybeifq55zy72ewlhlqqvqpswuu2splzswy47wyilfnsq2t4yzxw4vxae
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeifxm255lp5xcjxhxg54wj7t2zqbrmagvmkfhzvgu6hmquxtlsdx3u
+agent: valory/mech:0.1.0:bafybeidalmknato3fcxehy6kb4ab2alcnwd2gq3geyerwdwipue4rkoyne
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeicgn2xqktxfmsvpyr72cebvnaa3ycaf55vuky5bshoco4rocvgtoq
+agent: valory/mech:0.1.0:bafybeigqaxmov5hcqoltqpoectabf3tbr3bltqwjasp352msbb7nrd4kku
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeic5fvvxecyfrrau25zjwmcpqtaa2y65j4esstgiq6s7bge5enacqm
+agent: valory/mech:0.1.0:bafybeiaqacjnhysu4yhm7krhemdl7jz3eju6tm2qgxplpwlzn2rfy66m3m
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiaqacjnhysu4yhm7krhemdl7jz3eju6tm2qgxplpwlzn2rfy66m3m
+agent: valory/mech:0.1.0:bafybeihvzdx6mlaib4ucfygp7ujg3a37opexdz3vefunedkpqaithaq5py
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihnnyvwtjofuyge6dcbrkt5qsmeinv3zjx4fm24lxap2brvaht6ha
+agent: valory/mech:0.1.0:bafybeic5fvvxecyfrrau25zjwmcpqtaa2y65j4esstgiq6s7bge5enacqm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeicel3x56aql6ni3xanmx6yvurvb6hqt4yxq7xgbbx7n35sae7kpje
+agent: valory/mech:0.1.0:bafybeidwjrlxrsbfoosr6zuvgm22fyy5vcltrviz6ijmw6in2e4cbg6zjq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigqaxmov5hcqoltqpoectabf3tbr3bltqwjasp352msbb7nrd4kku
+agent: valory/mech:0.1.0:bafybeihnnyvwtjofuyge6dcbrkt5qsmeinv3zjx4fm24lxap2brvaht6ha
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiaqa7kuubtrjjpbby3exsy3yedbxkqh3zvzhw5uuoohbvtxdrsdvu
+agent: valory/mech:0.1.0:bafybeifxm255lp5xcjxhxg54wj7t2zqbrmagvmkfhzvgu6hmquxtlsdx3u
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidalmknato3fcxehy6kb4ab2alcnwd2gq3geyerwdwipue4rkoyne
+agent: valory/mech:0.1.0:bafybeigulg2nqvc7cbgsb5dmp76xjfyyfqr4f63o77s456t5bvp3rs4b3m
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeifq55zy72ewlhlqqvqpswuu2splzswy47wyilfnsq2t4yzxw4vxae
+agent: valory/mech:0.1.0:bafybeicgn2xqktxfmsvpyr72cebvnaa3ycaf55vuky5bshoco4rocvgtoq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiflb4kh7l7y4myia5zkw2jvetu53vamknrythw5x3deucyn7vnr5e
+agent: valory/mech:0.1.0:bafybeih3pgsgtek6igk7cb5fwerfiaepbr5pahnugspga6fdoilzlwixmy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/contract_subscription/skill.yaml
+++ b/packages/valory/skills/contract_subscription/skill.yaml
@@ -19,7 +19,7 @@ contracts: []
 protocols:
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
 skills:
-- valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
+- valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m
 behaviours:
   contract_subscriptions:
     args: {}
@@ -31,17 +31,18 @@ handlers:
       websocket_provider: https://rpc.gnosischain.com
     class_name: WebSocketHandler
 models:
+  params:
+    args:
+      contract_address: '0xFf82123dFB52ab75C417195c5fDB87630145ae81'
+      subscription_id: mech-contract-subscription
+      use_polling: false
+      websocket_provider: ws://localhost:8001
+    class_name: Params
   websocket_client_dialogues:
     args: {}
     class_name: WebsocketClientDialogues
-  params:
-    args:
-      use_polling: false
-      websocket_provider: ws://localhost:8001
-      contract_address: '0xFf82123dFB52ab75C417195c5fDB87630145ae81'
-      subscription_id: mech-contract-subscription
-    class_name: Params
 dependencies:
   web3:
     version: <8,>=7.15.0
 is_abstract: false
+customs: []

--- a/packages/valory/skills/delivery_rate_abci/skill.yaml
+++ b/packages/valory/skills/delivery_rate_abci/skill.yaml
@@ -27,8 +27,8 @@ protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
-- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
+- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
+- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/delivery_rate_abci/skill.yaml
+++ b/packages/valory/skills/delivery_rate_abci/skill.yaml
@@ -20,15 +20,15 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
 - valory/gnosis_safe:0.1.0:bafybeiek7zs3r5c4wspwwuvnhunc2ddvccbsuy3xccedbjffju5eywp3ju
 - valory/multisend:0.1.0:bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi
+- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
 protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
+- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
+- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
 behaviours:
   main:
     args: {}
@@ -81,6 +81,7 @@ models:
   params:
     args:
       cleanup_history_depth_current: null
+      default_chain_id: gnosis
       drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
       finalize_timeout: 60.0
       genesis_config:
@@ -105,9 +106,13 @@ models:
       ipfs_fetch_timeout: 15.0
       keeper_allowed_retries: 3
       keeper_timeout: 30.0
+      light_slash_unit_amount: 5000000000000000
+      manual_gas_limit: 1000000
       max_attempts: 10
       max_healthcheck: 120
+      mech_to_max_delivery_rate: {}
       on_chain_service_id: null
+      profit_split_balance: 1000
       request_retry_delay: 1.0
       request_timeout: 10.0
       reset_pause_duration: 10
@@ -115,7 +120,10 @@ models:
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 30.0
+      serious_slash_unit_amount: 8000000000000000
+      service_endpoint_base: https://dummy_service.autonolas.tech/
       service_id: task_execution
+      service_owner_share: 1000
       service_registry_address: null
       setup:
         all_participants:
@@ -123,6 +131,8 @@ models:
         consensus_threshold: null
         safe_contract_address: '0x0000000000000000000000000000000000000000'
       share_tm_config_on_startup: false
+      slash_cooldown_hours: 3
+      slash_threshold_amount: 10000000000000000
       sleep_time: 1
       task_wait_timeout: 15
       tendermint_check_sleep_delay: 3
@@ -131,19 +141,9 @@ models:
       tendermint_p2p_url: localhost:26656
       tendermint_url: http://localhost:26657
       tx_timeout: 10.0
-      use_termination: false
-      manual_gas_limit: 1000000
-      validate_timeout: 1205
       use_slashing: false
-      service_owner_share: 1000
-      profit_split_balance: 1000
-      slash_cooldown_hours: 3
-      slash_threshold_amount: 10000000000000000
-      light_slash_unit_amount: 5000000000000000
-      serious_slash_unit_amount: 8000000000000000
-      mech_to_max_delivery_rate: {}
-      service_endpoint_base: https://dummy_service.autonolas.tech/
-      default_chain_id: gnosis
+      use_termination: false
+      validate_timeout: 1205
     class_name: Params
   requests:
     args: {}
@@ -159,3 +159,4 @@ models:
     class_name: TendermintDialogues
 dependencies: {}
 is_abstract: true
+customs: []

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu
-- valory/task_submission_abci:0.1.0:bafybeifxsikjyebutrq43jznpo4s2dkpiynwgwry6pr5b2l2wqbezwbdli
+- valory/task_execution:0.1.0:bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq
+- valory/task_submission_abci:0.1.0:bafybeidz3nidtvdbk67fn3epxcottuwfycund3tiwkyba6eqshdkbjefmu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai
-- valory/task_submission_abci:0.1.0:bafybeihtnnjk4qfn3o7dz3cycib3jfvvtkifg2l5vu6yk6tkr4n57hnn4q
+- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
+- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae
 - valory/registration_abci:0.1.0:bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e
 - valory/reset_pause_abci:0.1.0:bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga
-- valory/task_execution:0.1.0:bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq
-- valory/task_submission_abci:0.1.0:bafybeigvk6vrawvvsswcujciempa6usumogedaeaqc4pjlr3ztfmq5hw7a
+- valory/task_execution:0.1.0:bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi
+- valory/task_submission_abci:0.1.0:bafybeihmvdk4wxzbwoehztin7zosiqykq6egyc4eixnfbyvfv4hfnru3de
 - valory/termination_abci:0.1.0:bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi
 - valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiehmrgd5umd22g56jsdk3gxayd6myx6ufhj6jkl5j2ajvhlkaoycu
+- valory/task_submission_abci:0.1.0:bafybeiff6a6p2swb7e6m6nmhn5mn4m5a76knnsnzgdaakcbo3j36mcunau
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm
+- valory/task_execution:0.1.0:bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi
-- valory/task_submission_abci:0.1.0:bafybeidvjxawskjuu43bzju2mobjgll3jzkdebmy7xhdfr644dtud7bkoa
+- valory/task_execution:0.1.0:bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise
+- valory/task_submission_abci:0.1.0:bafybeiclu2huy25ghuemnbpua6ut5b5opsc4o3c5jdqbuqkruabsqfdfhe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -22,19 +22,19 @@ fingerprint:
   tests/test_models.py: bafybeif4iuuknrtx3tc72y2ii237dqtl6nlqgpdywy227sfqbvxkk6mugy
 fingerprint_ignore_patterns: []
 connections:
-- valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
+- valory/http_server:0.22.0:bafybeihjuoo45sk6dktxktqgfhyk2t5qsomztmsfzgv3vt3bq7updg3piq
 contracts: []
 protocols:
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
-- valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeicvk5e6h7ucjrc5jhnv4qhqjucg6abdig6n4waconethh53uksbii
-- valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu
+- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
+- valory/delivery_rate_abci:0.1.0:bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae
+- valory/registration_abci:0.1.0:bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e
+- valory/reset_pause_abci:0.1.0:bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga
+- valory/task_execution:0.1.0:bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq
+- valory/task_submission_abci:0.1.0:bafybeigvk6vrawvvsswcujciempa6usumogedaeaqc4pjlr3ztfmq5hw7a
+- valory/termination_abci:0.1.0:bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi
+- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
 behaviours:
   main:
     args: {}
@@ -86,13 +86,18 @@ models:
     class_name: LedgerApiDialogues
   params:
     args:
-      mech_to_config: {}
+      agent_funding_amount: 200000000000000000
       api_keys: {}
       cleanup_history_depth: 1
       cleanup_history_depth_current: null
+      complementary_service_metadata_address: '0x0000000000000000000000000000000000000000'
+      default_chain_id: gnosis
       drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
-      tools_to_package_hash: {}
       finalize_timeout: 60.0
+      gas_params:
+        gas_price: null
+        max_fee_per_gas: null
+        max_priority_fee_per_gas: null
       genesis_config:
         genesis_time: '2022-09-26T00:00:00.000000000Z'
         chain_id: chain-c4daS1
@@ -110,73 +115,68 @@ models:
             - ed25519
           version: {}
         voting_power: '10'
+      hash_checkpoint_address: '0x0000000000000000000000000000000000000000'
       history_check_timeout: 1205
       init_fallback_gas: 0
+      ipfs_fetch_timeout: 15.0
       keeper_allowed_retries: 3
       keeper_timeout: 30.0
+      light_slash_unit_amount: 5000000000000000
+      manual_gas_limit: 1000000
       max_attempts: 10
       max_healthcheck: 120
+      mech_events_chain_id: 0
+      mech_events_sweep_max_age_seconds: 3600.0
+      mech_events_sweep_pending_enabled: false
+      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
+      mech_staking_instance_address: '0x0000000000000000000000000000000000000000'
+      mech_to_config: {}
+      mech_to_max_delivery_rate: {}
+      metadata_hash: '00000000000000000000000000000000000000000000000000'
+      minimum_agent_balance: 100000000000000000
       multisend_address: '0x0000000000000000000000000000000000000000'
       on_chain_service_id: null
       polling_interval: 25
+      predict_api_events_timeout_seconds: 5.0
+      predict_api_events_url: https://mpp.autonolas.tech/mech/events
+      profit_split_balance: 100
       request_retry_delay: 1.0
       request_timeout: 10.0
       reset_pause_duration: 10
       reset_period_count: 100
-      gas_params:
-        gas_price: null
-        max_fee_per_gas: null
-        max_priority_fee_per_gas: null
       reset_tendermint_after: 100
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 30.0
-      ipfs_fetch_timeout: 15.0
+      serious_slash_unit_amount: 8000000000000000
+      service_endpoint_base: https://dummy_service.autonolas.tech/
       service_id: mech
+      service_owner_share: 1000
       service_registry_address: null
       setup:
         all_participants: []
         safe_contract_address: '0x0000000000000000000000000000000000000000'
         consensus_threshold: null
       share_tm_config_on_startup: false
+      slash_cooldown_hours: 3
+      slash_threshold_amount: 10000000000000000
       sleep_time: 1
+      task_wait_timeout: 15.0
       tendermint_check_sleep_delay: 3
       tendermint_com_url: http://localhost:8080
       tendermint_max_retries: 5
       tendermint_p2p_url: localhost:26656
       tendermint_url: http://localhost:26657
+      termination_from_block: 0
       termination_sleep: 900
+      tools_to_package_hash: {}
+      tools_to_pricing: {}
       tx_timeout: 10.0
+      use_offchain: false
       use_polling: false
+      use_slashing: false
       use_termination: false
       validate_timeout: 1205
-      task_wait_timeout: 15.0
-      use_slashing: false
-      manual_gas_limit: 1000000
-      mech_staking_instance_address: '0x0000000000000000000000000000000000000000'
-      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
-      complementary_service_metadata_address: '0x0000000000000000000000000000000000000000'
-      metadata_hash: '00000000000000000000000000000000000000000000000000'
-      slash_cooldown_hours: 3
-      hash_checkpoint_address: '0x0000000000000000000000000000000000000000'
-      slash_threshold_amount: 10000000000000000
-      termination_from_block: 0
-      light_slash_unit_amount: 5000000000000000
-      service_owner_share: 1000
-      profit_split_balance: 100
-      serious_slash_unit_amount: 8000000000000000
-      agent_funding_amount: 200000000000000000
-      minimum_agent_balance: 100000000000000000
-      mech_to_max_delivery_rate: {}
-      tools_to_pricing: {}
-      service_endpoint_base: https://dummy_service.autonolas.tech/
-      default_chain_id: gnosis
-      use_offchain: false
-      predict_api_events_url: https://mpp.autonolas.tech/mech/events
-      predict_api_events_timeout_seconds: 5.0
-      mech_events_sweep_pending_enabled: false
-      mech_events_sweep_max_age_seconds: 3600.0
-      mech_events_chain_id: 0
     class_name: Params
   randomness_api:
     args:
@@ -205,3 +205,4 @@ dependencies:
   open-aea-cli-ipfs:
     version: ==2.2.9
 is_abstract: false
+customs: []

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy
-- valory/task_submission_abci:0.1.0:bafybeiasz7rioybpqadkvd4e6nmxx2pvoeca4h5zdezflr4o5dr5godz7a
+- valory/task_execution:0.1.0:bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai
+- valory/task_submission_abci:0.1.0:bafybeihtnnjk4qfn3o7dz3cycib3jfvvtkifg2l5vu6yk6tkr4n57hnn4q
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise
-- valory/task_submission_abci:0.1.0:bafybeiclu2huy25ghuemnbpua6ut5b5opsc4o3c5jdqbuqkruabsqfdfhe
+- valory/task_execution:0.1.0:bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy
+- valory/task_submission_abci:0.1.0:bafybeiasz7rioybpqadkvd4e6nmxx2pvoeca4h5zdezflr4o5dr5godz7a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly
-- valory/task_submission_abci:0.1.0:bafybeiayhuho5dyqqng6vgwtajyu737ambdsgf24for6jgkrvo35wbgfay
+- valory/task_execution:0.1.0:bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu
+- valory/task_submission_abci:0.1.0:bafybeifxsikjyebutrq43jznpo4s2dkpiynwgwry6pr5b2l2wqbezwbdli
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq
-- valory/task_submission_abci:0.1.0:bafybeidz3nidtvdbk67fn3epxcottuwfycund3tiwkyba6eqshdkbjefmu
+- valory/task_execution:0.1.0:bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi
+- valory/task_submission_abci:0.1.0:bafybeidvjxawskjuu43bzju2mobjgll3jzkdebmy7xhdfr644dtud7bkoa
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeiff6a6p2swb7e6m6nmhn5mn4m5a76knnsnzgdaakcbo3j36mcunau
+- valory/task_submission_abci:0.1.0:bafybeih5rgsjycdufrkqoo2muxiwpmw63cixvpa6u2wsbdcysjvv6jroua
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m
+- valory/task_execution:0.1.0:bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a
+- valory/task_submission_abci:0.1.0:bafybeicigscuv6gdsw5v54cc63qkhtho3236seiqibylg37cielufagrfe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
+- valory/task_execution:0.1.0:bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeicigscuv6gdsw5v54cc63qkhtho3236seiqibylg37cielufagrfe
+- valory/task_submission_abci:0.1.0:bafybeiehmrgd5umd22g56jsdk3gxayd6myx6ufhj6jkl5j2ajvhlkaoycu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq
+- valory/task_execution:0.1.0:bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -30,11 +30,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_submission_abci:0.1.0:bafybeih5rgsjycdufrkqoo2muxiwpmw63cixvpa6u2wsbdcysjvv6jroua
+- valory/task_submission_abci:0.1.0:bafybeicvk5e6h7ucjrc5jhnv4qhqjucg6abdig6n4waconethh53uksbii
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm
+- valory/task_execution:0.1.0:bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -22,19 +22,19 @@ fingerprint:
   tests/test_models.py: bafybeif4iuuknrtx3tc72y2ii237dqtl6nlqgpdywy227sfqbvxkk6mugy
 fingerprint_ignore_patterns: []
 connections:
-- valory/http_server:0.22.0:bafybeihjuoo45sk6dktxktqgfhyk2t5qsomztmsfzgv3vt3bq7updg3piq
+- valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
 contracts: []
 protocols:
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
-- valory/delivery_rate_abci:0.1.0:bafybeifjtxexh6trir7thjtl63g2v2nbucyzsnuemlzf2suugdxnxqmzae
-- valory/registration_abci:0.1.0:bafybeibxrtnilq2oz6rt2rvmitw7z3sp4t2grlc7mhmgiwarillhrylo6e
-- valory/reset_pause_abci:0.1.0:bafybeifa6tbg54qc7fhdeqlhuld6fcniaz5wksrvdmyetproagccxgdtga
-- valory/task_execution:0.1.0:bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi
-- valory/task_submission_abci:0.1.0:bafybeihmvdk4wxzbwoehztin7zosiqykq6egyc4eixnfbyvfv4hfnru3de
-- valory/termination_abci:0.1.0:bafybeigdxyvzuzyfy7vbjz7lgmpxopif7vrq2hpwg7cinbpehoicienrvi
-- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
+- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
+- valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
+- valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
+- valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
+- valory/task_execution:0.1.0:bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly
+- valory/task_submission_abci:0.1.0:bafybeiayhuho5dyqqng6vgwtajyu737ambdsgf24for6jgkrvo35wbgfay
+- valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
+- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -34,6 +34,7 @@ from aea.mail.base import EnvelopeContext
 from aea.protocols.base import Message
 from aea.protocols.dialogue.base import Dialogue
 from aea.skills.behaviours import SimpleBehaviour
+from eth_utils import to_checksum_address
 from pebble import ProcessPool
 from prometheus_client import Counter, Gauge, Histogram
 
@@ -183,11 +184,18 @@ def _release_outstanding_nonce(
     settling_all = shared_state.setdefault(SETTLING_NONCES_BY_SENDER, {})
     accepted_key = _find_sender_key(accepted_all or {}, sender)
     if accepted_key is None:
-        # No accepted entry to move (already rolled back / on-chain
-        # path / crash-recovery). Still add to settling under the
-        # lowercase key so a subsequent settlement prune is
-        # deterministic; the pruner discards anything < on_chain.
-        settling_key = _find_sender_key(settling_all, sender) or str(sender).lower()
+        # No accepted entry to move (already rolled back, on-chain
+        # path, or crash-recovery). Canonicalise the settling key to
+        # the EIP-55 checksum form so it agrees with the key shape
+        # the handler-side maps and their exact-lookup consumers
+        # use. A raw wire ``sender`` that is not a valid address
+        # cannot be canonicalised and the release becomes a no-op.
+        try:
+            settling_key = _find_sender_key(
+                settling_all, sender
+            ) or to_checksum_address(str(sender))
+        except (TypeError, ValueError):
+            return
     else:
         entries = accepted_all[accepted_key]  # type: ignore[index]
         entries.discard(wire_nonce)
@@ -1296,13 +1304,16 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         executing_task = cast(Dict[str, Any], self._executing_task)
         req_id = executing_task.get("requestId", None)
 
-        # This should never be the case but added to handle all cases for latest mypy updates
+        # Off-chain ``requestId`` is coerced to ``int`` at accept time
+        # (see ``handlers._enqueue_offchain_request``), so a wire
+        # ``request_id`` of ``"0"`` is falsy under this check.
+        # Routing through ``_reset_executing_task`` keeps the
+        # accepted-nonce discard uniform across every drop path.
         if not req_id:
             self.context.logger.error(
                 "Request id not found inside executing task for handle timedout task."
             )
-            self._executing_task = None
-            self._async_result = None
+            self._reset_executing_task()
             return None
 
         # Prometheus has no way to remove/clear metrics, so we set to default 0
@@ -1372,10 +1383,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "Task data arrived after deadline. "
                 "Skipping tool execution and cleaning up."
             )
-            self._executing_task = None
-            self._async_result = None
-            self._request_handling_deadline = None
+            # Route through ``_reset_executing_task`` so the accepted-
+            # nonce discard runs on this drop branch, matching every
+            # other terminal branch on the off-chain path.
             self.tool_preparation_start_time = 0.0
+            self._reset_executing_task()
             return
 
         executing_task = cast(Dict[str, Any], self._executing_task)

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -90,12 +90,71 @@ REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
 # buffered request metadata from the behaviour side.
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
 IN_MEMORY_REQUESTS = "in_memory_requests"
+# Shared-state key owned by the MechHttpHandler; mirrored here because the
+# off-chain finalize / rejection paths need to drop the sender's outstanding
+# wire-nonce entry so the handler-side admission gate on subsequent accepts
+# computes the correct next-expected slot.
+OUTSTANDING_NONCES_BY_SENDER = "outstanding_nonces_by_sender"
+# Wire-body keys copied through into the pending task dict at accept time.
+# Kept as literals here (rather than importing from handlers) so the
+# behaviour does not add a cross-module import for a handful of string
+# constants shared across the accept and finalize sides.
+_SENDER_KEY = "sender"
+_NONCE_KEY = "nonce"
 INITIAL_DEADLINE = 1200.0  # 20mins of deadline
 SUBSEQUENT_DEADLINE = 300.0  # 5min of deadline
 STATUS_CHECK_INTERVAL = 600.0  # 10min interval
 RESPONSE_SCHEMA_VERSION = "2.0"
 IPFS_MAX_TASK_BYTES = 1_048_576  # 1MB cap on attacker-controlled task payload
 MAX_PROMPT_BYTES = 100_000  # 100KB cap on the prompt field
+
+
+def _release_outstanding_nonce(
+    shared_state: Dict[str, Any],
+    executing_task: Optional[Dict[str, Any]],
+) -> None:
+    """Drop the sender+nonce entry recorded at accept time, if any.
+
+    The handler's admission gate on the next accept from the same
+    sender computes the next-expected slot as
+    ``on_chain_mapNonces + len(outstanding_nonces_by_sender[sender])``.
+    Leaving a settled or rejected entry in the outstanding set would
+    make the gate demand a nonce one slot higher than settlement
+    actually expects, dragging the sender's next legitimate request
+    into a permanent 401 loop.
+
+    Idempotent on missing keys: the on-chain path never populates the
+    outstanding set, and a rollback that ran before this call already
+    cleared its own entry.
+
+    :param shared_state: the AEA shared-state dict.
+    :param executing_task: the just-settled task dict (or None). Read
+        the sender + nonce pair off it because the request-id string
+        is not enough — the outstanding set is keyed by sender
+        checksum, and the wire nonce (int) is the entry inside the
+        per-sender set.
+    """
+    if not executing_task:
+        return
+    sender = executing_task.get(_SENDER_KEY)
+    nonce = executing_task.get(_NONCE_KEY)
+    if sender is None or nonce is None:
+        return
+    outstanding_all = shared_state.get(OUTSTANDING_NONCES_BY_SENDER)
+    if not outstanding_all:
+        return
+    # ``sender`` on ``executing_task`` is the raw wire value; the
+    # admission gate keys on the checksum-cased address. Compare
+    # case-insensitively via the lowercase 0x-address form since a
+    # dict-key lookup would otherwise miss a mixed-case wire value.
+    sender_str = str(sender).lower()
+    for key in list(outstanding_all.keys()):
+        if key.lower() == sender_str:
+            entries = outstanding_all[key]
+            entries.discard(int(nonce))
+            if not entries:
+                outstanding_all.pop(key, None)
+            break
 
 
 def _iso_z(dt: datetime) -> str:
@@ -1602,6 +1661,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # ``handlers.py:776``), so the pop needs the ``str`` form or it
         # silently misses and leaks the full request JSON.
         self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(str(req_id), None)
+        # Free the sender's outstanding-nonce slot so the handler-side
+        # admission gate on the sender's next accept computes the correct
+        # next-expected value (on_chain + outstanding_count). A no-op on
+        # the on-chain path (which never populates the set).
+        _release_outstanding_nonce(self.context.shared_state, executing_task)
         self._reset_executing_task()
 
     def _build_predict_api_event(
@@ -1960,6 +2024,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             req_id, reason, None, preimage_buffer.STATUS_REJECTED
         )
         self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(req_id, None)
+        # Free the sender's outstanding-nonce slot even on the rejection
+        # path so a subsequent legitimate accept from the same sender is
+        # not blocked by a stale entry. Read the sender + nonce off the
+        # still-set ``_executing_task`` slot before it is cleared below.
+        _release_outstanding_nonce(self.context.shared_state, self._executing_task)
         self._reset_executing_task()
 
     # --- off-chain preimage buffer (kv_store) -----------------------------

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -209,16 +209,19 @@ def _discard_outstanding_nonce(
     shared_state: Dict[str, Any],
     executing_task: Optional[Dict[str, Any]],
 ) -> None:
-    """Drop the sender+nonce from BOTH the accepted and settling sets.
+    """Drop the sender+nonce from the accepted set.
 
     Used on the rejection / failure paths (``_record_offchain_failure``,
     and the defensive release inside ``_reset_executing_task`` for
     off-chain drops that skip both ``_finalize_done_task`` and
     ``_record_offchain_failure``). Different from
     :func:`_release_outstanding_nonce`, which moves the entry from
-    accepted to settling so settlement can eventually drain it — a
-    rejected task will never reach settlement, so both sets need to
-    be cleared to keep the admission-gate slot count truthful.
+    accepted to settling so settlement can eventually drain it. Only
+    the accepted set is touched here: the settling set is by
+    definition "released and awaiting chain" — clearing it here would
+    undo a release that has already happened on the finalise path and
+    collapse the admission gate's three-state accounting back into a
+    two-state one.
 
     :param shared_state: the AEA shared-state dict.
     :param executing_task: the failed task dict (or None).
@@ -233,17 +236,16 @@ def _discard_outstanding_nonce(
         wire_nonce = int(nonce)
     except (TypeError, ValueError):
         return
-    for map_key in (ACCEPTED_NONCES_BY_SENDER, SETTLING_NONCES_BY_SENDER):
-        target = shared_state.get(map_key)
-        if not target:
-            continue
-        sender_key = _find_sender_key(target, sender)
-        if sender_key is None:
-            continue
-        entries = target[sender_key]
-        entries.discard(wire_nonce)
-        if not entries:
-            target.pop(sender_key, None)
+    target = shared_state.get(ACCEPTED_NONCES_BY_SENDER)
+    if not target:
+        return
+    sender_key = _find_sender_key(target, sender)
+    if sender_key is None:
+        return
+    entries = target[sender_key]
+    entries.discard(wire_nonce)
+    if not entries:
+        target.pop(sender_key, None)
 
 
 def _iso_z(dt: datetime) -> str:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -90,11 +90,15 @@ REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
 # buffered request metadata from the behaviour side.
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
 IN_MEMORY_REQUESTS = "in_memory_requests"
-# Shared-state key owned by the MechHttpHandler; mirrored here because the
-# off-chain finalize / rejection paths need to drop the sender's outstanding
-# wire-nonce entry so the handler-side admission gate on subsequent accepts
-# computes the correct next-expected slot.
-OUTSTANDING_NONCES_BY_SENDER = "outstanding_nonces_by_sender"
+# Shared-state keys owned by the MechHttpHandler; mirrored here because
+# the off-chain finalize / rejection paths need to move the sender's
+# wire-nonce entry across the accepted→settling boundary so the
+# handler-side admission gate on subsequent accepts computes the
+# correct next-expected slot across the release/settlement gap.
+ACCEPTED_NONCES_BY_SENDER = "accepted_nonces_by_sender"
+SETTLING_NONCES_BY_SENDER = "settling_nonces_by_sender"
+# Kept as an alias for consumers still referring to the pre-split name.
+OUTSTANDING_NONCES_BY_SENDER = ACCEPTED_NONCES_BY_SENDER
 # Wire-body keys copied through into the pending task dict at accept time.
 # Kept as literals here (rather than importing from handlers) so the
 # behaviour does not add a cross-module import for a handful of string
@@ -109,30 +113,61 @@ IPFS_MAX_TASK_BYTES = 1_048_576  # 1MB cap on attacker-controlled task payload
 MAX_PROMPT_BYTES = 100_000  # 100KB cap on the prompt field
 
 
+def _find_sender_key(
+    nonces_by_sender: Dict[str, Any],
+    sender: Any,
+) -> Optional[str]:
+    """Return the checksum-cased key in ``nonces_by_sender`` that matches ``sender``.
+
+    ``sender`` on ``executing_task`` is the raw wire value; the
+    admission gate keys on the checksum-cased address, so a
+    ``dict[sender]`` lookup would miss a mixed-case wire value.
+    Compare case-insensitively via the lowercase 0x-address form.
+
+    :param nonces_by_sender: the per-sender nonce map.
+    :param sender: the raw wire sender value.
+    :return: the matching key from ``nonces_by_sender``, or None.
+    """
+    if not nonces_by_sender or sender is None:
+        return None
+    sender_str = str(sender).lower()
+    for key in list(nonces_by_sender.keys()):
+        if key.lower() == sender_str:
+            return key
+    return None
+
+
 def _release_outstanding_nonce(
     shared_state: Dict[str, Any],
     executing_task: Optional[Dict[str, Any]],
 ) -> None:
-    """Drop the sender+nonce entry recorded at accept time, if any.
+    """Move the sender+nonce entry from the accepted set to the settling set.
 
-    The handler's admission gate on the next accept from the same
-    sender computes the next-expected slot as
-    ``on_chain_mapNonces + len(outstanding_nonces_by_sender[sender])``.
-    Leaving a settled or rejected entry in the outstanding set would
-    make the gate demand a nonce one slot higher than settlement
-    actually expects, dragging the sender's next legitimate request
-    into a permanent 401 loop.
+    Called when a task moves from ``pending_tasks`` to ``done_tasks``
+    (``_finalize_done_task``). The wire nonce transitions from
+    "accepted, not-yet-done" to "done, not-yet-settled". The
+    handler-side admission gate computes the next-expected slot as
+    ``on_chain_mapNonces + len(accepted) + len(settling)``; leaving
+    the entry in ``accepted`` after the release would double-count
+    it when the on-chain counter also reflected the same nonce.
+    Removing it from both without adding to ``settling`` would
+    UNDER-count during the release/settlement gap (typically several
+    ABCI rounds) — the same window where the pre-split code let a
+    duplicate wire nonce re-enter under a colliding request_id.
 
-    Idempotent on missing keys: the on-chain path never populates the
-    outstanding set, and a rollback that ran before this call already
-    cleared its own entry.
+    The settling entry is drained later by the pruning pass in
+    ``_bind_wire_nonce_to_chain`` when the on-chain
+    ``mapNonces[sender]`` advances past the nonce.
+
+    Idempotent on missing keys: the on-chain path never populates
+    either set, and a rollback that ran before this call already
+    cleared its own entry from ``accepted``.
 
     :param shared_state: the AEA shared-state dict.
-    :param executing_task: the just-settled task dict (or None). Read
+    :param executing_task: the just-done task dict (or None). Read
         the sender + nonce pair off it because the request-id string
-        is not enough — the outstanding set is keyed by sender
-        checksum, and the wire nonce (int) is the entry inside the
-        per-sender set.
+        is not enough — the maps are keyed by sender checksum, and
+        the wire nonce (int) is the entry inside the per-sender set.
     """
     if not executing_task:
         return
@@ -140,21 +175,67 @@ def _release_outstanding_nonce(
     nonce = executing_task.get(_NONCE_KEY)
     if sender is None or nonce is None:
         return
-    outstanding_all = shared_state.get(OUTSTANDING_NONCES_BY_SENDER)
-    if not outstanding_all:
+    try:
+        wire_nonce = int(nonce)
+    except (TypeError, ValueError):
         return
-    # ``sender`` on ``executing_task`` is the raw wire value; the
-    # admission gate keys on the checksum-cased address. Compare
-    # case-insensitively via the lowercase 0x-address form since a
-    # dict-key lookup would otherwise miss a mixed-case wire value.
-    sender_str = str(sender).lower()
-    for key in list(outstanding_all.keys()):
-        if key.lower() == sender_str:
-            entries = outstanding_all[key]
-            entries.discard(int(nonce))
-            if not entries:
-                outstanding_all.pop(key, None)
-            break
+    accepted_all = shared_state.get(ACCEPTED_NONCES_BY_SENDER)
+    settling_all = shared_state.setdefault(SETTLING_NONCES_BY_SENDER, {})
+    accepted_key = _find_sender_key(accepted_all or {}, sender)
+    if accepted_key is None:
+        # No accepted entry to move (already rolled back / on-chain
+        # path / crash-recovery). Still add to settling under the
+        # lowercase key so a subsequent settlement prune is
+        # deterministic; the pruner discards anything < on_chain.
+        settling_key = _find_sender_key(settling_all, sender) or str(sender).lower()
+    else:
+        entries = accepted_all[accepted_key]  # type: ignore[index]
+        entries.discard(wire_nonce)
+        if not entries:
+            accepted_all.pop(accepted_key, None)  # type: ignore[union-attr]
+        settling_key = accepted_key
+    settling_all.setdefault(settling_key, set()).add(wire_nonce)
+
+
+def _discard_outstanding_nonce(
+    shared_state: Dict[str, Any],
+    executing_task: Optional[Dict[str, Any]],
+) -> None:
+    """Drop the sender+nonce from BOTH the accepted and settling sets.
+
+    Used on the rejection / failure paths (``_record_offchain_failure``,
+    and the defensive release inside ``_reset_executing_task`` for
+    off-chain drops that skip both ``_finalize_done_task`` and
+    ``_record_offchain_failure``). Different from
+    :func:`_release_outstanding_nonce`, which moves the entry from
+    accepted to settling so settlement can eventually drain it — a
+    rejected task will never reach settlement, so both sets need to
+    be cleared to keep the admission-gate slot count truthful.
+
+    :param shared_state: the AEA shared-state dict.
+    :param executing_task: the failed task dict (or None).
+    """
+    if not executing_task:
+        return
+    sender = executing_task.get(_SENDER_KEY)
+    nonce = executing_task.get(_NONCE_KEY)
+    if sender is None or nonce is None:
+        return
+    try:
+        wire_nonce = int(nonce)
+    except (TypeError, ValueError):
+        return
+    for map_key in (ACCEPTED_NONCES_BY_SENDER, SETTLING_NONCES_BY_SENDER):
+        target = shared_state.get(map_key)
+        if not target:
+            continue
+        sender_key = _find_sender_key(target, sender)
+        if sender_key is None:
+            continue
+        entries = target[sender_key]
+        entries.discard(wire_nonce)
+        if not entries:
+            target.pop(sender_key, None)
 
 
 def _iso_z(dt: datetime) -> str:
@@ -1348,6 +1429,16 @@ class TaskExecutionBehaviour(SimpleBehaviour):
 
         my_mech = self._get_designated_marketplace_mech_address().lower()
         exec_prio = str(executing_task.get("priorityMech", "")).lower()
+        # Off-chain tasks never carry ``priorityMech`` (the field is set
+        # by the on-chain contract call reader; the accept path does not
+        # populate it), so ``stepping_in`` evaluates to True for every
+        # off-chain task and the tool-not-installed drop below always
+        # fires for a typo'd tool name. Route those drops through
+        # ``_record_offchain_failure`` so the client sees a definitive
+        # rejection over the polling endpoint AND the sender's
+        # outstanding-nonce entry is discarded — leaving it behind
+        # would inflate the admission gate's slot count forever, hard-
+        # 401'ing every subsequent request from the same sender.
         stepping_in = exec_prio != my_mech
         tool_name = task_data["tool"]
         if stepping_in and tool_name not in self._tools_to_package_hash:
@@ -1360,14 +1451,19 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 tool=tool_name,
                 reason=reason,
             )
+            if bool(executing_task.get("is_offchain", False)):
+                # Definitive rejection + nonce release + slot reset in
+                # one call. Reads sender / nonce off ``_executing_task``
+                # before the reset clears it.
+                self._record_offchain_failure(str(rid), reason)
+                self.tool_preparation_start_time = 0.0
+                return
             # Prometheus has no way to remove/clear metrics, so we set to default 0
             self.mech_metrics.set_gauge(
                 self.mech_metrics.mech_tasks_inflight,
                 0,
             )
-            self._executing_task = None
-            self._request_handling_deadline = None
-            self._async_result = None
+            self._reset_executing_task()
             # reset the time counter used to measure time taken to prepare the task
             self.tool_preparation_start_time = 0.0
             return
@@ -1991,7 +2087,26 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         }
 
     def _reset_executing_task(self) -> None:
-        """Reset the in-flight task slot so the next task can be picked up."""
+        """Reset the in-flight task slot so the next task can be picked up.
+
+        Belt-and-braces: any off-chain task still bound to the slot at
+        reset time gets its nonce dropped from both the accepted and
+        settling sets, so any drop path a future refactor forgets to
+        thread ``_record_offchain_failure`` / ``_release_outstanding_nonce``
+        through cannot leak the sender's outstanding-nonce entry.
+        No-op on on-chain tasks (they never populate either set) and
+        no-op when the slot is already empty. The primary release
+        paths (``_finalize_done_task`` → ``_release_outstanding_nonce``
+        and ``_record_offchain_failure`` → ``_discard_outstanding_nonce``)
+        run BEFORE this method, so this discard is guaranteed to be a
+        no-op on the happy paths.
+        """
+        # Discard before clearing the slot so ``_executing_task`` still
+        # carries the sender + nonce pair the discard reads off.
+        if self._executing_task is not None and bool(
+            self._executing_task.get("is_offchain", False)
+        ):
+            _discard_outstanding_nonce(self.context.shared_state, self._executing_task)
         # Prometheus has no clear; set the in-flight gauge back to 0.
         self.mech_metrics.set_gauge(self.mech_metrics.mech_tasks_inflight, 0)
         self._executing_task = None
@@ -2024,11 +2139,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             req_id, reason, None, preimage_buffer.STATUS_REJECTED
         )
         self.context.shared_state.get(IN_MEMORY_REQUESTS, {}).pop(req_id, None)
-        # Free the sender's outstanding-nonce slot even on the rejection
-        # path so a subsequent legitimate accept from the same sender is
-        # not blocked by a stale entry. Read the sender + nonce off the
-        # still-set ``_executing_task`` slot before it is cleared below.
-        _release_outstanding_nonce(self.context.shared_state, self._executing_task)
+        # Drop from both accepted and settling on the rejection path.
+        # A rejected task will never settle, so leaving anything in
+        # ``settling`` would keep the admission-gate slot count
+        # inflated until the pruner eventually removes it (or, if the
+        # sender never sends again, forever).
+        _discard_outstanding_nonce(self.context.shared_state, self._executing_task)
         self._reset_executing_task()
 
     # --- off-chain preimage buffer (kv_store) -----------------------------

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -20,6 +20,7 @@
 """This package contains a scaffold of a handler."""
 
 import base64
+import concurrent.futures
 import json
 import re
 import threading
@@ -27,7 +28,18 @@ import time
 import urllib.parse
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from aea.protocols.base import Message
 from aea.skills.base import Handler
@@ -81,6 +93,15 @@ PAYMENT_INFO = "payment_info"
 ROUTES_INFO = "routes_info"
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
 IN_MEMORY_REQUESTS = "in_memory_requests"
+# Live outstanding accepted-but-unsettled wire nonces per sender. Keyed
+# by the sender's checksum address; values are the set of wire nonces
+# currently held in ``pending_tasks`` / ``in_memory_requests`` awaiting
+# settlement. Read by the nonce-bind admission gate to require the next
+# wire nonce equal exactly the on-chain ``mapNonces`` value plus the
+# outstanding count (no gaps, no duplicates). Written from the accept
+# path (on enqueue) and cleared on rollback, done, and rejection —
+# same lifecycle as ``in_memory_requests`` so the two stay coherent.
+OUTSTANDING_NONCES_BY_SENDER = "outstanding_nonces_by_sender"
 JSON_CONTENT_HEADER = "Content-Type: application/json\n"
 ENCODING_UTF8 = "utf-8"
 
@@ -122,37 +143,18 @@ REQUEST_ID_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
 # guard exists to close. Mirrors ``MAX_DELIVERY_RATE``.
 MAX_REQUEST_ID = 2**256 - 1
 
-# ``nonce`` on the wire is the decimal encoding of the requester's
-# uint256 ``mapNonces`` counter at the moment of signing. Coerce to
-# ``int`` at ingress and validate the alphabet + magnitude the same
-# way ``request_id`` is validated. Downstream (see
-# ``task_submission_abci.behaviours._get_offchain_tasks_deliver_data``)
-# calls ``sorted(..., key=lambda x: x[NONCE])``; a wire ``str`` would
-# sort lexicographically (``"10"`` before ``"9"``) and the on-chain
-# ``mapNonces`` array consume would fail the whole batch.
-NONCE_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
-MAX_NONCE = 2**256 - 1
-
-# Maximum gap between the wire ``nonce`` and the on-chain
-# ``MechMarketplace.mapNonces[sender]`` value that the accept path
-# tolerates before rejecting. The settlement path groups a per-sender
-# batch by ``nonce`` and consumes the on-chain counter strictly in
-# order; a sender that queues too many in-flight requests ahead of the
-# on-chain cursor starves its own settlement. Sixteen leaves headroom
-# for legitimate batching (mech-client posts small bursts) while
-# keeping the wire ``nonce`` numerically close to what settlement will
-# actually see, so the derived ``request_id`` still matches when the
-# on-chain call recomputes it. A wire ``nonce`` below the on-chain
-# value can never settle at all — the counter only moves upward — so
-# the accept path refuses it as well.
-MAX_OUTSTANDING_NONCE_WINDOW = 16
-
 # Rejection reasons carried on ``SignatureVerdict`` for the nonce-bind
 # outcomes. Kept as module-level constants so tests and log-search
 # tooling can pin the exact string rather than fishing it out of the
-# enum by index.
-NONCE_BELOW_CHAIN = "wire nonce below on-chain mapNonces"
-NONCE_ABOVE_WINDOW = "wire nonce above allowed outstanding window"
+# enum by index. ``NONCE_BELOW_EXPECTED`` covers a wire value that lands
+# strictly before the sender's next contiguous slot (settlement would
+# derive a different ``request_id`` for it and revert the whole batch),
+# and ``NONCE_ABOVE_EXPECTED`` covers a wire value that skips a slot
+# (same batch-revert outcome from the settlement side, but the sender
+# can retry as soon as their earlier requests drain — so this branch
+# routes to 503 rather than 401).
+NONCE_BELOW_EXPECTED = "wire nonce below sender's next expected slot"
+NONCE_ABOVE_EXPECTED = "wire nonce above sender's next expected slot"
 NONCE_READ_FAILED = "on-chain mapNonces read failed"
 
 # Timeout applied to the sender's ``isValidSignature`` view via the
@@ -178,6 +180,35 @@ _EIP1271_CALL_GAS_CAP = 500_000
 # "signature verification failed" reason so operators can tell an
 # unresponsive Safe apart from an actively-declined signature.
 EIP1271_CALL_TIMEOUT = "eip1271 isValidSignature call timed out"
+
+# Wall-clock deadline enforced on the two on-path RPCs the sig-verify
+# code makes (EIP-1271 ``isValidSignature`` and marketplace
+# ``mapNonces``). The per-HTTP-request timeout on ``EthereumApi`` is
+# not a wall-clock bound: both ``web3.HTTPProvider``'s
+# ``exception_retry_configuration`` (five retries with backoff on
+# ``requests.Timeout``) and open-aea's ``RotatingHTTPProvider``
+# (``min(MAX_RETRIES=6, url_count * 2)`` outer retries with
+# ``time.sleep(min(2**a, 5.0))`` between attempts) multiply the
+# per-request timeout well past the ``http_server`` reply budget
+# (default ``RESPONSE_TIMEOUT=5s``). Wrapping each on-path call in a
+# thread with an explicit ``future.result(timeout=...)`` returns
+# control to the AEA main loop within the budget so a slow / hostile
+# RPC or ``isValidSignature`` cannot stall ABCI processing. The
+# underlying HTTP call keeps running in the worker thread but the
+# handler-thread returns and the outcome maps to the same infra
+# verdicts (``EIP1271_CALL_TIMEOUT`` / ``NONCE_READ_FAILED``) as any
+# other transport failure. Four seconds leaves a one-second margin
+# under the five-second http_server reply budget so the client sees a
+# verdict before the server-side timeout fires.
+_RPC_WALL_CLOCK_DEADLINE_SECONDS = 4.0
+
+# ``max_workers`` for the ``ThreadPoolExecutor`` cached on
+# :class:`MechHttpHandler` and used to enforce
+# ``_RPC_WALL_CLOCK_DEADLINE_SECONDS`` on on-path RPCs. The pool is
+# used exclusively for I/O-bound web3 calls and is sized to absorb a
+# small burst of concurrent accepts without queueing while still
+# leaving headroom against the AEA main-thread pool.
+_RPC_EXECUTOR_MAX_WORKERS = 4
 
 # ``signature`` on the wire is the hex encoding of the packed signature
 # bytes with a mandatory ``0x`` prefix. The settlement path
@@ -963,6 +994,20 @@ class MechHttpHandler(AbstractResponseHandler):
         return self.context.shared_state[IN_MEMORY_REQUESTS]
 
     @property
+    def outstanding_nonces_by_sender(self) -> Dict[str, Set[int]]:
+        """Get the live outstanding wire-nonce set per sender checksum.
+
+        Values are ``set`` instances so admission-gate reads and mutation
+        on accept / rollback / done can share a single container without
+        rebuilding on every mutation.
+
+        :return: a dict keyed by sender checksum address. A missing key
+            means "no in-flight requests from this sender" and the
+            admission gate uses ``len()==0`` in that case.
+        """
+        return self.context.shared_state[OUTSTANDING_NONCES_BY_SENDER]
+
+    @property
     def params(self) -> Params:
         """Get the parameters."""
         return cast(Params, self.context.params)
@@ -976,6 +1021,12 @@ class MechHttpHandler(AbstractResponseHandler):
         self.context.shared_state[IPFS_TASKS] = []
         self.context.shared_state[OFFCHAIN_REQUEST_RESPONSES] = {}
         self.context.shared_state[IN_MEMORY_REQUESTS] = {}
+        # Live outstanding accepted-but-unsettled wire nonces per sender.
+        # Populated on accept (``_enqueue_offchain_request``) and cleared
+        # on rollback / done / rejection — same lifecycle as
+        # ``in_memory_requests`` so the two containers stay coherent for
+        # the admission gate in ``_bind_wire_nonce_to_chain``.
+        self.context.shared_state[OUTSTANDING_NONCES_BY_SENDER] = {}
         self.json_content_header = JSON_CONTENT_HEADER
         # Deployment-scoped constants used by the offchain request-id
         # derivation: the marketplace EIP-712 ``domainSeparator`` and the
@@ -1010,10 +1061,73 @@ class MechHttpHandler(AbstractResponseHandler):
         # for the balance-check reads without either overwriting the
         # other's provider timeout.
         self._ledger_api_cache: Dict[Tuple[str, int, float], EthereumApi] = {}
+        # Executor for on-path RPCs whose wall-clock duration must be
+        # capped independently of the per-HTTP-request provider timeout.
+        # See ``_RPC_WALL_CLOCK_DEADLINE_SECONDS`` for the multiplication
+        # rationale (web3 + RotatingHTTPProvider retry loops). Threads
+        # are used (not processes) because the wrapped calls are I/O
+        # bound and share the ``EthereumApi`` cache above. Constructed
+        # lazily on first call so a deployment with ``use_offchain=False``
+        # never spins the pool up.
+        self._rpc_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         if self.params.use_offchain:
             self._initialise_offchain_verification_constants()
         self.start_prometheus_server()
         super().setup()
+
+    def _get_rpc_executor(self) -> concurrent.futures.ThreadPoolExecutor:
+        """Return the lazily-constructed on-path RPC executor.
+
+        Kept lazy so a deployment with the off-chain path disabled never
+        spins the pool up. The pool is used exclusively to bound the
+        wall-clock time of the two on-path RPCs (EIP-1271
+        ``isValidSignature`` and marketplace ``mapNonces``); balance
+        checks stay on the AEA main thread because they run through
+        their own longer-timeout ``EthereumApi``.
+
+        :return: the cached ``ThreadPoolExecutor`` instance.
+        """
+        if self._rpc_executor is None:
+            self._rpc_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=_RPC_EXECUTOR_MAX_WORKERS,
+                thread_name_prefix="mech-rpc-sigverify",
+            )
+        return self._rpc_executor
+
+    def _run_with_wall_clock_deadline(
+        self,
+        fn: Callable[[], Any],
+        deadline_seconds: float,
+    ) -> Any:
+        """Run ``fn`` on the RPC executor and enforce a wall-clock deadline.
+
+        Delegates the call to the dedicated ``ThreadPoolExecutor`` and
+        waits at most ``deadline_seconds`` for the result. On timeout
+        the underlying HTTP call keeps running in the worker thread but
+        this method raises ``concurrent.futures.TimeoutError`` so the
+        caller can return an infra verdict to the client and free the
+        AEA main thread to process the next message. Any exception the
+        wrapped call raises propagates to the caller so existing
+        exception handling (``TimeoutError`` from the EIP-1271 wrapper,
+        the broad ``except`` around the ``mapNonces`` read) keeps
+        working unchanged.
+
+        :param fn: zero-arg callable that performs the RPC.
+        :param deadline_seconds: wall-clock upper bound in seconds.
+        :return: whatever ``fn`` returns.
+        :raises concurrent.futures.TimeoutError: when the deadline
+            elapses before ``fn`` returns.
+        """
+        future = self._get_rpc_executor().submit(fn)
+        try:
+            return future.result(timeout=deadline_seconds)
+        except concurrent.futures.TimeoutError:
+            # Best-effort cancel: the underlying HTTP call can't be
+            # interrupted mid-flight, but the future is marked so the
+            # thread pool won't reuse the slot for the same callable if
+            # the call finally returns.
+            future.cancel()
+            raise
 
     def _get_ledger_api(
         self,
@@ -1419,7 +1533,10 @@ class MechHttpHandler(AbstractResponseHandler):
         # posted twice hashes to the same id, and any change to a signed
         # field would have produced a different id. Return 200 with a
         # note rather than a 409 so mech-client's idempotent-retry
-        # semantics are preserved on a genuine network retry.
+        # semantics are preserved on a genuine network retry. Dedup
+        # runs BEFORE the nonce-bind admission gate so a client that
+        # re-posts an already-delivered request still sees a 200 with
+        # ``REQUEST_ALREADY_ACCEPTED`` instead of a nonce mismatch.
         if self._is_duplicate_request(request_id):
             self.context.logger.info(
                 "Duplicate offchain request %s already known; returning 200 "
@@ -1434,6 +1551,56 @@ class MechHttpHandler(AbstractResponseHandler):
                     ResponseKey.STATUS.value: ResponseStatus.OK.value,
                     ResponseKey.REASON.value: REQUEST_ALREADY_ACCEPTED,
                 },
+            )
+            return
+
+        # Admission gate: bind the wire nonce to the sender's
+        # ``MechMarketplace.mapNonces`` counter combined with the live
+        # outstanding accepted-but-unsettled nonces for the same
+        # sender. This is where the contiguity requirement settlement
+        # imposes (``_deliverMarketplaceWithSignatures`` recomputes
+        # each request_id from its own ``nonce, nonce+1, ...`` counter
+        # and reverts the whole per-sender batch on the first mismatch)
+        # is enforced on the way in. Runs AFTER dedup so a genuine
+        # idempotent retry never reaches this branch. Also runs BEFORE
+        # the balance check so a nonce mismatch — which is a hard
+        # settlement-side rejection, not a transient state — short-
+        # circuits without an RPC round-trip for balance.
+        sender_checksum = self._resolve_sender_checksum(sender)
+        if sender_checksum is None:
+            # Sig-verify above already succeeded, so the checksum
+            # conversion should be deterministic; a failure here means
+            # ledger settings were reconfigured between the two calls
+            # (settings dict is rebuilt per call). Treat as an infra
+            # verdict so the caller retries.
+            self._send_rejection_response(
+                http_msg,
+                http_dialogue,
+                request_id,
+                reason=NONCE_READ_FAILED,
+                status_code=HttpCode.SERVICE_UNAVAILABLE_CODE.value,
+                status_text="Service unavailable",
+            )
+            return
+        nonce_verdict = self._bind_wire_nonce_to_chain(
+            sender_checksum=sender_checksum,
+            wire_nonce=request_nonce,
+            wire_request_id=request_id,
+        )
+        if not nonce_verdict.ok:
+            if nonce_verdict.is_infra:
+                status_code = HttpCode.SERVICE_UNAVAILABLE_CODE.value
+                status_text = "Service unavailable"
+            else:
+                status_code = HttpCode.UNAUTHORIZED_CODE.value
+                status_text = "Unauthorized"
+            self._send_rejection_response(
+                http_msg,
+                http_dialogue,
+                request_id,
+                reason=nonce_verdict.reason,
+                status_code=status_code,
+                status_text=status_text,
             )
             return
 
@@ -1515,6 +1682,8 @@ class MechHttpHandler(AbstractResponseHandler):
                 ipfs_hash=ipfs_hash,
                 request_delivery_rate=request_delivery_rate,
                 data=enqueue_data,
+                sender_checksum=sender_checksum,
+                wire_nonce=request_nonce,
             )
         except Exception as e:
             self.context.logger.error(
@@ -2036,8 +2205,26 @@ class MechHttpHandler(AbstractResponseHandler):
         encoded = base64.b64encode(json.dumps(receipt).encode(ENCODING_UTF8))
         return f"Payment-Receipt: {encoded.decode('ascii')}\n"
 
-    def _rollback_offchain_enqueue(self, request_id: str) -> None:
-        """Rollback a partial off-chain enqueue in case of unexpected failure."""
+    def _rollback_offchain_enqueue(
+        self,
+        request_id: str,
+        sender_checksum: Optional[str] = None,
+        wire_nonce: Optional[int] = None,
+    ) -> None:
+        """Rollback a partial off-chain enqueue in case of unexpected failure.
+
+        :param request_id: the wire-format request id whose partial
+            entries must be removed from the pending queue and the
+            in-memory buffer.
+        :param sender_checksum: the sender address in checksum form.
+            When supplied together with ``wire_nonce``, the wire nonce
+            is also removed from the sender's outstanding set so the
+            admission gate on subsequent accepts stays coherent with
+            the actual live queue. Optional so pre-existing callers
+            that did not track sender / nonce still work.
+        :param wire_nonce: the wire nonce recorded in the outstanding
+            set at enqueue time. See ``sender_checksum``.
+        """
         # The pending task's ``requestId`` is stored as ``int`` after the
         # ingress coercion in :meth:`_enqueue_offchain_request`; the local
         # ``request_id`` here is still the wire-format ``str`` used as the
@@ -2051,6 +2238,12 @@ class MechHttpHandler(AbstractResponseHandler):
             if req.get(RequestKey.REQUEST_ID_CAMEL.value) != target_id_int
         ]
         self.in_memory_requests.pop(request_id, None)
+        if sender_checksum is not None and wire_nonce is not None:
+            outstanding = self.outstanding_nonces_by_sender.get(sender_checksum)
+            if outstanding is not None:
+                outstanding.discard(wire_nonce)
+                if not outstanding:
+                    self.outstanding_nonces_by_sender.pop(sender_checksum, None)
         self.context.logger.error(
             f"Queue rollback applied for {request_id=}. "
             f"pending_tasks={len(self.pending_tasks)} "
@@ -2075,6 +2268,8 @@ class MechHttpHandler(AbstractResponseHandler):
         ipfs_hash: str,
         request_delivery_rate: int,
         data: Dict[str, Any],
+        sender_checksum: str,
+        wire_nonce: int,
     ) -> Dict[str, Any]:
         """Enqueue the off-chain task and buffer its request metadata locally.
 
@@ -2086,6 +2281,13 @@ class MechHttpHandler(AbstractResponseHandler):
             downstream lexicographic-vs-numeric sort discipline holds;
             the type is ``Dict[str, Any]`` (not ``Dict[str, str]``)
             because the coerced ``nonce`` is an ``int``.
+        :param sender_checksum: the sender address in checksum form.
+            Used to record the wire nonce in ``outstanding_nonces_by_sender``
+            so the admission gate on subsequent accepts from the same
+            sender computes the correct next-expected slot.
+        :param wire_nonce: the wire ``nonce`` (already coerced to
+            ``int`` and admitted by the nonce-bind gate). Recorded in
+            the outstanding set alongside the pending task.
         :return: the queued task dict.
         :raises Exception: if either queue write fails; partial state is rolled back.
         """
@@ -2176,8 +2378,20 @@ class MechHttpHandler(AbstractResponseHandler):
         try:
             self.pending_tasks.append(req)
             self.in_memory_requests[request_id] = data[RequestKey.IPFS_DATA.value]
+            # Track the wire nonce as live-outstanding for this sender
+            # so the admission gate on subsequent accepts computes the
+            # correct next-expected slot. ``setdefault`` avoids
+            # clobbering an existing set built by an earlier accept
+            # from the same sender.
+            self.outstanding_nonces_by_sender.setdefault(sender_checksum, set()).add(
+                wire_nonce
+            )
         except Exception:
-            self._rollback_offchain_enqueue(request_id)
+            self._rollback_offchain_enqueue(
+                request_id,
+                sender_checksum=sender_checksum,
+                wire_nonce=wire_nonce,
+            )
             raise
         # Buffer the request half of the durable preimage (no-op unless off-chain
         # preimage retention is enabled). The response half is added at
@@ -2489,12 +2703,7 @@ class MechHttpHandler(AbstractResponseHandler):
                 sender_checksum,
                 recovered,
             )
-            return self._bind_wire_nonce_to_chain(
-                ledger_api=ledger_api,
-                sender_checksum=sender_checksum,
-                wire_nonce=nonce,
-                wire_request_id=wire_request_id,
-            )
+            return SignatureVerdict(ok=True, reason="", is_infra=False)
         # Log the EOA branch outcome for auditability: recovery either
         # returned ``None`` (malformed / malleable / bad-v signature) or
         # yielded an address other than the declared sender. The
@@ -2518,14 +2727,22 @@ class MechHttpHandler(AbstractResponseHandler):
             rpc_address, chain_id, timeout_seconds=_EIP1271_CALL_TIMEOUT_SECONDS
         )
         try:
-            eip1271_ok = check_eip1271_signature(
-                ledger_api=eip1271_ledger_api,
-                contract_address=sender_checksum,
-                message_hash=derived,
-                signature=signature_bytes,
-                gas=_EIP1271_CALL_GAS_CAP,
+            # Wall-clock bound the call so a slow / hostile
+            # ``isValidSignature`` combined with the multiplying
+            # web3 + RotatingHTTPProvider retry loops cannot stall the
+            # AEA main thread past the http_server reply budget. See
+            # ``_RPC_WALL_CLOCK_DEADLINE_SECONDS``.
+            eip1271_ok = self._run_with_wall_clock_deadline(
+                lambda: check_eip1271_signature(
+                    ledger_api=eip1271_ledger_api,
+                    contract_address=sender_checksum,
+                    message_hash=derived,
+                    signature=signature_bytes,
+                    gas=_EIP1271_CALL_GAS_CAP,
+                ),
+                deadline_seconds=_RPC_WALL_CLOCK_DEADLINE_SECONDS,
             )
-        except TimeoutError as exc:
+        except (TimeoutError, concurrent.futures.TimeoutError) as exc:
             self.context.logger.warning(
                 "EIP-1271 isValidSignature timed out for sender %s on "
                 "request %s: %s.",
@@ -2546,17 +2763,11 @@ class MechHttpHandler(AbstractResponseHandler):
             )
         if eip1271_ok:
             self.context.logger.info(
-                "offchain_auth accepted request %s sender=%s "
-                "mechanism=eip1271",
+                "offchain_auth accepted request %s sender=%s mechanism=eip1271",
                 wire_request_id,
                 sender_checksum,
             )
-            return self._bind_wire_nonce_to_chain(
-                ledger_api=ledger_api,
-                sender_checksum=sender_checksum,
-                wire_nonce=nonce,
-                wire_request_id=wire_request_id,
-            )
+            return SignatureVerdict(ok=True, reason="", is_infra=False)
         return SignatureVerdict(
             ok=False,
             reason="signature verification failed",
@@ -2565,46 +2776,94 @@ class MechHttpHandler(AbstractResponseHandler):
 
     def _bind_wire_nonce_to_chain(
         self,
-        ledger_api: EthereumApi,
         sender_checksum: str,
         wire_nonce: int,
         wire_request_id: str,
     ) -> SignatureVerdict:
-        """Bind the wire ``nonce`` to ``MechMarketplace.mapNonces[sender]``.
+        """Admission gate: bind the wire ``nonce`` to the sender's next slot.
 
-        Reads the sender's current ``mapNonces`` counter from the
-        marketplace and compares against the wire value. A wire value
-        below the on-chain counter can never settle (the counter only
-        moves upward), and a wire value too far above the counter will
-        starve the sender's own settlement queue before it can drain
-        because settlement consumes ``mapNonces`` strictly in order.
-        Both outcomes reject with 401. A transport-level failure on
-        the read returns an infra verdict (503) rather than accepting
-        under an unknown nonce.
+        Reads ``MechMarketplace.mapNonces[sender]`` and combines the
+        result with the sender's live outstanding accepted-but-unsettled
+        nonces to compute the single next-expected slot:
+        ``on_chain + len(outstanding)``. This is the contiguity check
+        settlement's ``_deliverMarketplaceWithSignatures`` already
+        enforces on chain — it recomputes each request_id from its own
+        ``nonce, nonce+1, ...`` counter and reverts the whole per-sender
+        batch on the first mismatch. Admitting a request that skips a
+        slot would enqueue work that settlement is guaranteed to
+        revert, dragging every legitimately co-batched request down
+        with it.
 
-        :param ledger_api: cached ``EthereumApi`` used for the read.
+        Outcomes:
+
+        * ``wire == expected``: accept.
+        * ``wire < expected``: reject 401 (``NONCE_BELOW_EXPECTED``) —
+          the sender signed a nonce that settlement will never derive.
+        * ``wire > expected``: reject 503 (``NONCE_ABOVE_EXPECTED``,
+          ``is_infra=True``) — the sender is racing ahead of its own
+          in-flight queue; mech-client's 503 handling retries in the
+          next round.
+        * ``wire in outstanding``: reject 401 (``NONCE_BELOW_EXPECTED``,
+          identical routing to the "already sent" branch); a duplicate
+          submission of a pending nonce would enqueue a second task
+          under a request_id settlement cannot resolve.
+        * Read failure: reject 503 (``NONCE_READ_FAILED``,
+          ``is_infra=True``).
+
+        The read itself is wall-clock bounded through the on-path RPC
+        executor so a slow ``mapNonces`` read cannot stall the AEA main
+        loop past the ``http_server`` reply budget; the timeout branch
+        routes to the same infra verdict as any other read failure.
+
         :param sender_checksum: the sender address in checksum form.
         :param wire_nonce: the ``nonce`` supplied on the wire (already
             coerced to ``int`` and range-checked at ingress).
         :param wire_request_id: the wire request_id, for logging only.
         :return: a :class:`SignatureVerdict`. ``ok=True`` when the wire
-            nonce sits in ``[on_chain, on_chain + MAX_OUTSTANDING_NONCE_WINDOW]``;
-            ``ok=False`` (401) on out-of-window; ``ok=False`` with
-            ``is_infra=True`` (503) on read failure.
+            nonce equals the sender's next expected slot; ``ok=False``
+            with the appropriate reason and infra flag otherwise.
         """
+        ledger_settings = self._get_ledger_settings()
+        if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
+            # Sig-verify has already gated on the same settings above
+            # by the time this method runs, but a reconfiguration
+            # between the two calls (settings dict rebuilt per call) is
+            # possible in principle; treat it as an infra failure so
+            # the caller returns 503 and the request is retried.
+            self.context.logger.warning(
+                "Cannot bind wire nonce: ledger settings unavailable "
+                "(%s); rejecting request %s.",
+                ledger_settings.get(ResponseKey.REASON.value, "unknown"),
+                wire_request_id,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_READ_FAILED,
+                is_infra=True,
+            )
+        rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
+        chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
+        ledger_api = self._get_ledger_api(rpc_address, chain_id)
         try:
-            on_chain_result = MechMarketplaceContract.get_nonce(
-                ledger_api=ledger_api,
-                contract_address=self.params.mech_marketplace_address,
-                sender_address=sender_checksum,
+            # Wall-clock bound the read for the same reason as the
+            # EIP-1271 view above; see ``_RPC_WALL_CLOCK_DEADLINE_SECONDS``.
+            on_chain_result = self._run_with_wall_clock_deadline(
+                lambda: MechMarketplaceContract.get_nonce(
+                    ledger_api=ledger_api,
+                    contract_address=self.params.mech_marketplace_address,
+                    sender_address=sender_checksum,
+                ),
+                deadline_seconds=_RPC_WALL_CLOCK_DEADLINE_SECONDS,
             )
             on_chain_nonce = int(cast(int, on_chain_result.get(BodyKey.DATA.value, 0)))
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            # Transport, decode, or RPC error on the ``mapNonces`` read.
-            # Fail closed with an infra verdict so the caller returns
-            # 503 and a well-behaved client retries; accepting under an
-            # unknown nonce would let a wire value that settlement will
-            # later reject enqueue a task the operator pays to run.
+            # Transport, decode, RPC error, or wall-clock deadline on
+            # the ``mapNonces`` read. Fail closed with an infra verdict
+            # so the caller returns 503 and a well-behaved client
+            # retries; accepting under an unknown nonce would let a
+            # wire value that settlement will later reject enqueue a
+            # task the operator pays to run. ``concurrent.futures.TimeoutError``
+            # is a subclass of ``Exception``, so it lands here as well.
             self.context.logger.warning(
                 "mapNonces read failed for sender %s on request %s: %s.",
                 sender_checksum,
@@ -2616,36 +2875,93 @@ class MechHttpHandler(AbstractResponseHandler):
                 reason=NONCE_READ_FAILED,
                 is_infra=True,
             )
-        if wire_nonce < on_chain_nonce:
+        # Combine the on-chain counter with the live outstanding set
+        # for this sender to compute the single next-expected slot.
+        # Missing key = no in-flight requests from this sender.
+        outstanding = self.outstanding_nonces_by_sender.get(sender_checksum, set())
+        expected_next_nonce = on_chain_nonce + len(outstanding)
+        if wire_nonce in outstanding:
+            # Duplicate of a pending nonce. Reject the same way as a
+            # stale wire value: settlement cannot derive the same
+            # request_id twice for the same sender, and accepting the
+            # duplicate would enqueue a second task under a request_id
+            # settlement guarantees to revert.
             self.context.logger.warning(
-                "Wire nonce %d below on-chain mapNonces %d for sender %s "
-                "on request %s.",
+                "Wire nonce %d already outstanding for sender %s on request %s "
+                "(expected next %d, outstanding=%d).",
                 wire_nonce,
-                on_chain_nonce,
                 sender_checksum,
                 wire_request_id,
+                expected_next_nonce,
+                len(outstanding),
             )
             return SignatureVerdict(
                 ok=False,
-                reason=NONCE_BELOW_CHAIN,
+                reason=NONCE_BELOW_EXPECTED,
                 is_infra=False,
             )
-        if wire_nonce > on_chain_nonce + MAX_OUTSTANDING_NONCE_WINDOW:
+        if wire_nonce < expected_next_nonce:
             self.context.logger.warning(
-                "Wire nonce %d exceeds on-chain mapNonces %d by more than "
-                "the allowed window %d for sender %s on request %s.",
+                "Wire nonce %d below expected next slot %d for sender %s on "
+                "request %s (on_chain=%d, outstanding=%d).",
                 wire_nonce,
-                on_chain_nonce,
-                MAX_OUTSTANDING_NONCE_WINDOW,
+                expected_next_nonce,
                 sender_checksum,
                 wire_request_id,
+                on_chain_nonce,
+                len(outstanding),
             )
             return SignatureVerdict(
                 ok=False,
-                reason=NONCE_ABOVE_WINDOW,
+                reason=NONCE_BELOW_EXPECTED,
                 is_infra=False,
+            )
+        if wire_nonce > expected_next_nonce:
+            self.context.logger.warning(
+                "Wire nonce %d above expected next slot %d for sender %s on "
+                "request %s (on_chain=%d, outstanding=%d).",
+                wire_nonce,
+                expected_next_nonce,
+                sender_checksum,
+                wire_request_id,
+                on_chain_nonce,
+                len(outstanding),
+            )
+            # 503 (is_infra=True) — the sender is racing its own
+            # in-flight queue. mech-client retries 503 in the next
+            # round, so the earlier requests get a chance to drain and
+            # the same body settles when the slot opens.
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_ABOVE_EXPECTED,
+                is_infra=True,
             )
         return SignatureVerdict(ok=True, reason="", is_infra=False)
+
+    def _resolve_sender_checksum(self, sender: str) -> Optional[str]:
+        """Return the sender's checksum address using the cached ledger api.
+
+        Extracted from the sig-verify path so the caller in
+        ``_handle_signed_requests`` can compute the checksum once for
+        both the dedup key (unchanged) and the outstanding-nonces
+        admission gate. Returns ``None`` on a failed checksum
+        conversion; the caller treats that identically to a failed
+        sig-verify because settlement would 401 the sender at the same
+        step later.
+
+        :param sender: the raw sender string from the wire body.
+        :return: the checksum-cased address, or ``None`` on failure.
+        """
+        ledger_settings = self._get_ledger_settings()
+        if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
+            return None
+        try:
+            rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
+            chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
+            ledger_api = self._get_ledger_api(rpc_address, chain_id)
+            return cast(str, ledger_api.api.to_checksum_address(sender))
+        except Exception:  # pylint: disable=broad-exception-caught
+            return None
 
     def _get_ledger_settings(self) -> Dict[str, Union[str, int]]:
         """Read ledger RPC settings from skill params using default_chain_id."""

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -27,12 +27,14 @@ import time
 import urllib.parse
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, NamedTuple, Optional, Union, cast
 
 from aea.protocols.base import Message
 from aea.skills.base import Handler
 from aea_ledger_ethereum import EthereumApi
 from prometheus_client import start_http_server
+from requests.exceptions import RequestException
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
 
 from packages.valory.connections.ledger.connection import (
     PUBLIC_ID as LEDGER_CONNECTION_PUBLIC_ID,
@@ -54,7 +56,6 @@ from packages.valory.skills.task_execution.utils.eip1271 import (
     check_eip1271_signature,
     get_marketplace_domain_separator,
     get_marketplace_request_id_view,
-    get_mech_payment_type,
 )
 from packages.valory.skills.task_execution.utils.ipfs import to_multihash
 from packages.valory.skills.task_execution.utils.local_cid import compute_cidv1
@@ -132,6 +133,27 @@ MAX_REQUEST_ID = 2**256 - 1
 NONCE_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
 MAX_NONCE = 2**256 - 1
 
+# ``signature`` on the wire is the hex encoding of the packed signature
+# bytes with a mandatory ``0x`` prefix. The settlement path
+# (``task_submission_abci.behaviours``) does an unconditional
+# ``bytes.fromhex(sig[2:])`` when it packs the on-chain payload; a
+# body sent without the ``0x`` would have its first hex byte silently
+# truncated there. The lower bound is 65 bytes for a canonical
+# secp256k1 signature; the upper bound is generous so multi-signer
+# Safe EIP-1271 payloads (n * 65 bytes plus contract signature data)
+# fit while capping payload growth to a fixed constant. The alphabet
+# is case-insensitive hex and the length is always even
+# (``bytes.fromhex`` would otherwise raise on the settlement path).
+SIGNATURE_BYTES_MIN = 65
+SIGNATURE_BYTES_MAX = 2048
+SIGNATURE_RE = re.compile(
+    r"\A0x(?:[0-9a-fA-F]{2}){"
+    + str(SIGNATURE_BYTES_MIN)
+    + ","
+    + str(SIGNATURE_BYTES_MAX)
+    + r"}\Z"
+)
+
 # Boot-time self-check inputs for the marketplace ``getRequestId`` view
 # vs the local ``compute_request_id`` reimplementation. Any well-formed
 # tuple is fine because we compare two bytes32 outputs, not the
@@ -144,17 +166,22 @@ _SELFCHECK_REQUEST_DATA = b"\x00" * 32
 _SELFCHECK_DELIVERY_RATE = 1
 _SELFCHECK_NONCE = 0
 
-# Sentinel rejection reason surfaced when the boot-time self-check
-# between the marketplace ``getRequestId`` view and the local
-# ``compute_request_id`` disagrees. Every subsequent offchain accept
-# 401s with this reason so operators can grep the log line to the
-# corresponding fatal at boot.
-MARKETPLACE_VERIFICATION_FAILED = "marketplace-verification-failed"
-
 # Rejection reason for a body whose local CID does not match the
 # posted ``ipfs_hash``: the request would enqueue arbitrary work under
 # a signature that authorised different content.
 IPFS_HASH_BODY_MISMATCH = "ipfs_hash does not match ipfs_data content"
+
+# Rejection reason for a body whose ``ipfs_data`` exceeds the 256 KiB
+# single-block CID bound (``compute_cidv1`` raises above it). Distinct
+# from ``IPFS_HASH_BODY_MISMATCH`` so a caller can tell a size overflow
+# apart from a genuine content-hash disagreement.
+IPFS_DATA_OVERSIZE = "ipfs_data exceeds the single-block CID bound"
+
+# Single-block CID bound (256 KiB). Mirrors ``local_cid._MAX_BLOCK_BYTES``
+# and is used to range-check ``ipfs_data`` before ``compute_cidv1`` is
+# called so an oversize body surfaces as ``IPFS_DATA_OVERSIZE`` (accept
+# rejection) rather than a misleading CID-mismatch reason.
+MAX_IPFS_DATA_BYTES = 256 * 1024
 
 # Reason surfaced on the idempotent-retry response (HTTP 200) when the
 # handler already knows the ``request_id`` from the pending queue, the
@@ -244,6 +271,23 @@ PAYMENT_SCHEME = "olas-prepay"
 DEPOSIT_FN_ABI = "depositFor(address requester, uint256 amount)"
 SETTLEMENT_STATUS_PENDING = "pending"
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+class SignatureVerdict(NamedTuple):
+    """Outcome of ``_verify_offchain_request_signature``.
+
+    ``is_infra`` distinguishes verification failures caused by our
+    side (boot constants unset, ledger settings missing, address
+    preparation failure) from a genuinely bad caller signature. The
+    caller routes ``is_infra=True`` outcomes to a 503 ("try again
+    later") so a well-behaved client backs off instead of giving up
+    on the assumption its credentials are wrong; ``is_infra=False``
+    outcomes stay 401 ("unauthorized").
+    """
+
+    ok: bool
+    reason: str
+    is_infra: bool
 
 
 class BaseHandler(Handler):
@@ -970,10 +1014,20 @@ class MechHttpHandler(AbstractResponseHandler):
                 ledger_api=ledger_api,
                 marketplace_address=self.params.mech_marketplace_address,
             )
-            self._payment_type = get_mech_payment_type(
-                ledger_api=ledger_api,
-                mech_address=self._marketplace_mech_address,
+            # Read the mech ``paymentType`` through the packaged
+            # ``OlasMechContract`` wrapper (same selector,
+            # ``paymentType()``, same ``bytes32`` return) so this
+            # module does not carry a second ABI fragment for the
+            # same view.
+            payment_type_res = OlasMechContract.get_mech_type(
+                ledger_api, self._marketplace_mech_address
             )
+            payment_type_raw = payment_type_res.get(BodyKey.MECH_TYPE.value)
+            self._payment_type = bytes(cast(bytes, payment_type_raw))
+            if len(self._payment_type) != 32:
+                raise ValueError(
+                    f"payment_type length is {len(self._payment_type)}, expected 32"
+                )
             self.context.logger.info(
                 "Offchain verification constants loaded: "
                 "domain_separator=0x%s payment_type=0x%s",
@@ -996,12 +1050,18 @@ class MechHttpHandler(AbstractResponseHandler):
         Calls the marketplace ``getRequestId`` view with fixed dummy inputs
         and compares its bytes32 output with ``compute_request_id`` run on
         the same inputs and the boot-cached ``domain_separator`` and
-        ``payment_type``. On mismatch: log a fatal-level error, flip the
-        boot-cached constants to ``None`` (so every subsequent
-        offchain accept 401s with ``marketplace-verification-failed``),
-        and return without raising. The mismatch is an operational signal;
-        crashing the mech process on a marketplace upgrade would be more
-        disruptive than the accept refusal.
+        ``payment_type``. Outcomes:
+
+        - On value mismatch (or a genuine contract revert / decode
+          error): treat as a real incompat, flip the boot-cached
+          constants to ``None`` (subsequent accepts route to 503 via
+          the sig-verify infra branch), and log fatal-level.
+        - On a transport failure (RPC unreachable, timeout, socket
+          error): leave the constants loaded so a transient blip does
+          not permanently disable the endpoint. The sig-verify path's
+          own EIP-1271 call will hit the same RPC on the next request;
+          if it stays down, per-request 503s and standard alerts fire
+          without the boot handler locking the endpoint open-loop.
 
         :param ledger_api: the ledger API object used for the view call.
         """
@@ -1033,14 +1093,25 @@ class MechHttpHandler(AbstractResponseHandler):
                 nonce=_SELFCHECK_NONCE,
                 domain_separator=self._domain_separator,
             )
-        except Exception:  # pylint: disable=broad-exception-caught
-            # Any failure here — RPC unreachable, contract revert,
-            # local derivation raising — leaves the constants unset so
-            # the accept path 401s with a clear reason instead of
-            # trusting a derivation we could not confirm.
+        except (RequestException, TimeoutError, Web3RPCError):
+            # Transport-level failure: leave the constants loaded so a
+            # transient RPC blip does not permanently disable the
+            # endpoint. Per-request sig verification will re-attempt
+            # against the same RPC.
+            self.context.logger.warning(
+                "Marketplace request-id self-check hit a transport error; "
+                "keeping the boot-cached constants and continuing.",
+                exc_info=True,
+            )
+            return
+        except (ContractLogicError, BadFunctionCallOutput, ValueError):
+            # Genuine incompat: a revert, an undecodable return, or the
+            # local derivation raising. Flip the constants off so
+            # subsequent accepts refuse with a clear infra-side reason.
             self.context.logger.exception(
-                "Marketplace request-id self-check failed; disabling "
-                "offchain accepts until the next restart."
+                "Marketplace request-id self-check failed with a "
+                "contract-level error; disabling offchain accepts "
+                "until the next restart."
             )
             self._domain_separator = None
             self._payment_type = None
@@ -1125,67 +1196,17 @@ class MechHttpHandler(AbstractResponseHandler):
             return
 
         # ``request_id`` on the wire is the decimal encoding of the uint256
-        # marketplace ``getRequestId`` return, so it must be canonical ASCII
-        # decimal (see ``REQUEST_ID_RE``) AND fit in uint256. Validate here
-        # alongside the other body-shape checks so a non-canonical id is
-        # rejected with a specific log line rather than surfacing later as
-        # an opaque ``ValueError`` inside :meth:`_enqueue_offchain_request`'s
-        # ``int(request_id)`` coercion, or — worse — passing coercion via
-        # ``int('๔๒')`` and desynchronising the writer's
-        # ``str(int(request_id))`` key from the wire ``request_id``.
-        # ``fullmatch`` (vs ``match``) rejects a trailing ``\n`` that ``$``
-        # would let through — see ``REQUEST_ID_RE`` docstring.
-        if not REQUEST_ID_RE.fullmatch(request_id or ""):
-            self.context.logger.error(
-                f"Rejecting offchain request {request_id!r}: "
-                f"request_id must be a canonical ASCII decimal "
-                f"(len={len(request_id) if request_id else 0})."
-            )
+        # marketplace ``getRequestId`` return; ``nonce`` is the decimal
+        # encoding of the requester's uint256 ``mapNonces`` counter at
+        # signing time. Both must be canonical ASCII decimals inside the
+        # uint256 upper bound — validated by the shared helper below so
+        # the two call sites stay in lock-step. See the helper's
+        # docstring for the rationale on the alphabet regex plus the
+        # length short-circuit before ``int()``.
+        if not self._reject_unless_uint256_decimal(request_id, "request_id"):
             self._handle_bad_request(http_msg, http_dialogue)
             return
-        # Regex constrains the alphabet; the magnitude has to be checked
-        # separately. The length branch MUST short-circuit before the
-        # ``int()`` call: on CPython 3.11+, ``int()`` on a string longer
-        # than ``sys.get_int_max_str_digits()`` (4300 by default) raises
-        # ``ValueError`` — a 5000-digit canonical decimal would pass
-        # ``fullmatch`` but blow up here, outside any ``try/except``, and
-        # bypass this handler's own 400 return. ``len(str(MAX_REQUEST_ID))``
-        # is 78, well under the CPython cap, so the length branch is the
-        # cheap guard that makes the value branch safe. Rejecting a
-        # >uint256 id here matches the range check
-        # ``request_delivery_rate`` already gets below.
-        if (
-            len(request_id) > len(str(MAX_REQUEST_ID))
-            or int(request_id) > MAX_REQUEST_ID
-        ):
-            self.context.logger.error(
-                f"Rejecting offchain request {request_id!r}: "
-                f"request_id exceeds uint256 upper bound "
-                f"(MAX_REQUEST_ID={MAX_REQUEST_ID})."
-            )
-            self._handle_bad_request(http_msg, http_dialogue)
-            return
-
-        # ``nonce`` gets the same treatment as ``request_id``: canonical
-        # ASCII decimal + uint256 magnitude. The alphabet regex catches
-        # ``"9abc"`` and empty strings; the uint256 bound catches
-        # ``2**256`` and the length short-circuit stops
-        # ``ValueError`` from firing at ``int()`` for pathological input
-        # lengths. Rejects negatives (``\A-`` never matches ``NONCE_RE``)
-        # so ``int(nonce)`` downstream is guaranteed a non-negative int.
-        if not NONCE_RE.fullmatch(wire_nonce or ""):
-            self.context.logger.error(
-                f"Rejecting offchain request {request_id}: "
-                f"nonce must be a canonical ASCII decimal "
-                f"(nonce={wire_nonce!r})."
-            )
-            self._handle_bad_request(http_msg, http_dialogue)
-            return
-        if len(wire_nonce) > len(str(MAX_NONCE)) or request_nonce > MAX_NONCE:
-            self.context.logger.error(
-                f"Rejecting offchain request {request_id}: "
-                f"nonce exceeds uint256 upper bound (nonce={wire_nonce})."
-            )
+        if not self._reject_unless_uint256_decimal(wire_nonce, "nonce"):
             self._handle_bad_request(http_msg, http_dialogue)
             return
 
@@ -1193,6 +1214,26 @@ class MechHttpHandler(AbstractResponseHandler):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id}: invalid ipfs_hash "
                 f"format (len={len(ipfs_hash)})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+
+        # ``signature`` on the wire is the one signed field with no format
+        # guard at the parser layer. The settlement path does an
+        # unconditional ``bytes.fromhex(sig[2:])`` when packing the
+        # on-chain payload; a body without the mandatory ``0x`` prefix
+        # would have its first hex byte silently truncated there, the
+        # marketplace would revert with ``IncorrectSignatureLength``, and
+        # the whole per-sender batch would be dropped. Validate the
+        # format alongside the other body-shape checks so a
+        # missing-prefix or bad-hex signature 400s at ingress rather
+        # than surfacing as an on-chain revert at settlement time.
+        if not SIGNATURE_RE.fullmatch(signature_hex or ""):
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id}: signature must be "
+                f"a 0x-prefixed even-length hex string within "
+                f"[{SIGNATURE_BYTES_MIN}, {SIGNATURE_BYTES_MAX}] bytes "
+                f"(len={len(signature_hex) if signature_hex else 0})."
             )
             self._handle_bad_request(http_msg, http_dialogue)
             return
@@ -1215,8 +1256,8 @@ class MechHttpHandler(AbstractResponseHandler):
 
         # Verify the request signature before charging the requester's balance.
         # EIP-1271 for Safe senders, plain ecrecover for EOAs. Sequential by
-        # design: a failure here 401s before the balance-check RPC runs.
-        sig_ok = self._verify_offchain_request_signature(
+        # design: a failure here rejects before the balance-check RPC runs.
+        sig_verdict = self._verify_offchain_request_signature(
             sender=sender,
             ipfs_hash=ipfs_hash,
             delivery_rate=request_delivery_rate,
@@ -1224,19 +1265,32 @@ class MechHttpHandler(AbstractResponseHandler):
             wire_request_id=request_id,
             signature_hex=signature_hex,
         )
-        if not sig_ok:
-            # Pre-auth 401: do NOT persist a rejection payload keyed by
-            # the caller-supplied ``request_id`` — a caller could
-            # otherwise poison an arbitrary id that a legitimate caller
-            # would later read via the polling endpoint. See
+        if not sig_verdict.ok:
+            # Route infra-side failures (boot constants unset, ledger
+            # settings missing, address preparation failure) to 503 so a
+            # well-behaved client backs off and retries instead of
+            # concluding its credentials are wrong. Bad-caller
+            # signatures still 401.
+            #
+            # Pre-auth: do NOT persist a rejection payload keyed by
+            # the caller-supplied ``request_id`` on either branch — a
+            # caller could otherwise poison an arbitrary id that a
+            # legitimate caller would later read via the polling
+            # endpoint. See
             # ``_send_rejection_response(record_response=...)``.
+            if sig_verdict.is_infra:
+                status_code = HttpCode.SERVICE_UNAVAILABLE_CODE.value
+                status_text = "Service unavailable"
+            else:
+                status_code = HttpCode.UNAUTHORIZED_CODE.value
+                status_text = "Unauthorized"
             self._send_rejection_response(
                 http_msg,
                 http_dialogue,
                 request_id,
-                reason="signature verification failed",
-                status_code=HttpCode.UNAUTHORIZED_CODE.value,
-                status_text="Unauthorized",
+                reason=sig_verdict.reason,
+                status_code=status_code,
+                status_text=status_text,
             )
             return
 
@@ -1247,7 +1301,7 @@ class MechHttpHandler(AbstractResponseHandler):
         # the mech executes body Y. Re-derive the CID over the bytes
         # the mech will actually run and reject the request outright
         # if it does not equal the posted ``ipfs_hash``.
-        cid_bind_ok = self._verify_ipfs_hash_binding(
+        cid_bind_ok, cid_reject_reason = self._verify_ipfs_hash_binding(
             request_id=request_id,
             ipfs_hash=ipfs_hash,
             ipfs_data=data.get(RequestKey.IPFS_DATA.value, ""),
@@ -1257,7 +1311,7 @@ class MechHttpHandler(AbstractResponseHandler):
                 http_msg,
                 http_dialogue,
                 request_id,
-                reason=IPFS_HASH_BODY_MISMATCH,
+                reason=cid_reject_reason,
                 status_code=HttpCode.BAD_REQUEST_CODE.value,
                 status_text="Bad request",
             )
@@ -1351,14 +1405,20 @@ class MechHttpHandler(AbstractResponseHandler):
         # would fall back to lexicographic order (``"10"`` before
         # ``"9"``) and mis-order the batch against the on-chain
         # ``mapNonces`` array consume.
-        data[RequestKey.NONCE.value] = request_nonce  # type: ignore[assignment]
+        # Copy at the call site rather than mutating in place: the
+        # parsed body is typed ``Dict[str, str]`` and other consumers
+        # (``preimage_buffer.record_accept``) read the same dict; a
+        # spread copy keeps the source dict immutable and lets the
+        # enqueue accept the wider ``Dict[str, Any]`` type without a
+        # ``type: ignore``.
+        enqueue_data = {**data, RequestKey.NONCE.value: request_nonce}
 
         try:
             req = self._enqueue_offchain_request(
                 request_id=request_id,
                 ipfs_hash=ipfs_hash,
                 request_delivery_rate=request_delivery_rate,
-                data=data,
+                data=enqueue_data,
             )
         except Exception as e:
             self.context.logger.error(
@@ -1393,13 +1453,60 @@ class MechHttpHandler(AbstractResponseHandler):
             )
             self._send_internal_error(http_msg, http_dialogue, request_id)
 
+    def _reject_unless_uint256_decimal(self, value: str, name: str) -> bool:
+        """Return True iff ``value`` is a canonical ASCII decimal in uint256.
+
+        Combined alphabet + magnitude guard for the two wire fields
+        the handler treats as uint256 decimals (``request_id`` and
+        ``nonce``). The alphabet regex catches ``"9abc"``, empty
+        strings, leading zeros, Unicode digits (``๙``, ``٩``,
+        superscripts), and any string ``int()`` would happily coerce
+        to a value that doesn't round-trip via ``str(int(x)) == x``.
+        The uint256 range check catches ``2**256``. The length check
+        MUST short-circuit before ``int(value)``: on CPython 3.11+,
+        ``int()`` on a string longer than
+        ``sys.get_int_max_str_digits()`` (4300 by default) raises
+        ``ValueError`` — a 5000-digit canonical decimal would pass
+        ``fullmatch`` but blow up here, outside any try/except, and
+        bypass the caller's own 400 return. ``len(str(2**256-1))`` is
+        78, well under the CPython cap, so the length branch is the
+        cheap guard that makes the value branch safe.
+
+        Emits a specific error log naming ``name`` on rejection so
+        operators can attribute a 400 to the right field.
+
+        :param value: the wire-format value being validated. May be
+            ``None``/empty; the alphabet regex rejects both.
+        :param name: the wire field name for the rejection log line.
+        :return: True on a canonical uint256 decimal; False otherwise.
+        """
+        # ``str(2**256 - 1)`` is 78 chars; both request_id and nonce
+        # share the same magnitude bound. Kept as a single check
+        # instead of parametrising on ``MAX_REQUEST_ID`` vs
+        # ``MAX_NONCE`` because the two are numerically identical and
+        # any drift would be a spec regression, not a design change.
+        max_len = len(str(MAX_REQUEST_ID))
+        if not value or not REQUEST_ID_RE.fullmatch(value):
+            self.context.logger.error(
+                f"Rejecting offchain request: {name} must be a canonical "
+                f"ASCII decimal ({name}={value!r})."
+            )
+            return False
+        if len(value) > max_len or int(value) > MAX_REQUEST_ID:
+            self.context.logger.error(
+                f"Rejecting offchain request: {name} exceeds uint256 upper "
+                f"bound ({name}={value})."
+            )
+            return False
+        return True
+
     def _verify_ipfs_hash_binding(
         self,
         request_id: str,
         ipfs_hash: str,
         ipfs_data: str,
-    ) -> bool:
-        """Return True iff the local CID of ``ipfs_data`` matches ``ipfs_hash``.
+    ) -> "tuple[bool, str]":
+        """Return (True, "") iff the local CID of ``ipfs_data`` matches ``ipfs_hash``.
 
         The trader signs a ``request_id`` derived from ``keccak(ipfs_hash)``
         where ``ipfs_hash`` is the on-chain content commitment. The
@@ -1415,7 +1522,9 @@ class MechHttpHandler(AbstractResponseHandler):
         ``to_multihash`` on the locally-derived CID) or 34 bytes
         (SHA-256 multihash prefix ``0x1220`` + 32-byte digest, 68 hex
         chars). Both forms reduce to the same 32-byte digest for the
-        compare; the multihash prefix is stripped when present.
+        compare; the multihash prefix is stripped only from the 68-char
+        form (a bare 64-char digest whose bytes happen to start with
+        ``1220`` is content, not a prefix).
 
         :param request_id: the caller-supplied off-chain request id
             (used only for the log line).
@@ -1423,8 +1532,11 @@ class MechHttpHandler(AbstractResponseHandler):
             signed body, already ``IPFS_HASH_RE``-validated.
         :param ipfs_data: the raw request-metadata JSON string carried
             inline in the signed body under ``ipfs_data``.
-        :return: True on match; False on any mismatch (empty body,
-            oversize body, digest mismatch).
+        :return: ``(True, "")`` on match; ``(False, reason)`` on
+            rejection, where ``reason`` is one of
+            ``IPFS_HASH_BODY_MISMATCH`` (empty body or digest
+            disagreement) or ``IPFS_DATA_OVERSIZE`` (body over the
+            single-block CID bound).
         """
         if not ipfs_data:
             self.context.logger.error(
@@ -1432,27 +1544,47 @@ class MechHttpHandler(AbstractResponseHandler):
                 "cannot re-derive the CID for the binding check.",
                 request_id,
             )
-            return False
+            return False, IPFS_HASH_BODY_MISMATCH
+        encoded_body = ipfs_data.encode(ENCODING_UTF8)
+        # Range-check the encoded body before ``compute_cidv1`` so an
+        # oversize body surfaces as a distinct rejection reason
+        # (``IPFS_DATA_OVERSIZE``) instead of being folded into the
+        # ``ValueError`` catch below alongside actual CID-mismatch
+        # cases. The 256 KiB single-block bound applies to the encoded
+        # bytes, not the source string length.
+        if len(encoded_body) > MAX_IPFS_DATA_BYTES:
+            self.context.logger.error(
+                "Rejecting offchain request %s: ipfs_data length %d bytes "
+                "exceeds the single-block CID bound (%d bytes).",
+                request_id,
+                len(encoded_body),
+                MAX_IPFS_DATA_BYTES,
+            )
+            return False, IPFS_DATA_OVERSIZE
         try:
-            local_cid = compute_cidv1(ipfs_data.encode(ENCODING_UTF8))
+            local_cid = compute_cidv1(encoded_body)
         except ValueError:
-            # ``compute_cidv1`` raises above the single-block bound
-            # (256 KiB). Reject with the same reason as a hash mismatch
-            # rather than 500: an oversize body is an accept-time
-            # rejection, not a server error.
+            # Reachable only via ``local_cid._varint`` (rejects negative
+            # sizes it does not see today because the size guard above
+            # short-circuits first). Kept as a defensive fallback so a
+            # future ``compute_cidv1`` refactor cannot silently 500 on
+            # an accept-time input.
             self.context.logger.exception(
-                "Rejecting offchain request %s: ipfs_data exceeds the "
-                "single-block CID bound.",
+                "Rejecting offchain request %s: local CID derivation "
+                "raised ValueError; treating as a content-hash mismatch.",
                 request_id,
             )
-            return False
+            return False, IPFS_HASH_BODY_MISMATCH
         local_digest_hex = to_multihash(local_cid)
         # Strip a leading ``0x`` (guaranteed by ``IPFS_HASH_RE``) and,
-        # if the caller sent the 34-byte multihash form, the ``1220``
-        # SHA-256 function-code + digest-length prefix. Both forms
-        # collapse to the 64-hex-char raw digest for the compare.
+        # only for the 68-char multihash form, the ``1220`` SHA-256
+        # function-code + digest-length prefix. The 64-char bare-digest
+        # form is left as-is: a bare digest whose bytes happen to start
+        # with ``1220`` is content, not a wrapper, and stripping four
+        # chars there would deterministically break every valid payload
+        # whose digest starts with that nibble sequence.
         posted_hex = ipfs_hash[2:]
-        if posted_hex.startswith(IPFS_HASH_MULTIHASH_PREFIX):
+        if len(posted_hex) == 68 and posted_hex.startswith(IPFS_HASH_MULTIHASH_PREFIX):
             posted_hex = posted_hex[len(IPFS_HASH_MULTIHASH_PREFIX) :]
         # Case-fold: ``IPFS_HASH_RE`` accepts both cases; ``to_multihash``
         # returns lowercase. Compare lowercase to lowercase.
@@ -1464,11 +1596,11 @@ class MechHttpHandler(AbstractResponseHandler):
                 local_digest_hex,
                 ipfs_hash,
             )
-            return False
-        return True
+            return False, IPFS_HASH_BODY_MISMATCH
+        return True, ""
 
     def _is_duplicate_request(self, request_id: str) -> bool:
-        """Return True iff ``request_id`` is already known to the handler.
+        """Return True iff ``request_id`` is already in an accepted state.
 
         Trace of the off-chain request lifecycle:
 
@@ -1480,23 +1612,34 @@ class MechHttpHandler(AbstractResponseHandler):
            entry is present through every intermediate state (pending
            list, ``_executing_task`` attribute).
         3. ``offchain_request_responses[str(request_id)]`` is populated
-           at settlement (delivered) and at post-auth rejection
+           at settlement (delivered), on 402 challenges (pre-enqueue,
+           the caller must retry after depositing), on defensive 500
+           responses (post-auth), and on post-auth rejection
            (``_record_offchain_failure``).
 
-        Union of the two dicts therefore covers every state a caller
-        might retry into (pending, executing, delivered, rejected).
-        Keys on both sides are ``str``; the wire ``request_id`` is
-        also ``str`` after the ``REQUEST_ID_RE`` guard, so no coercion
-        is needed for the lookup.
+        Only settled entries — those whose ``status`` is not
+        ``REJECTED`` — count as "already accepted" for dedup. A stored
+        rejection means the request was NOT enqueued, so the retry
+        that follows a 402 deposit (mech-client's ``auto_deposit`` path
+        re-posts the identical body) must not be short-circuited into
+        an ``already accepted`` reply that never runs the balance
+        check. Keys on both sides are ``str``; the wire ``request_id``
+        is also ``str`` after the ``REQUEST_ID_RE`` guard, so no
+        coercion is needed for the lookup.
 
         :param request_id: the wire-format request id (already
             ``REQUEST_ID_RE``-validated and inside the uint256 bound).
-        :return: True if the id is present in either in-memory dict.
+        :return: True if the id is present in ``in_memory_requests``
+            (pending or executing), or the ``offchain_request_responses``
+            entry for it is a settled/accepted payload rather than a
+            rejection.
         """
-        return (
-            request_id in self.in_memory_requests
-            or request_id in self.offchain_request_responses
-        )
+        if request_id in self.in_memory_requests:
+            return True
+        stored = self.offchain_request_responses.get(request_id)
+        if stored is None:
+            return False
+        return stored.get(ResponseKey.STATUS.value) != ResponseStatus.REJECTED.value
 
     def _handle_offchain_request_info(
         self, http_msg: HttpMessage, http_dialogue: HttpDialogue
@@ -1753,9 +1896,13 @@ class MechHttpHandler(AbstractResponseHandler):
         """Build the ``WWW-Authenticate`` header line for a 402 response.
 
         :return: a single header line terminated with newline.
-        :raises ValueError: if no marketplace mech is configured; without
-            it the ``realm`` would be blank and clients could not route
-            the deposit to the right balance tracker.
+        :raises ValueError: defensive-only. The 402 branch that calls
+            this is only reached after ``_check_offchain_requester_balance``
+            returned OK, and that method returns ``UNAVAILABLE`` when
+            ``_marketplace_mech_address is None`` — so the guard below
+            is unreachable on today's paths. Kept so a future refactor
+            that widens the balance-check contract cannot silently emit
+            a blank-realm challenge.
         """
         # The ``realm`` carries the mech address so clients with multiple mechs
         # configured can route the deposit to the right balance tracker.
@@ -1831,14 +1978,18 @@ class MechHttpHandler(AbstractResponseHandler):
         request_id: str,
         ipfs_hash: str,
         request_delivery_rate: int,
-        data: Dict[str, str],
+        data: Dict[str, Any],
     ) -> Dict[str, Any]:
         """Enqueue the off-chain task and buffer its request metadata locally.
 
         :param request_id: the off-chain request id.
         :param ipfs_hash: the requester-supplied content hash (0x-prefixed hex).
         :param request_delivery_rate: the requester-signed delivery rate.
-        :param data: the parsed HTTP body dict (signature, sender, ipfs_data, etc).
+        :param data: the request-body dict. Caller passes a copy of the
+            parsed HTTP body with ``nonce`` coerced to ``int`` so the
+            downstream lexicographic-vs-numeric sort discipline holds;
+            the type is ``Dict[str, Any]`` (not ``Dict[str, str]``)
+            because the coerced ``nonce`` is an ``int``.
         :return: the queued task dict.
         :raises Exception: if either queue write fails; partial state is rolled back.
         """
@@ -2079,17 +2230,18 @@ class MechHttpHandler(AbstractResponseHandler):
         nonce: int,
         wire_request_id: str,
         signature_hex: str,
-    ) -> bool:
+    ) -> SignatureVerdict:
         """Verify the caller signed the marketplace-derived request_id.
 
         Sequential path:
 
-        1. Reject if the deployment-scoped constants (marketplace
-           ``domainSeparator``, mech ``paymentType``) are missing.
-        2. Compute the request_id locally from
-           ``(marketplace, mech, sender, ipfs_hash, delivery_rate,
-           payment_type, nonce, domain_separator)`` and require it to
-           match the value on the wire.
+        1. Infra failure if the deployment-scoped constants
+           (marketplace ``domainSeparator``, mech ``paymentType``) are
+           missing. The caller replies 503.
+        2. Client failure if the ``ipfs_hash`` or ``signature`` bytes
+           are malformed hex, if the derivation fails, or if the wire
+           request_id disagrees with the locally-derived value. The
+           caller replies 401.
         3. Try local ``ecrecover`` against ``sender``. Match wins with
            zero RPC.
         4. Fall back to the sender's EIP-1271 ``isValidSignature`` view.
@@ -2104,7 +2256,12 @@ class MechHttpHandler(AbstractResponseHandler):
             the wire; must equal the locally-derived value.
         :param signature_hex: hex-encoded signature bytes, with or without
             a leading ``0x``.
-        :return: True on a valid EOA or Safe signature; False otherwise.
+        :return: a :class:`SignatureVerdict`. ``ok=True`` on a valid
+            signature; ``ok=False`` with ``is_infra=True`` on
+            server-side prerequisites (constants unset, ledger config
+            missing, address preparation failure) or ``is_infra=False``
+            on a bad-caller outcome (malformed hex, derivation
+            mismatch, sig recovery failure).
         """
         if self._domain_separator is None or self._payment_type is None:
             self.context.logger.error(
@@ -2112,7 +2269,11 @@ class MechHttpHandler(AbstractResponseHandler):
                 "unavailable; rejecting request %s.",
                 wire_request_id,
             )
-            return False
+            return SignatureVerdict(
+                ok=False,
+                reason="marketplace verification constants unavailable",
+                is_infra=True,
+            )
 
         try:
             request_data = bytes.fromhex(ipfs_hash[2:])
@@ -2124,7 +2285,11 @@ class MechHttpHandler(AbstractResponseHandler):
                 "Malformed hex in signature or ipfs_hash for request %s.",
                 wire_request_id,
             )
-            return False
+            return SignatureVerdict(
+                ok=False,
+                reason="malformed signature or ipfs_hash hex",
+                is_infra=False,
+            )
 
         ledger_settings = self._get_ledger_settings()
         if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
@@ -2134,7 +2299,11 @@ class MechHttpHandler(AbstractResponseHandler):
                 ledger_settings.get(ResponseKey.REASON.value, "unknown"),
                 wire_request_id,
             )
-            return False
+            return SignatureVerdict(
+                ok=False,
+                reason="ledger settings unavailable",
+                is_infra=True,
+            )
 
         try:
             rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
@@ -2149,7 +2318,7 @@ class MechHttpHandler(AbstractResponseHandler):
             # None when the address is None (see
             # ``_initialise_offchain_verification_constants``), and the
             # None-guard on those constants at the top of this method
-            # would have already returned False.
+            # would have already returned an infra verdict.
             mech_address = ledger_api.api.to_checksum_address(
                 cast(str, self._marketplace_mech_address)
             )
@@ -2159,7 +2328,11 @@ class MechHttpHandler(AbstractResponseHandler):
                 wire_request_id,
                 e,
             )
-            return False
+            return SignatureVerdict(
+                ok=False,
+                reason="address preparation failed",
+                is_infra=True,
+            )
 
         try:
             derived = compute_request_id(
@@ -2176,7 +2349,11 @@ class MechHttpHandler(AbstractResponseHandler):
             self.context.logger.error(
                 "Request-id derivation failed for %s: %s.", wire_request_id, e
             )
-            return False
+            return SignatureVerdict(
+                ok=False,
+                reason="request-id derivation failed",
+                is_infra=False,
+            )
 
         # ``wire_request_id`` has already passed the canonical ASCII decimal
         # + uint256 guards above, so ``int(...)`` is safe.
@@ -2188,19 +2365,30 @@ class MechHttpHandler(AbstractResponseHandler):
                 derived.hex(),
                 sender_checksum,
             )
-            return False
+            return SignatureVerdict(
+                ok=False,
+                reason="wire request_id does not match local derivation",
+                is_infra=False,
+            )
 
         recovered = recover_eoa_signer(derived, signature_bytes)
         if recovered is not None and recovered == sender_checksum:
-            return True
+            return SignatureVerdict(ok=True, reason="", is_infra=False)
 
         # Sender is either a Safe or an EOA that produced an unrecognised
         # signature. Defer to the sender's EIP-1271 view for the final call.
-        return check_eip1271_signature(
+        eip1271_ok = check_eip1271_signature(
             ledger_api=ledger_api,
             contract_address=sender_checksum,
             message_hash=derived,
             signature=signature_bytes,
+        )
+        if eip1271_ok:
+            return SignatureVerdict(ok=True, reason="", is_infra=False)
+        return SignatureVerdict(
+            ok=False,
+            reason="signature verification failed",
+            is_infra=False,
         )
 
     def _get_ledger_settings(self) -> Dict[str, Union[str, int]]:

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -50,6 +50,15 @@ from packages.valory.skills.abstract_round_abci.handlers import AbstractResponse
 from packages.valory.skills.task_execution.dialogues import HttpDialogue
 from packages.valory.skills.task_execution.models import Params
 from packages.valory.skills.task_execution.utils import preimage as preimage_buffer
+from packages.valory.skills.task_execution.utils.eip1271 import (
+    check_eip1271_signature,
+    get_marketplace_domain_separator,
+    get_mech_payment_type,
+)
+from packages.valory.skills.task_execution.utils.request_id import (
+    compute_request_id,
+    recover_eoa_signer,
+)
 
 PENDING_TASKS = "pending_tasks"
 DONE_TASKS = "ready_tasks"
@@ -159,6 +168,8 @@ class RequestKey(str, Enum):
     DELIVERY_RATE = "delivery_rate"
     REQUEST_DELIVERY_RATE = "request_delivery_rate"
     IS_OFFCHAIN = "is_offchain"
+    SIGNATURE = "signature"
+    NONCE = "nonce"
 
 
 class ResponseKey(str, Enum):
@@ -766,6 +777,7 @@ class HttpCode(Enum):
     OK_CODE = 200
     NOT_FOUND_CODE = 404
     BAD_REQUEST_CODE = 400
+    UNAUTHORIZED_CODE = 401
     PAYMENT_REQUIRED_CODE = 402
     SERVICE_UNAVAILABLE_CODE = 503
     INTERNAL_SERVER_ERROR_CODE = 500
@@ -822,8 +834,57 @@ class MechHttpHandler(AbstractResponseHandler):
         self.context.shared_state[OFFCHAIN_REQUEST_RESPONSES] = {}
         self.context.shared_state[IN_MEMORY_REQUESTS] = {}
         self.json_content_header = JSON_CONTENT_HEADER
+        # Deployment-scoped constants used by the offchain request-id
+        # derivation: the marketplace EIP-712 ``domainSeparator`` and the
+        # mech's ``paymentType``. Both are set once at contract deployment
+        # and read on-chain here at handler init; the request-handling path
+        # references the cached bytes so a normal accept never triggers an
+        # extra RPC for these values.
+        self._domain_separator: Optional[bytes] = None
+        self._payment_type: Optional[bytes] = None
+        if self.params.use_offchain:
+            self._initialise_offchain_verification_constants()
         self.start_prometheus_server()
         super().setup()
+
+    def _initialise_offchain_verification_constants(self) -> None:
+        """Read the marketplace ``domainSeparator`` and mech ``paymentType``.
+
+        Any read failure logs a warning and leaves the constants unset; the
+        request-handling path treats an unset value as an internal error and
+        replies 401 so the client sees a clear rejection instead of a
+        mis-derived request_id.
+        """
+        ledger_settings = self._get_ledger_settings()
+        if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
+            self.context.logger.warning(
+                "Offchain verification constants unavailable: %s",
+                ledger_settings.get(ResponseKey.REASON.value, "unknown"),
+            )
+            return
+        try:
+            rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
+            chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
+            ledger_api = EthereumApi(address=rpc_address, chain_id=chain_id)
+            self._domain_separator = get_marketplace_domain_separator(
+                ledger_api=ledger_api,
+                marketplace_address=self.params.mech_marketplace_address,
+            )
+            self._payment_type = get_mech_payment_type(
+                ledger_api=ledger_api,
+                mech_address=self.params.agent_mech_contract_addresses[0],
+            )
+            self.context.logger.info(
+                "Offchain verification constants loaded: "
+                "domain_separator=0x%s payment_type=0x%s",
+                self._domain_separator.hex(),
+                self._payment_type.hex(),
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            self.context.logger.exception(
+                "Failed to load offchain verification constants; "
+                "offchain requests will be refused until the next restart."
+            )
 
     def start_prometheus_server(self) -> None:
         """Starts the prometheus server"""
@@ -870,6 +931,8 @@ class MechHttpHandler(AbstractResponseHandler):
             ipfs_hash = data[RequestKey.IPFS_HASH.value]
             sender = data[RequestKey.SENDER.value]
             request_delivery_rate = int(data[RequestKey.DELIVERY_RATE.value])
+            signature_hex = data[RequestKey.SIGNATURE.value]
+            request_nonce = int(data[RequestKey.NONCE.value])
         except Exception as e:
             self.context.logger.error(
                 f"Error processing signed request. body_len={len(http_msg.body)} "
@@ -943,6 +1006,28 @@ class MechHttpHandler(AbstractResponseHandler):
         self.context.logger.info(
             f"Received signed offchain request with {request_id=} and {request_delivery_rate=}."
         )
+
+        # Verify the request signature before charging the requester's balance.
+        # EIP-1271 for Safe senders, plain ecrecover for EOAs. Sequential by
+        # design: a failure here 401s before the balance-check RPC runs.
+        sig_ok = self._verify_offchain_request_signature(
+            sender=sender,
+            ipfs_hash=ipfs_hash,
+            delivery_rate=request_delivery_rate,
+            nonce=request_nonce,
+            wire_request_id=request_id,
+            signature_hex=signature_hex,
+        )
+        if not sig_ok:
+            self._send_rejection_response(
+                http_msg,
+                http_dialogue,
+                request_id,
+                reason="signature verification failed",
+                status_code=HttpCode.UNAUTHORIZED_CODE.value,
+                status_text="Unauthorized",
+            )
+            return
 
         balance_check = self._check_offchain_requester_balance(
             sender=sender,
@@ -1570,6 +1655,132 @@ class MechHttpHandler(AbstractResponseHandler):
             requester=requester,
         )
         return cast(int, requester_balance_res.get(BodyKey.REQUESTER_BALANCE.value, 0))
+
+    def _verify_offchain_request_signature(
+        self,
+        sender: str,
+        ipfs_hash: str,
+        delivery_rate: int,
+        nonce: int,
+        wire_request_id: str,
+        signature_hex: str,
+    ) -> bool:
+        """Verify the caller signed the marketplace-derived request_id.
+
+        Sequential path:
+
+        1. Reject if the deployment-scoped constants (marketplace
+           ``domainSeparator``, mech ``paymentType``) are missing.
+        2. Compute the request_id locally from
+           ``(marketplace, mech, sender, ipfs_hash, delivery_rate,
+           payment_type, nonce, domain_separator)`` and require it to
+           match the value on the wire.
+        3. Try local ``ecrecover`` against ``sender``. Match wins with
+           zero RPC.
+        4. Fall back to the sender's EIP-1271 ``isValidSignature`` view.
+
+        :param sender: the requester address, EOA or Safe.
+        :param ipfs_hash: 0x-prefixed hex string used as the on-chain
+            ``requestData`` blob.
+        :param delivery_rate: requester-signed delivery rate.
+        :param nonce: requester nonce as tracked by
+            ``MechMarketplace.mapNonces[sender]`` at signing time.
+        :param wire_request_id: the ASCII decimal request_id supplied on
+            the wire; must equal the locally-derived value.
+        :param signature_hex: hex-encoded signature bytes, with or without
+            a leading ``0x``.
+        :return: True on a valid EOA or Safe signature; False otherwise.
+        """
+        if self._domain_separator is None or self._payment_type is None:
+            self.context.logger.error(
+                "Cannot verify offchain signature: marketplace constants "
+                "unavailable; rejecting request %s.",
+                wire_request_id,
+            )
+            return False
+
+        try:
+            request_data = bytes.fromhex(ipfs_hash[2:])
+            signature_bytes = bytes.fromhex(
+                signature_hex[2:] if signature_hex.startswith("0x") else signature_hex
+            )
+        except ValueError:
+            self.context.logger.error(
+                "Malformed hex in signature or ipfs_hash for request %s.",
+                wire_request_id,
+            )
+            return False
+
+        ledger_settings = self._get_ledger_settings()
+        if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
+            self.context.logger.error(
+                "Cannot verify offchain signature: ledger settings unavailable "
+                "(%s); rejecting request %s.",
+                ledger_settings.get(ResponseKey.REASON.value, "unknown"),
+                wire_request_id,
+            )
+            return False
+
+        try:
+            rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
+            chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
+            ledger_api = EthereumApi(address=rpc_address, chain_id=chain_id)
+            sender_checksum = ledger_api.api.to_checksum_address(sender)
+            marketplace_address = ledger_api.api.to_checksum_address(
+                self.params.mech_marketplace_address
+            )
+            mech_address = ledger_api.api.to_checksum_address(
+                self.params.agent_mech_contract_addresses[0]
+            )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self.context.logger.error(
+                "Address preparation failed for request %s: %s.",
+                wire_request_id,
+                e,
+            )
+            return False
+
+        try:
+            derived = compute_request_id(
+                marketplace=marketplace_address,
+                mech=mech_address,
+                requester=sender_checksum,
+                request_data=request_data,
+                delivery_rate=delivery_rate,
+                payment_type=self._payment_type,
+                nonce=nonce,
+                domain_separator=self._domain_separator,
+            )
+        except ValueError as e:
+            self.context.logger.error(
+                "Request-id derivation failed for %s: %s.", wire_request_id, e
+            )
+            return False
+
+        # ``wire_request_id`` has already passed the canonical ASCII decimal
+        # + uint256 guards above, so ``int(...)`` is safe.
+        if int.from_bytes(derived, "big") != int(wire_request_id):
+            self.context.logger.warning(
+                "Wire request_id %s does not match locally-derived value "
+                "0x%s for sender %s.",
+                wire_request_id,
+                derived.hex(),
+                sender_checksum,
+            )
+            return False
+
+        recovered = recover_eoa_signer(derived, signature_bytes)
+        if recovered is not None and recovered == sender_checksum:
+            return True
+
+        # Sender is either a Safe or an EOA that produced an unrecognised
+        # signature. Defer to the sender's EIP-1271 view for the final call.
+        return check_eip1271_signature(
+            ledger_api=ledger_api,
+            contract_address=sender_checksum,
+            message_hash=derived,
+            signature=signature_bytes,
+        )
 
     def _get_ledger_settings(self) -> Dict[str, Union[str, int]]:
         """Read ledger RPC settings from skill params using default_chain_id."""

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -3262,46 +3262,158 @@ class MechHttpHandler(AbstractResponseHandler):
             is_infra=False,
         )
 
-    @staticmethod
-    def _prune_stale_nonces(
-        nonces_by_sender: Dict[str, Set[int]],
+    def _reconcile_stale_accepted(
+        self,
         sender_checksum: str,
         on_chain_nonce: int,
     ) -> Set[int]:
-        """Drop entries at or below ``on_chain_nonce`` and return what remains.
+        """Evict orphaned accepted entries and return what remains.
 
-        Called on both ``accepted`` and ``settling`` before computing
-        the admission gate's next-expected-slot formula. Guards two
-        recovery paths:
+        An accepted entry with nonce **strictly below** ``on_chain_nonce``
+        cannot settle: ``deliverMarketplaceWithSignatures`` derives
+        each ``requestId`` from its own ``mapNonces[sender]`` at
+        settlement time, and a task signed against an older slot does
+        not match. This state is reached when the same sender uses
+        both the on-chain and off-chain rails — an on-chain
+        ``request()`` bumps ``mapNonces`` past a slot whose off-chain
+        task is still in ``pending_tasks``.
 
-        * ``settling`` shrinks naturally when the batch settlement
-          advances ``mapNonces`` past the nonce, but only if we prune
-          on read — the release side has no observer for the on-chain
-          counter.
-        * ``accepted`` should never contain a nonce at or below
-          ``on_chain_nonce`` in the healthy case (the release path
-          moves entries to ``settling`` before settlement can advance
-          the counter), but a crash / restart / a sender using both
-          the on-chain and off-chain rails could leave a stale entry
-          in the set indefinitely, silently inflating the gate's slot
-          count forever.
+        For each such entry the method evicts the corresponding
+        pending task, pops its in-memory payload, and writes a
+        rejection into ``offchain_request_responses`` so the polling
+        client sees a definitive result. A WARNING per eviction
+        carries sender + nonce + on_chain for operator triage.
 
-        :param nonces_by_sender: the accepted or settling map.
         :param sender_checksum: the sender's checksum key.
         :param on_chain_nonce: current ``mapNonces[sender]`` value.
-        :return: the surviving set for ``sender_checksum`` (empty set
-            if the sender had none or every entry was stale). Also
-            pops the sender key from the map if nothing survives.
+        :return: the surviving set for ``sender_checksum`` (empty
+            set if the sender had none or every entry was orphaned).
+            Also pops the sender key from the map if nothing survives.
         """
-        entries = nonces_by_sender.get(sender_checksum)
+        entries = self.accepted_nonces_by_sender.get(sender_checksum)
         if not entries:
             return set()
-        stale = {n for n in entries if n < on_chain_nonce}
-        if stale:
-            entries -= stale
-            if not entries:
-                nonces_by_sender.pop(sender_checksum, None)
+        orphaned = {n for n in entries if n < on_chain_nonce}
+        if not orphaned:
+            return entries
+        for wire_nonce in sorted(orphaned):
+            self.context.logger.warning(
+                "Evicting orphaned accepted nonce %d for sender %s: "
+                "on-chain mapNonces has advanced to %d "
+                "(concurrent on-chain activity from this sender "
+                "consumed the slot; the task cannot settle).",
+                wire_nonce,
+                sender_checksum,
+                on_chain_nonce,
+            )
+            self._evict_orphaned_pending(sender_checksum, wire_nonce, on_chain_nonce)
+        entries -= orphaned
+        if not entries:
+            self.accepted_nonces_by_sender.pop(sender_checksum, None)
         return entries
+
+    def _reconcile_stale_settling(
+        self,
+        sender_checksum: str,
+        on_chain_nonce: int,
+    ) -> Set[int]:
+        """Drop settling entries the on-chain counter has already consumed.
+
+        Called on ``settling`` before computing the admission gate's
+        next-expected-slot formula. A settling entry with nonce
+        **strictly below** ``on_chain_nonce`` corresponds to a slot
+        the marketplace has already consumed (``mapNonces`` advances
+        via ``deliverMarketplaceWithSignatures`` finishing a batch,
+        or via a same-sender on-chain ``request()``). The drain is
+        logged at INFO so the transition is observable.
+
+        An entry AT ``on_chain_nonce`` is the next slot to be
+        consumed and stays: the same wire nonce must remain
+        recognisable as a duplicate while its batch is in flight.
+
+        :param sender_checksum: the sender's checksum key.
+        :param on_chain_nonce: current ``mapNonces[sender]`` value.
+        :return: the surviving set for ``sender_checksum``.
+        """
+        entries = self.settling_nonces_by_sender.get(sender_checksum)
+        if not entries:
+            return set()
+        drained = {n for n in entries if n < on_chain_nonce}
+        if not drained:
+            return entries
+        self.context.logger.info(
+            "Draining %d settled nonce(s) from sender %s "
+            "(on-chain mapNonces advanced to %d): %s",
+            len(drained),
+            sender_checksum,
+            on_chain_nonce,
+            sorted(drained),
+        )
+        entries -= drained
+        if not entries:
+            self.settling_nonces_by_sender.pop(sender_checksum, None)
+        return entries
+
+    def _evict_orphaned_pending(
+        self,
+        sender_checksum: str,
+        wire_nonce: int,
+        on_chain_nonce: int,
+    ) -> None:
+        """Remove an orphaned pending task and write its rejection payload.
+
+        Handler-side counterpart to
+        ``behaviours.TaskExecutionBehaviour._record_offchain_failure``
+        for slots the on-chain rail has advanced past. Pending tasks
+        carry the raw wire ``sender`` (may be lowercase or checksum),
+        so the match is case-insensitive; ``nonce`` is the coerced
+        ``int`` written at accept time.
+
+        :param sender_checksum: the sender's checksum key.
+        :param wire_nonce: the orphaned wire nonce.
+        :param on_chain_nonce: current ``mapNonces[sender]`` used in
+            the WARNING log for operator triage.
+        """
+        sender_lower = sender_checksum.lower()
+        pending = self.pending_tasks
+        for idx in range(len(pending) - 1, -1, -1):
+            task = pending[idx]
+            if not task.get(RequestKey.IS_OFFCHAIN.value):
+                continue
+            if str(task.get("sender", "")).lower() != sender_lower:
+                continue
+            raw_nonce = task.get("nonce")
+            if raw_nonce is None:
+                continue
+            try:
+                task_nonce = int(raw_nonce)
+            except (TypeError, ValueError):
+                continue
+            if task_nonce != wire_nonce:
+                continue
+            request_id = str(task.get(RequestKey.REQUEST_ID_CAMEL.value, ""))
+            del pending[idx]
+            if request_id:
+                self.in_memory_requests.pop(request_id, None)
+                self.offchain_request_responses[request_id] = {
+                    RequestKey.REQUEST_ID.value: request_id,
+                    ResponseKey.STATUS.value: ResponseStatus.REJECTED.value,
+                    ResponseKey.REASON.value: (
+                        "on-chain nonce advanced past this slot; "
+                        "concurrent on-chain activity from this "
+                        "sender consumed it before the off-chain "
+                        "batch could settle"
+                    ),
+                }
+            self.context.logger.warning(
+                "Evicted orphaned pending task request_id=%s "
+                "(sender=%s, nonce=%d, on_chain=%d).",
+                request_id,
+                sender_checksum,
+                wire_nonce,
+                on_chain_nonce,
+            )
+            return
 
     def _bind_wire_nonce_to_chain(
         self,
@@ -3471,15 +3583,13 @@ class MechHttpHandler(AbstractResponseHandler):
                 reason=NONCE_READ_UNRECOVERABLE,
                 is_infra=True,
             )
-        # Prune stale entries in both maps before computing the count.
-        # See ``_prune_stale_nonces`` for the crash-recovery rationale
-        # and the settlement-gap semantics of ``settling``.
-        accepted = self._prune_stale_nonces(
-            self.accepted_nonces_by_sender, sender_checksum, on_chain_nonce
-        )
-        settling = self._prune_stale_nonces(
-            self.settling_nonces_by_sender, sender_checksum, on_chain_nonce
-        )
+        # Reconcile both maps against the current on-chain counter
+        # before computing the slot count. Accepted entries below
+        # the counter carry their pending tasks with them to the
+        # eviction path; settling entries below the counter are
+        # drained (their slot has already been consumed on chain).
+        accepted = self._reconcile_stale_accepted(sender_checksum, on_chain_nonce)
+        settling = self._reconcile_stale_settling(sender_checksum, on_chain_nonce)
         expected_next_nonce = on_chain_nonce + len(accepted) + len(settling)
         # Duplicate detection covers both sets: a wire nonce already
         # accepted (and either still pending on the mech side or moved

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -3293,21 +3293,49 @@ class MechHttpHandler(AbstractResponseHandler):
         entries = self.accepted_nonces_by_sender.get(sender_checksum)
         if not entries:
             return set()
-        orphaned = {n for n in entries if n < on_chain_nonce}
+        orphaned = sorted(n for n in entries if n < on_chain_nonce)
         if not orphaned:
             return entries
-        for wire_nonce in sorted(orphaned):
-            self.context.logger.warning(
-                "Evicting orphaned accepted nonce %d for sender %s: "
-                "on-chain mapNonces has advanced to %d "
-                "(concurrent on-chain activity from this sender "
-                "consumed the slot; the task cannot settle).",
-                wire_nonce,
-                sender_checksum,
-                on_chain_nonce,
-            )
-            self._evict_orphaned_pending(sender_checksum, wire_nonce, on_chain_nonce)
-        entries -= orphaned
+        for wire_nonce in orphaned:
+            try:
+                matched = self._evict_orphaned_pending(
+                    sender_checksum, wire_nonce, on_chain_nonce
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Per-nonce eviction is isolated: a corrupt entry in
+                # ``pending_tasks`` / ``done_tasks`` (non-dict, missing
+                # keys) must not abort the loop and leave later orphans
+                # in the accepted set. Log with traceback and discard
+                # this nonce so the gate's slot count stays truthful.
+                self.context.logger.warning(
+                    "Failure while evicting orphaned nonce %d for sender %s "
+                    "(on_chain=%d); dropping the gate entry regardless.",
+                    wire_nonce,
+                    sender_checksum,
+                    on_chain_nonce,
+                    exc_info=True,
+                )
+                matched = False
+            if matched:
+                self.context.logger.warning(
+                    "Evicted orphaned accepted nonce %d for sender %s: "
+                    "on-chain mapNonces has advanced to %d "
+                    "(concurrent on-chain activity from this sender "
+                    "consumed the slot).",
+                    wire_nonce,
+                    sender_checksum,
+                    on_chain_nonce,
+                )
+            else:
+                self.context.logger.warning(
+                    "No pending/done task matched orphaned nonce %d for "
+                    "sender %s (on_chain=%d); the task may be executing "
+                    "or awaiting settlement. Dropping the gate entry.",
+                    wire_nonce,
+                    sender_checksum,
+                    on_chain_nonce,
+                )
+            entries.discard(wire_nonce)
         if not entries:
             self.accepted_nonces_by_sender.pop(sender_checksum, None)
         return entries
@@ -3359,61 +3387,91 @@ class MechHttpHandler(AbstractResponseHandler):
         sender_checksum: str,
         wire_nonce: int,
         on_chain_nonce: int,
-    ) -> None:
-        """Remove an orphaned pending task and write its rejection payload.
+    ) -> bool:
+        """Remove an orphaned task from pending / done and record the rejection.
+
+        Scans both ``pending_tasks`` and ``done_tasks`` for a matching
+        off-chain task (case-insensitive on sender, exact match on
+        wire_nonce). When found, drops it from the list, removes its
+        in-memory payload, writes a rejection to
+        ``offchain_request_responses`` so the polling client sees a
+        terminal result, and records the rejection in the preimage
+        buffer so the durable audit row moves to the ``rejected``
+        terminal state instead of staying at ``processing``.
 
         Handler-side counterpart to
-        ``behaviours.TaskExecutionBehaviour._record_offchain_failure``
-        for slots the on-chain rail has advanced past. Pending tasks
-        carry the raw wire ``sender`` (may be lowercase or checksum),
-        so the match is case-insensitive; ``nonce`` is the coerced
-        ``int`` written at accept time.
+        ``behaviours.TaskExecutionBehaviour._record_offchain_failure``.
 
         :param sender_checksum: the sender's checksum key.
         :param wire_nonce: the orphaned wire nonce.
-        :param on_chain_nonce: current ``mapNonces[sender]`` used in
-            the WARNING log for operator triage.
+        :param on_chain_nonce: current ``mapNonces[sender]``, used in
+            the eviction log for operator triage.
+        :return: ``True`` if a matching task was found and evicted
+            from either queue, ``False`` otherwise (task may be
+            mid-flight between ``pending_tasks`` and ``done_tasks``).
         """
         sender_lower = sender_checksum.lower()
-        pending = self.pending_tasks
-        for idx in range(len(pending) - 1, -1, -1):
-            task = pending[idx]
+        rejection_reason = (
+            "on-chain nonce advanced past this slot; concurrent on-chain "
+            "activity from this sender consumed it before the off-chain "
+            "batch could settle"
+        )
+        now = time.time()
+
+        def _match(task: Dict[str, Any]) -> bool:
+            if not isinstance(task, dict):
+                return False
             if not task.get(RequestKey.IS_OFFCHAIN.value):
-                continue
-            if str(task.get("sender", "")).lower() != sender_lower:
-                continue
-            raw_nonce = task.get("nonce")
+                return False
+            task_sender = str(task.get(RequestKey.SENDER.value, "")).lower()
+            if task_sender != sender_lower:
+                return False
+            raw_nonce = task.get(RequestKey.NONCE.value)
             if raw_nonce is None:
-                continue
+                return False
             try:
-                task_nonce = int(raw_nonce)
+                return int(raw_nonce) == wire_nonce
             except (TypeError, ValueError):
-                continue
-            if task_nonce != wire_nonce:
-                continue
-            request_id = str(task.get(RequestKey.REQUEST_ID_CAMEL.value, ""))
-            del pending[idx]
-            if request_id:
-                self.in_memory_requests.pop(request_id, None)
-                self.offchain_request_responses[request_id] = {
-                    RequestKey.REQUEST_ID.value: request_id,
-                    ResponseKey.STATUS.value: ResponseStatus.REJECTED.value,
-                    ResponseKey.REASON.value: (
-                        "on-chain nonce advanced past this slot; "
-                        "concurrent on-chain activity from this "
-                        "sender consumed it before the off-chain "
-                        "batch could settle"
-                    ),
-                }
-            self.context.logger.warning(
-                "Evicted orphaned pending task request_id=%s "
-                "(sender=%s, nonce=%d, on_chain=%d).",
-                request_id,
-                sender_checksum,
-                wire_nonce,
-                on_chain_nonce,
-            )
-            return
+                return False
+
+        matched = False
+        for source_label, storage in (
+            ("pending_tasks", self.pending_tasks),
+            ("done_tasks", self.done_tasks),
+        ):
+            for idx in range(len(storage) - 1, -1, -1):
+                task = storage[idx]
+                if not _match(task):
+                    continue
+                request_id = str(task.get(RequestKey.REQUEST_ID_CAMEL.value, ""))
+                del storage[idx]
+                if request_id:
+                    self.in_memory_requests.pop(request_id, None)
+                    self.offchain_request_responses[request_id] = {
+                        RequestKey.REQUEST_ID.value: request_id,
+                        ResponseKey.STATUS.value: ResponseStatus.REJECTED.value,
+                        ResponseKey.REASON.value: rejection_reason,
+                    }
+                    if self.params.preimage_retention_enabled:
+                        preimage_buffer.record_settlement(
+                            self.context.shared_state,
+                            request_id,
+                            rejection_reason,
+                            None,
+                            preimage_buffer.STATUS_REJECTED,
+                            now,
+                        )
+                self.context.logger.info(
+                    "Removed orphaned task from %s: request_id=%s "
+                    "sender=%s nonce=%d on_chain=%d.",
+                    source_label,
+                    request_id,
+                    sender_checksum,
+                    wire_nonce,
+                    on_chain_nonce,
+                )
+                matched = True
+        return matched
 
     def _bind_wire_nonce_to_chain(
         self,

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -53,8 +53,11 @@ from packages.valory.skills.task_execution.utils import preimage as preimage_buf
 from packages.valory.skills.task_execution.utils.eip1271 import (
     check_eip1271_signature,
     get_marketplace_domain_separator,
+    get_marketplace_request_id_view,
     get_mech_payment_type,
 )
+from packages.valory.skills.task_execution.utils.ipfs import to_multihash
+from packages.valory.skills.task_execution.utils.local_cid import compute_cidv1
 from packages.valory.skills.task_execution.utils.request_id import (
     compute_request_id,
     recover_eoa_signer,
@@ -117,6 +120,56 @@ REQUEST_ID_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
 # the "opaque ``ValueError`` at the coercion site" outcome the upfront
 # guard exists to close. Mirrors ``MAX_DELIVERY_RATE``.
 MAX_REQUEST_ID = 2**256 - 1
+
+# ``nonce`` on the wire is the decimal encoding of the requester's
+# uint256 ``mapNonces`` counter at the moment of signing. Coerce to
+# ``int`` at ingress and validate the alphabet + magnitude the same
+# way ``request_id`` is validated. Downstream (see
+# ``task_submission_abci.behaviours._get_offchain_tasks_deliver_data``)
+# calls ``sorted(..., key=lambda x: x[NONCE])``; a wire ``str`` would
+# sort lexicographically (``"10"`` before ``"9"``) and the on-chain
+# ``mapNonces`` array consume would fail the whole batch.
+NONCE_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
+MAX_NONCE = 2**256 - 1
+
+# Boot-time self-check inputs for the marketplace ``getRequestId`` view
+# vs the local ``compute_request_id`` reimplementation. Any well-formed
+# tuple is fine because we compare two bytes32 outputs, not the
+# semantic meaning of the inputs. Dummy requester + 32-byte data blob
+# + delivery_rate=1 + nonce=0 keep the call cheap and deterministic; a
+# real client is never affected because the values never enter the
+# accept path.
+_SELFCHECK_REQUESTER = "0x0000000000000000000000000000000000000001"
+_SELFCHECK_REQUEST_DATA = b"\x00" * 32
+_SELFCHECK_DELIVERY_RATE = 1
+_SELFCHECK_NONCE = 0
+
+# Sentinel rejection reason surfaced when the boot-time self-check
+# between the marketplace ``getRequestId`` view and the local
+# ``compute_request_id`` disagrees. Every subsequent offchain accept
+# 401s with this reason so operators can grep the log line to the
+# corresponding fatal at boot.
+MARKETPLACE_VERIFICATION_FAILED = "marketplace-verification-failed"
+
+# Rejection reason for a body whose local CID does not match the
+# posted ``ipfs_hash``: the request would enqueue arbitrary work under
+# a signature that authorised different content.
+IPFS_HASH_BODY_MISMATCH = "ipfs_hash does not match ipfs_data content"
+
+# Reason surfaced on the idempotent-retry response (HTTP 200) when the
+# handler already knows the ``request_id`` from the pending queue, the
+# in-flight executor, the done batch, or the rejected-response cache.
+# Kept a 200 so mech-client's own retry loop doesn't treat it as a
+# different response than the first accept.
+REQUEST_ALREADY_ACCEPTED = "already accepted"
+
+# Multihash function-code + digest-length prefix a caller may include on
+# the wire when writing a full 34-byte multihash (``0x1220<digest>``)
+# in ``ipfs_hash``. The 32-byte form (bare SHA-256 digest, 64 hex
+# chars) is the wire default. Kept as a hex ``str`` so the strip is a
+# ``str.startswith`` on the ``0x``-stripped remainder — no ``bytes``
+# round-trip needed for the compare.
+IPFS_HASH_MULTIHASH_PREFIX = "1220"
 
 LEDGER_API_ADDRESS = str(LEDGER_CONNECTION_PUBLIC_ID)
 
@@ -840,12 +893,44 @@ class MechHttpHandler(AbstractResponseHandler):
         # and read on-chain here at handler init; the request-handling path
         # references the cached bytes so a normal accept never triggers an
         # extra RPC for these values.
+        #
+        # ``_marketplace_mech_address`` is resolved by scanning
+        # ``params.mech_to_config`` for the entry flagged
+        # ``is_marketplace_mech``, NOT by taking
+        # ``agent_mech_contract_addresses[0]``. A deployment whose
+        # ``mech_to_config`` lists a non-marketplace mech first would
+        # otherwise cache the wrong ``paymentType`` at setup, derive the
+        # wrong ``request_id`` from every accept, and 401 every offchain
+        # request. Falling back to None leaves the constants unloaded so
+        # the request-handling path 401s with a clear reason.
         self._domain_separator: Optional[bytes] = None
         self._payment_type: Optional[bytes] = None
+        self._marketplace_mech_address: Optional[str] = (
+            self._resolve_marketplace_mech_address()
+        )
         if self.params.use_offchain:
             self._initialise_offchain_verification_constants()
         self.start_prometheus_server()
         super().setup()
+
+    def _resolve_marketplace_mech_address(self) -> Optional[str]:
+        """Return the mech address flagged ``is_marketplace_mech`` in config.
+
+        Mirrors ``TaskExecutionBehaviour._get_designated_marketplace_mech_address``
+        so the offchain accept path and the on-chain delivery path pick the
+        same mech even when ``mech_to_config`` lists a non-marketplace mech
+        first. Returns ``None`` when no marketplace mech is configured; the
+        caller treats that as "offchain unavailable" and refuses subsequent
+        accepts with a clear reason instead of caching a wrong address.
+
+        :return: the marketplace mech address (lowercase, as stored in
+            ``mech_to_config``), or ``None`` if no marketplace mech is
+            configured.
+        """
+        for mech, config in self.params.mech_to_config.items():
+            if config.is_marketplace_mech:
+                return mech
+        return None
 
     def _initialise_offchain_verification_constants(self) -> None:
         """Read the marketplace ``domainSeparator`` and mech ``paymentType``.
@@ -854,7 +939,22 @@ class MechHttpHandler(AbstractResponseHandler):
         request-handling path treats an unset value as an internal error and
         replies 401 so the client sees a clear rejection instead of a
         mis-derived request_id.
+
+        After the constants are loaded, a boot-time self-check calls the
+        marketplace ``getRequestId`` view and compares its bytes32 output
+        with the local ``compute_request_id`` reimplementation on the same
+        dummy inputs. On mismatch the boot-cached constants are flipped off
+        and a fatal-level log line is emitted; every subsequent accept
+        401s. Guards against a marketplace upgrade that silently changes
+        either the ``getRequestId`` layout or the EIP-712 ``domainSeparator``
+        derivation (the marketplace sits behind ``MechMarketplaceProxy``).
         """
+        if self._marketplace_mech_address is None:
+            self.context.logger.warning(
+                "Offchain verification constants unavailable: no "
+                "marketplace mech configured in mech_to_config."
+            )
+            return
         ledger_settings = self._get_ledger_settings()
         if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
             self.context.logger.warning(
@@ -872,7 +972,7 @@ class MechHttpHandler(AbstractResponseHandler):
             )
             self._payment_type = get_mech_payment_type(
                 ledger_api=ledger_api,
-                mech_address=self.params.agent_mech_contract_addresses[0],
+                mech_address=self._marketplace_mech_address,
             )
             self.context.logger.info(
                 "Offchain verification constants loaded: "
@@ -885,6 +985,81 @@ class MechHttpHandler(AbstractResponseHandler):
                 "Failed to load offchain verification constants; "
                 "offchain requests will be refused until the next restart."
             )
+            return
+        self._selfcheck_marketplace_request_id_derivation(ledger_api)
+
+    def _selfcheck_marketplace_request_id_derivation(
+        self, ledger_api: EthereumApi
+    ) -> None:
+        """Cross-check the local request-id derivation against the marketplace.
+
+        Calls the marketplace ``getRequestId`` view with fixed dummy inputs
+        and compares its bytes32 output with ``compute_request_id`` run on
+        the same inputs and the boot-cached ``domain_separator`` and
+        ``payment_type``. On mismatch: log a fatal-level error, flip the
+        boot-cached constants to ``None`` (so every subsequent
+        offchain accept 401s with ``marketplace-verification-failed``),
+        and return without raising. The mismatch is an operational signal;
+        crashing the mech process on a marketplace upgrade would be more
+        disruptive than the accept refusal.
+
+        :param ledger_api: the ledger API object used for the view call.
+        """
+        # Precondition: the caller loaded both constants before invoking.
+        # Belt-and-braces to keep the type checker happy for the two
+        # dereferences below.
+        if self._domain_separator is None or self._payment_type is None:
+            return
+        marketplace_address = self.params.mech_marketplace_address
+        mech_address = cast(str, self._marketplace_mech_address)
+        try:
+            onchain_request_id = get_marketplace_request_id_view(
+                ledger_api=ledger_api,
+                marketplace_address=marketplace_address,
+                mech=mech_address,
+                requester=_SELFCHECK_REQUESTER,
+                data=_SELFCHECK_REQUEST_DATA,
+                delivery_rate=_SELFCHECK_DELIVERY_RATE,
+                payment_type=self._payment_type,
+                nonce=_SELFCHECK_NONCE,
+            )
+            local_request_id = compute_request_id(
+                marketplace=marketplace_address,
+                mech=mech_address,
+                requester=_SELFCHECK_REQUESTER,
+                request_data=_SELFCHECK_REQUEST_DATA,
+                delivery_rate=_SELFCHECK_DELIVERY_RATE,
+                payment_type=self._payment_type,
+                nonce=_SELFCHECK_NONCE,
+                domain_separator=self._domain_separator,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Any failure here — RPC unreachable, contract revert,
+            # local derivation raising — leaves the constants unset so
+            # the accept path 401s with a clear reason instead of
+            # trusting a derivation we could not confirm.
+            self.context.logger.exception(
+                "Marketplace request-id self-check failed; disabling "
+                "offchain accepts until the next restart."
+            )
+            self._domain_separator = None
+            self._payment_type = None
+            return
+        if onchain_request_id != local_request_id:
+            self.context.logger.error(
+                "FATAL: marketplace getRequestId does not match the local "
+                "compute_request_id reimplementation "
+                "(onchain=0x%s local=0x%s). The marketplace may have been "
+                "upgraded to a layout this handler does not mirror; "
+                "offchain accepts will 401 until the mech is redeployed "
+                "against a matching handler.",
+                onchain_request_id.hex(),
+                local_request_id.hex(),
+            )
+            self._domain_separator = None
+            self._payment_type = None
+            return
+        self.context.logger.info("Marketplace request-id self-check passed.")
 
     def start_prometheus_server(self) -> None:
         """Starts the prometheus server"""
@@ -932,7 +1107,15 @@ class MechHttpHandler(AbstractResponseHandler):
             sender = data[RequestKey.SENDER.value]
             request_delivery_rate = int(data[RequestKey.DELIVERY_RATE.value])
             signature_hex = data[RequestKey.SIGNATURE.value]
-            request_nonce = int(data[RequestKey.NONCE.value])
+            # ``nonce`` on the wire is form-urlencoded — always ``str``.
+            # Coerce with ``int(...)`` inside the ingress try/except so a
+            # non-numeric value 400s alongside the other body-shape
+            # violations. Downstream (see the ``_enqueue_offchain_request``
+            # writeback and the sort in
+            # ``task_submission_abci.behaviours._get_offchain_tasks_deliver_data``)
+            # gets the coerced ``int`` value.
+            wire_nonce = data[RequestKey.NONCE.value]
+            request_nonce = int(wire_nonce)
         except Exception as e:
             self.context.logger.error(
                 f"Error processing signed request. body_len={len(http_msg.body)} "
@@ -983,6 +1166,29 @@ class MechHttpHandler(AbstractResponseHandler):
             self._handle_bad_request(http_msg, http_dialogue)
             return
 
+        # ``nonce`` gets the same treatment as ``request_id``: canonical
+        # ASCII decimal + uint256 magnitude. The alphabet regex catches
+        # ``"9abc"`` and empty strings; the uint256 bound catches
+        # ``2**256`` and the length short-circuit stops
+        # ``ValueError`` from firing at ``int()`` for pathological input
+        # lengths. Rejects negatives (``\A-`` never matches ``NONCE_RE``)
+        # so ``int(nonce)`` downstream is guaranteed a non-negative int.
+        if not NONCE_RE.fullmatch(wire_nonce or ""):
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id}: "
+                f"nonce must be a canonical ASCII decimal "
+                f"(nonce={wire_nonce!r})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+        if len(wire_nonce) > len(str(MAX_NONCE)) or request_nonce > MAX_NONCE:
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id}: "
+                f"nonce exceeds uint256 upper bound (nonce={wire_nonce})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+
         if not IPFS_HASH_RE.match(ipfs_hash):
             self.context.logger.error(
                 f"Rejecting offchain request {request_id}: invalid ipfs_hash "
@@ -1019,6 +1225,11 @@ class MechHttpHandler(AbstractResponseHandler):
             signature_hex=signature_hex,
         )
         if not sig_ok:
+            # Pre-auth 401: do NOT persist a rejection payload keyed by
+            # the caller-supplied ``request_id`` — a caller could
+            # otherwise poison an arbitrary id that a legitimate caller
+            # would later read via the polling endpoint. See
+            # ``_send_rejection_response(record_response=...)``.
             self._send_rejection_response(
                 http_msg,
                 http_dialogue,
@@ -1029,11 +1240,63 @@ class MechHttpHandler(AbstractResponseHandler):
             )
             return
 
+        # Bind the executed payload to the signature. The trader signs
+        # a ``request_id`` derived from ``keccak(ipfs_hash)`` and posts
+        # the ``ipfs_data`` body inline; without a match check the
+        # signature would authorise "work described by CID X" while
+        # the mech executes body Y. Re-derive the CID over the bytes
+        # the mech will actually run and reject the request outright
+        # if it does not equal the posted ``ipfs_hash``.
+        cid_bind_ok = self._verify_ipfs_hash_binding(
+            request_id=request_id,
+            ipfs_hash=ipfs_hash,
+            ipfs_data=data.get(RequestKey.IPFS_DATA.value, ""),
+        )
+        if not cid_bind_ok:
+            self._send_rejection_response(
+                http_msg,
+                http_dialogue,
+                request_id,
+                reason=IPFS_HASH_BODY_MISMATCH,
+                status_code=HttpCode.BAD_REQUEST_CODE.value,
+                status_text="Bad request",
+            )
+            return
+
+        # Replay protection. Once the sig + CID gates have passed, the
+        # accept-time trust base is enough to dedup exactly: every field
+        # that changes the ``request_id`` is signed, so the same body
+        # posted twice hashes to the same id, and any change to a signed
+        # field would have produced a different id. Return 200 with a
+        # note rather than a 409 so mech-client's idempotent-retry
+        # semantics are preserved on a genuine network retry.
+        if self._is_duplicate_request(request_id):
+            self.context.logger.info(
+                "Duplicate offchain request %s already known; returning 200 "
+                "without a second enqueue.",
+                request_id,
+            )
+            self._send_ok_response(
+                http_msg=http_msg,
+                http_dialogue=http_dialogue,
+                data={
+                    RequestKey.REQUEST_ID.value: request_id,
+                    ResponseKey.STATUS.value: ResponseStatus.OK.value,
+                    ResponseKey.REASON.value: REQUEST_ALREADY_ACCEPTED,
+                },
+            )
+            return
+
         balance_check = self._check_offchain_requester_balance(
             sender=sender,
             delivery_rate=request_delivery_rate,
         )
         if balance_check[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
+            # Pre-enqueue 503: same pre-auth-write rule as the 401
+            # branch above. The caller has proven signature ownership,
+            # but the ledger read failed before any state was committed;
+            # do not persist a rejection payload for a request that
+            # never made it into pending_tasks.
             self._send_rejection_response(
                 http_msg,
                 http_dialogue,
@@ -1060,6 +1323,12 @@ class MechHttpHandler(AbstractResponseHandler):
                 )
                 self._send_internal_error(http_msg, http_dialogue, request_id)
                 return
+            # 402 is the one rejection path that DOES persist the
+            # response payload keyed by ``request_id``: the caller has
+            # authenticated (signature ownership proven) and needs the
+            # deposit challenge to be readable via the polling endpoint
+            # (``_handle_offchain_request_info``). Every other pre-auth
+            # rejection returns the HTTP response only.
             self._send_rejection_response(
                 http_msg,
                 http_dialogue,
@@ -1069,8 +1338,20 @@ class MechHttpHandler(AbstractResponseHandler):
                 status_text="Payment required",
                 extra_headers=extra_headers,
                 body_extras=challenge_body,
+                record_response=True,
             )
             return
+
+        # ``nonce`` moves from the wire ``str`` to the coerced ``int``
+        # before the enqueue merges the parsed body dict into the
+        # pending task. Without this, ``_enqueue_offchain_request``
+        # would spread the original ``str`` through as ``data["nonce"]``
+        # and the sort key in
+        # ``task_submission_abci.behaviours._get_offchain_tasks_deliver_data``
+        # would fall back to lexicographic order (``"10"`` before
+        # ``"9"``) and mis-order the batch against the on-chain
+        # ``mapNonces`` array consume.
+        data[RequestKey.NONCE.value] = request_nonce  # type: ignore[assignment]
 
         try:
             req = self._enqueue_offchain_request(
@@ -1111,6 +1392,111 @@ class MechHttpHandler(AbstractResponseHandler):
                 f"Failed to send OK response for {request_id}."
             )
             self._send_internal_error(http_msg, http_dialogue, request_id)
+
+    def _verify_ipfs_hash_binding(
+        self,
+        request_id: str,
+        ipfs_hash: str,
+        ipfs_data: str,
+    ) -> bool:
+        """Return True iff the local CID of ``ipfs_data`` matches ``ipfs_hash``.
+
+        The trader signs a ``request_id`` derived from ``keccak(ipfs_hash)``
+        where ``ipfs_hash`` is the on-chain content commitment. The
+        signature therefore binds the ``request_id`` to a content hash,
+        not to any particular body — a client could sign the CID of a
+        benign prompt and paste an expensive one into the same POST.
+        This method re-derives the CID over the raw ``ipfs_data`` bytes
+        the mech will feed to ``_handle_get_task`` and compares against
+        the caller-posted ``ipfs_hash`` before the request enqueues.
+
+        The wire ``ipfs_hash`` is a 0x-prefixed hex string of either
+        32 bytes (bare SHA-256 digest, 64 hex chars — matches
+        ``to_multihash`` on the locally-derived CID) or 34 bytes
+        (SHA-256 multihash prefix ``0x1220`` + 32-byte digest, 68 hex
+        chars). Both forms reduce to the same 32-byte digest for the
+        compare; the multihash prefix is stripped when present.
+
+        :param request_id: the caller-supplied off-chain request id
+            (used only for the log line).
+        :param ipfs_hash: the caller-posted ``ipfs_hash`` from the
+            signed body, already ``IPFS_HASH_RE``-validated.
+        :param ipfs_data: the raw request-metadata JSON string carried
+            inline in the signed body under ``ipfs_data``.
+        :return: True on match; False on any mismatch (empty body,
+            oversize body, digest mismatch).
+        """
+        if not ipfs_data:
+            self.context.logger.error(
+                "Rejecting offchain request %s: ipfs_data is empty; "
+                "cannot re-derive the CID for the binding check.",
+                request_id,
+            )
+            return False
+        try:
+            local_cid = compute_cidv1(ipfs_data.encode(ENCODING_UTF8))
+        except ValueError:
+            # ``compute_cidv1`` raises above the single-block bound
+            # (256 KiB). Reject with the same reason as a hash mismatch
+            # rather than 500: an oversize body is an accept-time
+            # rejection, not a server error.
+            self.context.logger.exception(
+                "Rejecting offchain request %s: ipfs_data exceeds the "
+                "single-block CID bound.",
+                request_id,
+            )
+            return False
+        local_digest_hex = to_multihash(local_cid)
+        # Strip a leading ``0x`` (guaranteed by ``IPFS_HASH_RE``) and,
+        # if the caller sent the 34-byte multihash form, the ``1220``
+        # SHA-256 function-code + digest-length prefix. Both forms
+        # collapse to the 64-hex-char raw digest for the compare.
+        posted_hex = ipfs_hash[2:]
+        if posted_hex.startswith(IPFS_HASH_MULTIHASH_PREFIX):
+            posted_hex = posted_hex[len(IPFS_HASH_MULTIHASH_PREFIX) :]
+        # Case-fold: ``IPFS_HASH_RE`` accepts both cases; ``to_multihash``
+        # returns lowercase. Compare lowercase to lowercase.
+        if posted_hex.lower() != local_digest_hex.lower():
+            self.context.logger.error(
+                "Rejecting offchain request %s: local CID digest "
+                "0x%s does not match posted ipfs_hash %s.",
+                request_id,
+                local_digest_hex,
+                ipfs_hash,
+            )
+            return False
+        return True
+
+    def _is_duplicate_request(self, request_id: str) -> bool:
+        """Return True iff ``request_id`` is already known to the handler.
+
+        Trace of the off-chain request lifecycle:
+
+        1. ``_enqueue_offchain_request`` writes
+           ``in_memory_requests[str(request_id)]`` at accept time.
+        2. The behaviour picks the task, executes it, and pops
+           ``in_memory_requests[str(req_id)]`` in ``_handle_done_task``
+           (see ``behaviours.py:1604``). Between accept and pop the
+           entry is present through every intermediate state (pending
+           list, ``_executing_task`` attribute).
+        3. ``offchain_request_responses[str(request_id)]`` is populated
+           at settlement (delivered) and at post-auth rejection
+           (``_record_offchain_failure``).
+
+        Union of the two dicts therefore covers every state a caller
+        might retry into (pending, executing, delivered, rejected).
+        Keys on both sides are ``str``; the wire ``request_id`` is
+        also ``str`` after the ``REQUEST_ID_RE`` guard, so no coercion
+        is needed for the lookup.
+
+        :param request_id: the wire-format request id (already
+            ``REQUEST_ID_RE``-validated and inside the uint256 bound).
+        :return: True if the id is present in either in-memory dict.
+        """
+        return (
+            request_id in self.in_memory_requests
+            or request_id in self.offchain_request_responses
+        )
 
     def _handle_offchain_request_info(
         self, http_msg: HttpMessage, http_dialogue: HttpDialogue
@@ -1233,8 +1619,9 @@ class MechHttpHandler(AbstractResponseHandler):
         status_text: str,
         extra_headers: str = "",
         body_extras: Optional[Dict[str, Any]] = None,
+        record_response: bool = False,
     ) -> None:
-        """Build a rejection payload, store it, and send the HTTP error response.
+        """Build a rejection payload, optionally persist it, and reply.
 
         :param http_msg: the incoming HTTP request message.
         :param http_dialogue: the HTTP dialogue used to reply.
@@ -1244,6 +1631,14 @@ class MechHttpHandler(AbstractResponseHandler):
         :param status_text: the HTTP status text to emit.
         :param extra_headers: optional pre-formatted header block to prepend.
         :param body_extras: optional dict merged into the JSON response body.
+        :param record_response: when True, persist the rejection payload in
+            ``offchain_request_responses`` keyed by ``request_id`` so the
+            polling endpoint can surface it. Callers on pre-authentication
+            paths (bad signature, malformed body, ledger unavailable)
+            must leave this False so a caller cannot pre-populate an
+            arbitrary payload under an id they do not own. Only the 402
+            balance-insufficient path passes True: the caller has already
+            proven signature ownership and needs the challenge readable.
         """
         # Each header line must be newline-terminated, else it would silently
         # merge with the Content-Type line that follows.
@@ -1260,7 +1655,8 @@ class MechHttpHandler(AbstractResponseHandler):
         }
         if body_extras:
             response_payload.update(body_extras)
-        self.offchain_request_responses[request_id] = response_payload
+        if record_response:
+            self.offchain_request_responses[request_id] = response_payload
         http_response = http_dialogue.reply(
             performative=HttpMessage.Performative.RESPONSE,
             target_message=http_msg,
@@ -1283,6 +1679,12 @@ class MechHttpHandler(AbstractResponseHandler):
         with no HTTP reply (hung). This emits a definitive 500 instead; passing
         no extra_headers keeps the senders' own newline guard from re-raising.
 
+        Both current 500 call sites are post-authentication (the sig-verify
+        gate has already passed and the caller has proven ownership of
+        ``request_id``), so persisting the rejection payload for the
+        polling endpoint is safe: it cannot be used to pre-poison an id
+        the caller does not own.
+
         :param http_msg: the incoming HTTP request message.
         :param http_dialogue: the HTTP dialogue used to reply.
         :param request_id: the off-chain request id being rejected.
@@ -1294,6 +1696,7 @@ class MechHttpHandler(AbstractResponseHandler):
             reason="internal error",
             status_code=HttpCode.INTERNAL_SERVER_ERROR_CODE.value,
             status_text="Internal server error",
+            record_response=True,
         )
 
     def _build_402_challenge(
@@ -1350,13 +1753,20 @@ class MechHttpHandler(AbstractResponseHandler):
         """Build the ``WWW-Authenticate`` header line for a 402 response.
 
         :return: a single header line terminated with newline.
+        :raises ValueError: if no marketplace mech is configured; without
+            it the ``realm`` would be blank and clients could not route
+            the deposit to the right balance tracker.
         """
         # The ``realm`` carries the mech address so clients with multiple mechs
         # configured can route the deposit to the right balance tracker.
-        mech_address = self.params.agent_mech_contract_addresses[0]
+        if self._marketplace_mech_address is None:
+            raise ValueError(
+                "cannot build a WWW-Authenticate header without a "
+                "marketplace mech address"
+            )
         return (
             f'WWW-Authenticate: Payment scheme="{PAYMENT_SCHEME}" '
-            f'realm="{mech_address}"\n'
+            f'realm="{self._marketplace_mech_address}"\n'
         )
 
     def _build_payment_receipt_header(
@@ -1554,6 +1964,11 @@ class MechHttpHandler(AbstractResponseHandler):
     ) -> Dict[str, Union[str, int]]:
         """Check requester balance in balance tracker against requested delivery rate."""
         required_amount = int(delivery_rate)
+        if self._marketplace_mech_address is None:
+            return self._make_unavailable_balance_response(
+                required_amount,
+                "No marketplace mech configured for the offchain handler.",
+            )
         ledger_settings = self._get_ledger_settings()
         if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
             return self._make_unavailable_balance_response(
@@ -1568,7 +1983,7 @@ class MechHttpHandler(AbstractResponseHandler):
 
             requester = ledger_api.api.to_checksum_address(sender)
             mech_address = ledger_api.api.to_checksum_address(
-                self.params.agent_mech_contract_addresses[0]
+                self._marketplace_mech_address
             )
             marketplace_address = ledger_api.api.to_checksum_address(
                 self.params.mech_marketplace_address
@@ -1729,8 +2144,14 @@ class MechHttpHandler(AbstractResponseHandler):
             marketplace_address = ledger_api.api.to_checksum_address(
                 self.params.mech_marketplace_address
             )
+            # The cached ``_marketplace_mech_address`` is non-None here
+            # because ``_domain_separator`` / ``_payment_type`` are both
+            # None when the address is None (see
+            # ``_initialise_offchain_verification_constants``), and the
+            # None-guard on those constants at the top of this method
+            # would have already returned False.
             mech_address = ledger_api.api.to_checksum_address(
-                self.params.agent_mech_contract_addresses[0]
+                cast(str, self._marketplace_mech_address)
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             self.context.logger.error(

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -27,7 +27,7 @@ import time
 import urllib.parse
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, NamedTuple, Optional, Union, cast
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union, cast
 
 from aea.protocols.base import Message
 from aea.skills.base import Handler
@@ -132,6 +132,52 @@ MAX_REQUEST_ID = 2**256 - 1
 # ``mapNonces`` array consume would fail the whole batch.
 NONCE_RE = re.compile(r"\A(0|[1-9][0-9]*)\Z")
 MAX_NONCE = 2**256 - 1
+
+# Maximum gap between the wire ``nonce`` and the on-chain
+# ``MechMarketplace.mapNonces[sender]`` value that the accept path
+# tolerates before rejecting. The settlement path groups a per-sender
+# batch by ``nonce`` and consumes the on-chain counter strictly in
+# order; a sender that queues too many in-flight requests ahead of the
+# on-chain cursor starves its own settlement. Sixteen leaves headroom
+# for legitimate batching (mech-client posts small bursts) while
+# keeping the wire ``nonce`` numerically close to what settlement will
+# actually see, so the derived ``request_id`` still matches when the
+# on-chain call recomputes it. A wire ``nonce`` below the on-chain
+# value can never settle at all — the counter only moves upward — so
+# the accept path refuses it as well.
+MAX_OUTSTANDING_NONCE_WINDOW = 16
+
+# Rejection reasons carried on ``SignatureVerdict`` for the nonce-bind
+# outcomes. Kept as module-level constants so tests and log-search
+# tooling can pin the exact string rather than fishing it out of the
+# enum by index.
+NONCE_BELOW_CHAIN = "wire nonce below on-chain mapNonces"
+NONCE_ABOVE_WINDOW = "wire nonce above allowed outstanding window"
+NONCE_READ_FAILED = "on-chain mapNonces read failed"
+
+# Timeout applied to the sender's ``isValidSignature`` view via the
+# provider-level HTTP timeout on the dedicated ``EthereumApi`` used for
+# EIP-1271 verification. Kept short so a slow or hostile Safe
+# ``isValidSignature`` cannot pin the AEA main thread past the
+# ``http_server`` reply budget (default ``RESPONSE_TIMEOUT=5s``). The
+# balance-check path continues to use a separately-cached
+# ``EthereumApi`` with the ledger default so a longer-running balance
+# read is not truncated at three seconds.
+_EIP1271_CALL_TIMEOUT_SECONDS = 3.0
+
+# ``gas`` cap applied to the ``isValidSignature`` ``eth_call``. Bounds
+# the amount of work a sender contract can force the RPC node to do
+# per verify. A well-behaved Safe returns in a few thousand gas; a
+# contract whose view loops to the block gas limit reverts here with
+# out-of-gas and the caller flattens the outcome to a rejected
+# signature — no accept, no runaway node work.
+_EIP1271_CALL_GAS_CAP = 500_000
+
+# Rejection reason for a Safe whose ``isValidSignature`` view exceeded
+# the provider-level HTTP timeout. Distinct from the generic
+# "signature verification failed" reason so operators can tell an
+# unresponsive Safe apart from an actively-declined signature.
+EIP1271_CALL_TIMEOUT = "eip1271 isValidSignature call timed out"
 
 # ``signature`` on the wire is the hex encoding of the packed signature
 # bytes with a mandatory ``0x`` prefix. The settlement path
@@ -952,10 +998,60 @@ class MechHttpHandler(AbstractResponseHandler):
         self._marketplace_mech_address: Optional[str] = (
             self._resolve_marketplace_mech_address()
         )
+        # Cache ``EthereumApi`` instances keyed by
+        # ``(rpc_address, chain_id, timeout_seconds)``. Every construction
+        # of ``EthereumApi`` builds a fresh ``RotatingHTTPProvider`` and
+        # connection pool; caching keeps one instance per (rpc, chain,
+        # timeout) tuple for the process lifetime so the sig-verify and
+        # balance-check paths reuse pooled connections instead of opening
+        # a new pool per accept. Keyed on ``timeout_seconds`` as well as
+        # ``(rpc, chain_id)`` so the short-timeout instance used for the
+        # EIP-1271 view coexists with the ledger-default instance used
+        # for the balance-check reads without either overwriting the
+        # other's provider timeout.
+        self._ledger_api_cache: Dict[Tuple[str, int, float], EthereumApi] = {}
         if self.params.use_offchain:
             self._initialise_offchain_verification_constants()
         self.start_prometheus_server()
         super().setup()
+
+    def _get_ledger_api(
+        self,
+        rpc_address: str,
+        chain_id: int,
+        timeout_seconds: Optional[float] = None,
+    ) -> EthereumApi:
+        """Return a cached ``EthereumApi`` for ``(rpc_address, chain_id, timeout)``.
+
+        A missing entry constructs a new ``EthereumApi`` (which builds a
+        ``RotatingHTTPProvider`` + connection pool) and stores it. Subsequent
+        calls for the same key return the same instance. When
+        ``timeout_seconds`` is ``None`` the ledger default HTTP timeout is
+        used and the cache key stores that as ``0.0``; a positive value
+        pins the provider-level HTTP timeout for calls made through the
+        returned instance.
+
+        :param rpc_address: the RPC endpoint URL (or comma-separated list
+            consumed by ``RotatingHTTPProvider``).
+        :param chain_id: the ledger chain id.
+        :param timeout_seconds: optional provider-level HTTP timeout in
+            seconds. ``None`` uses the ledger default (30s).
+        :return: the cached (or freshly-constructed) ``EthereumApi``.
+        """
+        cache_key: Tuple[str, int, float] = (
+            rpc_address,
+            chain_id,
+            0.0 if timeout_seconds is None else float(timeout_seconds),
+        )
+        cached = self._ledger_api_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        kwargs: Dict[str, Any] = {"address": rpc_address, "chain_id": chain_id}
+        if timeout_seconds is not None:
+            kwargs["timeout"] = float(timeout_seconds)
+        ledger_api = EthereumApi(**kwargs)
+        self._ledger_api_cache[cache_key] = ledger_api
+        return ledger_api
 
     def _resolve_marketplace_mech_address(self) -> Optional[str]:
         """Return the mech address flagged ``is_marketplace_mech`` in config.
@@ -1009,7 +1105,7 @@ class MechHttpHandler(AbstractResponseHandler):
         try:
             rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
             chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
-            ledger_api = EthereumApi(address=rpc_address, chain_id=chain_id)
+            ledger_api = self._get_ledger_api(rpc_address, chain_id)
             self._domain_separator = get_marketplace_domain_separator(
                 ledger_api=ledger_api,
                 marketplace_address=self.params.mech_marketplace_address,
@@ -2130,7 +2226,7 @@ class MechHttpHandler(AbstractResponseHandler):
         try:
             rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
             chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
-            ledger_api = EthereumApi(address=rpc_address, chain_id=chain_id)
+            ledger_api = self._get_ledger_api(rpc_address, chain_id)
 
             requester = ledger_api.api.to_checksum_address(sender)
             mech_address = ledger_api.api.to_checksum_address(
@@ -2243,8 +2339,18 @@ class MechHttpHandler(AbstractResponseHandler):
            request_id disagrees with the locally-derived value. The
            caller replies 401.
         3. Try local ``ecrecover`` against ``sender``. Match wins with
-           zero RPC.
-        4. Fall back to the sender's EIP-1271 ``isValidSignature`` view.
+           zero RPC for the sig-recover step.
+        4. Fall back to the sender's EIP-1271 ``isValidSignature`` view
+           via a cached short-timeout ``EthereumApi``; a transport
+           timeout on the view surfaces as a 401 with a dedicated
+           reason.
+        5. Bind the wire ``nonce`` to the sender's on-chain
+           ``MechMarketplace.mapNonces[sender]`` value. A wire value
+           below the on-chain counter, or more than
+           ``MAX_OUTSTANDING_NONCE_WINDOW`` above it, rejects 401. A
+           transport-level failure on the ``mapNonces`` read fails
+           closed as 503 rather than accepting under an unknown
+           counter.
 
         :param sender: the requester address, EOA or Safe.
         :param ipfs_hash: 0x-prefixed hex string used as the on-chain
@@ -2257,11 +2363,14 @@ class MechHttpHandler(AbstractResponseHandler):
         :param signature_hex: hex-encoded signature bytes, with or without
             a leading ``0x``.
         :return: a :class:`SignatureVerdict`. ``ok=True`` on a valid
-            signature; ``ok=False`` with ``is_infra=True`` on
+            signature whose wire nonce sits inside the accepted
+            on-chain window; ``ok=False`` with ``is_infra=True`` on
             server-side prerequisites (constants unset, ledger config
-            missing, address preparation failure) or ``is_infra=False``
-            on a bad-caller outcome (malformed hex, derivation
-            mismatch, sig recovery failure).
+            missing, address preparation failure, ``mapNonces`` read
+            failure) or ``is_infra=False`` on a bad-caller outcome
+            (malformed hex, derivation mismatch, sig recovery failure,
+            EIP-1271 view timeout, wire nonce below the on-chain
+            counter or above the accepted window).
         """
         if self._domain_separator is None or self._payment_type is None:
             self.context.logger.error(
@@ -2308,7 +2417,7 @@ class MechHttpHandler(AbstractResponseHandler):
         try:
             rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
             chain_id = cast(int, ledger_settings[ResponseKey.CHAIN_ID.value])
-            ledger_api = EthereumApi(address=rpc_address, chain_id=chain_id)
+            ledger_api = self._get_ledger_api(rpc_address, chain_id)
             sender_checksum = ledger_api.api.to_checksum_address(sender)
             marketplace_address = ledger_api.api.to_checksum_address(
                 self.params.mech_marketplace_address
@@ -2373,23 +2482,140 @@ class MechHttpHandler(AbstractResponseHandler):
 
         recovered = recover_eoa_signer(derived, signature_bytes)
         if recovered is not None and recovered == sender_checksum:
-            return SignatureVerdict(ok=True, reason="", is_infra=False)
+            return self._bind_wire_nonce_to_chain(
+                ledger_api=ledger_api,
+                sender_checksum=sender_checksum,
+                wire_nonce=nonce,
+                wire_request_id=wire_request_id,
+            )
 
         # Sender is either a Safe or an EOA that produced an unrecognised
         # signature. Defer to the sender's EIP-1271 view for the final call.
-        eip1271_ok = check_eip1271_signature(
-            ledger_api=ledger_api,
-            contract_address=sender_checksum,
-            message_hash=derived,
-            signature=signature_bytes,
+        # Use a separately-cached ``EthereumApi`` with a short provider
+        # HTTP timeout so a slow ``isValidSignature`` view cannot pin the
+        # AEA main thread past the ``http_server`` reply budget; the
+        # balance-check path continues to run against the ledger-default
+        # ``EthereumApi`` cached above.
+        eip1271_ledger_api = self._get_ledger_api(
+            rpc_address, chain_id, timeout_seconds=_EIP1271_CALL_TIMEOUT_SECONDS
         )
+        try:
+            eip1271_ok = check_eip1271_signature(
+                ledger_api=eip1271_ledger_api,
+                contract_address=sender_checksum,
+                message_hash=derived,
+                signature=signature_bytes,
+                gas=_EIP1271_CALL_GAS_CAP,
+            )
+        except TimeoutError as exc:
+            self.context.logger.warning(
+                "EIP-1271 isValidSignature timed out for sender %s on "
+                "request %s: %s.",
+                sender_checksum,
+                wire_request_id,
+                exc,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=EIP1271_CALL_TIMEOUT,
+                is_infra=False,
+            )
         if eip1271_ok:
-            return SignatureVerdict(ok=True, reason="", is_infra=False)
+            return self._bind_wire_nonce_to_chain(
+                ledger_api=ledger_api,
+                sender_checksum=sender_checksum,
+                wire_nonce=nonce,
+                wire_request_id=wire_request_id,
+            )
         return SignatureVerdict(
             ok=False,
             reason="signature verification failed",
             is_infra=False,
         )
+
+    def _bind_wire_nonce_to_chain(
+        self,
+        ledger_api: EthereumApi,
+        sender_checksum: str,
+        wire_nonce: int,
+        wire_request_id: str,
+    ) -> SignatureVerdict:
+        """Bind the wire ``nonce`` to ``MechMarketplace.mapNonces[sender]``.
+
+        Reads the sender's current ``mapNonces`` counter from the
+        marketplace and compares against the wire value. A wire value
+        below the on-chain counter can never settle (the counter only
+        moves upward), and a wire value too far above the counter will
+        starve the sender's own settlement queue before it can drain
+        because settlement consumes ``mapNonces`` strictly in order.
+        Both outcomes reject with 401. A transport-level failure on
+        the read returns an infra verdict (503) rather than accepting
+        under an unknown nonce.
+
+        :param ledger_api: cached ``EthereumApi`` used for the read.
+        :param sender_checksum: the sender address in checksum form.
+        :param wire_nonce: the ``nonce`` supplied on the wire (already
+            coerced to ``int`` and range-checked at ingress).
+        :param wire_request_id: the wire request_id, for logging only.
+        :return: a :class:`SignatureVerdict`. ``ok=True`` when the wire
+            nonce sits in ``[on_chain, on_chain + MAX_OUTSTANDING_NONCE_WINDOW]``;
+            ``ok=False`` (401) on out-of-window; ``ok=False`` with
+            ``is_infra=True`` (503) on read failure.
+        """
+        try:
+            on_chain_result = MechMarketplaceContract.get_nonce(
+                ledger_api=ledger_api,
+                contract_address=self.params.mech_marketplace_address,
+                sender_address=sender_checksum,
+            )
+            on_chain_nonce = int(cast(int, on_chain_result.get(BodyKey.DATA.value, 0)))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Transport, decode, or RPC error on the ``mapNonces`` read.
+            # Fail closed with an infra verdict so the caller returns
+            # 503 and a well-behaved client retries; accepting under an
+            # unknown nonce would let a wire value that settlement will
+            # later reject enqueue a task the operator pays to run.
+            self.context.logger.warning(
+                "mapNonces read failed for sender %s on request %s: %s.",
+                sender_checksum,
+                wire_request_id,
+                exc,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_READ_FAILED,
+                is_infra=True,
+            )
+        if wire_nonce < on_chain_nonce:
+            self.context.logger.warning(
+                "Wire nonce %d below on-chain mapNonces %d for sender %s "
+                "on request %s.",
+                wire_nonce,
+                on_chain_nonce,
+                sender_checksum,
+                wire_request_id,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_BELOW_CHAIN,
+                is_infra=False,
+            )
+        if wire_nonce > on_chain_nonce + MAX_OUTSTANDING_NONCE_WINDOW:
+            self.context.logger.warning(
+                "Wire nonce %d exceeds on-chain mapNonces %d by more than "
+                "the allowed window %d for sender %s on request %s.",
+                wire_nonce,
+                on_chain_nonce,
+                MAX_OUTSTANDING_NONCE_WINDOW,
+                sender_checksum,
+                wire_request_id,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_ABOVE_WINDOW,
+                is_infra=False,
+            )
+        return SignatureVerdict(ok=True, reason="", is_infra=False)
 
     def _get_ledger_settings(self) -> Dict[str, Union[str, int]]:
         """Read ledger RPC settings from skill params using default_chain_id."""

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -2482,12 +2482,30 @@ class MechHttpHandler(AbstractResponseHandler):
 
         recovered = recover_eoa_signer(derived, signature_bytes)
         if recovered is not None and recovered == sender_checksum:
+            self.context.logger.info(
+                "offchain_auth accepted request %s sender=%s "
+                "mechanism=ecrecover recovered=%s",
+                wire_request_id,
+                sender_checksum,
+                recovered,
+            )
             return self._bind_wire_nonce_to_chain(
                 ledger_api=ledger_api,
                 sender_checksum=sender_checksum,
                 wire_nonce=nonce,
                 wire_request_id=wire_request_id,
             )
+        # Log the EOA branch outcome for auditability: recovery either
+        # returned ``None`` (malformed / malleable / bad-v signature) or
+        # yielded an address other than the declared sender. The
+        # EIP-1271 fallback runs next.
+        self.context.logger.debug(
+            "offchain_auth eoa_recovery_failed request=%s sender=%s "
+            "recovered=%s (falls through to EIP-1271 branch)",
+            wire_request_id,
+            sender_checksum,
+            recovered,
+        )
 
         # Sender is either a Safe or an EOA that produced an unrecognised
         # signature. Defer to the sender's EIP-1271 view for the final call.
@@ -2515,12 +2533,24 @@ class MechHttpHandler(AbstractResponseHandler):
                 wire_request_id,
                 exc,
             )
+            # Provider-side slowness — the gas cap already bounds a
+            # hostile ``isValidSignature`` view to sub-millisecond CPU
+            # (that path surfaces as ``ContractLogicError`` and flattens
+            # to ``False`` on the other branch), so a timeout at this
+            # depth is an infrastructure signal, mirroring
+            # ``NONCE_READ_FAILED`` under identical conditions.
             return SignatureVerdict(
                 ok=False,
                 reason=EIP1271_CALL_TIMEOUT,
-                is_infra=False,
+                is_infra=True,
             )
         if eip1271_ok:
+            self.context.logger.info(
+                "offchain_auth accepted request %s sender=%s "
+                "mechanism=eip1271",
+                wire_request_id,
+                sender_checksum,
+            )
             return self._bind_wire_nonce_to_chain(
                 ledger_api=ledger_api,
                 sender_checksum=sender_checksum,

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -1243,9 +1243,13 @@ class MechHttpHandler(AbstractResponseHandler):
             # must terminate /send_signed_requests at a single agent
             # or the gate misbehaves. Warn loudly on boot so the
             # invariant is alertable rather than invisible when the
-            # deployment fans out ingress.
-            num_agents = getattr(self.params, "num_agents", 1) or 1
-            if num_agents > 1:
+            # deployment fans out ingress. ``isinstance`` guard so
+            # test harnesses that stand up ``skill_context`` with a
+            # ``MagicMock`` params namespace don't trip the ``>``
+            # comparison — real ``Params.num_agents`` is always an
+            # ``int``.
+            num_agents = getattr(self.params, "num_agents", 1)
+            if isinstance(num_agents, int) and num_agents > 1:
                 self.context.logger.warning(
                     "Offchain accept path is enabled with num_agents=%d; "
                     "deployment MUST ensure /send_signed_requests ingress "

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -65,6 +65,7 @@ from packages.valory.skills.task_execution.dialogues import HttpDialogue
 from packages.valory.skills.task_execution.models import Params
 from packages.valory.skills.task_execution.utils import preimage as preimage_buffer
 from packages.valory.skills.task_execution.utils.eip1271 import (
+    Eip1271Verdict,
     check_eip1271_signature,
     get_marketplace_domain_separator,
     get_marketplace_request_id_view,
@@ -93,15 +94,33 @@ PAYMENT_INFO = "payment_info"
 ROUTES_INFO = "routes_info"
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
 IN_MEMORY_REQUESTS = "in_memory_requests"
-# Live outstanding accepted-but-unsettled wire nonces per sender. Keyed
-# by the sender's checksum address; values are the set of wire nonces
-# currently held in ``pending_tasks`` / ``in_memory_requests`` awaiting
-# settlement. Read by the nonce-bind admission gate to require the next
-# wire nonce equal exactly the on-chain ``mapNonces`` value plus the
-# outstanding count (no gaps, no duplicates). Written from the accept
-# path (on enqueue) and cleared on rollback, done, and rejection —
-# same lifecycle as ``in_memory_requests`` so the two stay coherent.
-OUTSTANDING_NONCES_BY_SENDER = "outstanding_nonces_by_sender"
+# Accepted-but-not-yet-done wire nonces per sender. Populated on
+# ``_enqueue_offchain_request`` and removed on rollback / done / rejection.
+# ``done`` here means the task completed on the mech side (
+# ``_finalize_done_task``) — at that moment the nonce transitions from
+# the accepted set to the settling set, where it stays until the batch
+# on-chain settlement advances ``MechMarketplace.mapNonces[sender]``
+# past the nonce and the pruning pass in ``_bind_wire_nonce_to_chain``
+# removes it. See ``SETTLING_NONCES_BY_SENDER`` for the settlement-gap
+# half of the split.
+ACCEPTED_NONCES_BY_SENDER = "accepted_nonces_by_sender"
+# Wire nonces that have moved to done_tasks but whose batch settlement
+# has not yet landed on chain. Populated when
+# ``_release_outstanding_nonce`` fires on ``_finalize_done_task`` and
+# drained when ``_bind_wire_nonce_to_chain`` reads a
+# ``mapNonces[sender]`` value at or past the nonce (pruning below).
+# Required so the admission gate's next-expected-slot formula stays
+# monotonic across the release/settlement gap: without this half, the
+# formula would double-count the nonce (once in ``mapNonces`` which
+# hasn't advanced yet, once nowhere because ``accepted`` was already
+# cleared) and admit a duplicate under a colliding request_id or 503
+# the sender's next honest sequential slot until settlement lands.
+SETTLING_NONCES_BY_SENDER = "settling_nonces_by_sender"
+# Retained for backward compat with tests / consumers still keyed on
+# the pre-split name. Kept identical to ``ACCEPTED_NONCES_BY_SENDER``
+# so a shared-state seed against the old key still populates the
+# accepted-half of the admission gate.
+OUTSTANDING_NONCES_BY_SENDER = ACCEPTED_NONCES_BY_SENDER
 JSON_CONTENT_HEADER = "Content-Type: application/json\n"
 ENCODING_UTF8 = "utf-8"
 
@@ -156,16 +175,44 @@ MAX_REQUEST_ID = 2**256 - 1
 NONCE_BELOW_EXPECTED = "wire nonce below sender's next expected slot"
 NONCE_ABOVE_EXPECTED = "wire nonce above sender's next expected slot"
 NONCE_READ_FAILED = "on-chain mapNonces read failed"
+# Non-transient companion of ``NONCE_READ_FAILED`` used when the
+# ``mapNonces`` read fails deterministically (ABI drift, wrong
+# ``mech_marketplace_address``, unwrapped ledger return). Same 503
+# status code so the client backs off, but the reason string names the
+# fault as unrecoverable so an operator paging on the log line can
+# distinguish an infra blip from a config error.
+NONCE_READ_UNRECOVERABLE = "on-chain mapNonces read unrecoverable"
+# Distinct reason surfaced when checksum conversion of the wire
+# ``sender`` fails — a config-side problem (missing / malformed RPC
+# settings) rather than an RPC round-trip failure. Kept separate from
+# ``NONCE_READ_FAILED`` so operators can attribute the outcome to the
+# right subsystem.
+SENDER_RESOLUTION_FAILED = "sender address resolution failed"
+# Reason surfaced when the sender exceeds the per-sender in-flight cap
+# (``MAX_ACCEPTED_PER_SENDER``). ``is_infra=True`` at the caller so
+# mech-client's 503 handling backs off rather than treating the
+# outcome as a credential rejection — nothing about the client's
+# signature is wrong, they simply have too much unsettled work.
+SENDER_INFLIGHT_LIMIT = "sender in-flight request limit reached"
+# Reason surfaced when the EIP-1271 ``isValidSignature`` view call
+# fails with an infra-side error distinct from a genuine credential
+# rejection (``Web3RPCError``, ``BadResponseFormat``,
+# ``Web3ValidationError``, ``RequestException``, ``ValueError``, or
+# the wall-clock deadline). ``is_infra=True`` at the caller so the
+# client sees 503 with a "try again later" verdict rather than 401
+# "unauthorized" during an infra failure. A revert, an out-of-gas,
+# or a codeless target still returns the ``DECLINED`` verdict below
+# and stays 401.
+EIP1271_CALL_FAILED = "eip1271 isValidSignature call failed"
 
 # Timeout applied to the sender's ``isValidSignature`` view via the
 # provider-level HTTP timeout on the dedicated ``EthereumApi`` used for
 # EIP-1271 verification. Kept short so a slow or hostile Safe
 # ``isValidSignature`` cannot pin the AEA main thread past the
 # ``http_server`` reply budget (default ``RESPONSE_TIMEOUT=5s``). The
-# balance-check path continues to use a separately-cached
-# ``EthereumApi`` with the ledger default so a longer-running balance
-# read is not truncated at three seconds.
-_EIP1271_CALL_TIMEOUT_SECONDS = 3.0
+# balance-check path uses ``_BALANCE_RPC_DEADLINE_SECONDS`` under the
+# same executor to bound its own three unbounded balance-read RPCs.
+_EIP1271_CALL_TIMEOUT_SECONDS = 2.0
 
 # ``gas`` cap applied to the ``isValidSignature`` ``eth_call``. Bounds
 # the amount of work a sender contract can force the RPC node to do
@@ -181,10 +228,10 @@ _EIP1271_CALL_GAS_CAP = 500_000
 # unresponsive Safe apart from an actively-declined signature.
 EIP1271_CALL_TIMEOUT = "eip1271 isValidSignature call timed out"
 
-# Wall-clock deadline enforced on the two on-path RPCs the sig-verify
-# code makes (EIP-1271 ``isValidSignature`` and marketplace
-# ``mapNonces``). The per-HTTP-request timeout on ``EthereumApi`` is
-# not a wall-clock bound: both ``web3.HTTPProvider``'s
+# Wall-clock deadline enforced on the on-path RPCs the accept path
+# makes (EIP-1271 ``isValidSignature``, marketplace ``mapNonces``, and
+# the three balance-check reads). The per-HTTP-request timeout on
+# ``EthereumApi`` is not a wall-clock bound: both ``web3.HTTPProvider``'s
 # ``exception_retry_configuration`` (five retries with backoff on
 # ``requests.Timeout``) and open-aea's ``RotatingHTTPProvider``
 # (``min(MAX_RETRIES=6, url_count * 2)`` outer retries with
@@ -197,10 +244,55 @@ EIP1271_CALL_TIMEOUT = "eip1271 isValidSignature call timed out"
 # underlying HTTP call keeps running in the worker thread but the
 # handler-thread returns and the outcome maps to the same infra
 # verdicts (``EIP1271_CALL_TIMEOUT`` / ``NONCE_READ_FAILED``) as any
-# other transport failure. Four seconds leaves a one-second margin
-# under the five-second http_server reply budget so the client sees a
-# verdict before the server-side timeout fires.
-_RPC_WALL_CLOCK_DEADLINE_SECONDS = 4.0
+# other transport failure. Two seconds fits inside the accept-path
+# per-request budget: worst-case 2 (sig) + 2 (mapNonces) + 3 * 2
+# (balance path) = 10s of RPC work under complete infra collapse.
+# The healthy case (all RPCs <500ms) still returns inside the 5s
+# ``http_server`` reply budget with room to spare. The pathological
+# all-timeout case gives the client a 408 from the server-side
+# ``http_server`` timeout — accepted trade-off since no accept
+# verdict is coming from the mech either under total RPC collapse.
+_RPC_WALL_CLOCK_DEADLINE_SECONDS = 2.0
+
+# Wall-clock deadline for each of the three balance-check RPCs
+# (``paymentType`` on the mech, ``getBalanceTrackerForMechType`` on the
+# marketplace, ``getRequesterBalance`` on the balance tracker). Each
+# call was previously unbounded at the ledger-default 30 s per HTTP
+# request times the ``RotatingHTTPProvider`` retry loop. Two seconds
+# per call caps the healthy-case aggregate under a second and the
+# worst-case aggregate at six seconds, matching the same trade-off
+# ``_RPC_WALL_CLOCK_DEADLINE_SECONDS`` picks for the sig-verify calls.
+_BALANCE_RPC_DEADLINE_SECONDS = 2.0
+
+# Per-sender cap on ``accepted + settling`` in-flight nonces. Guards
+# the previously-unbounded growth of ``accepted_nonces_by_sender`` and
+# ``pending_tasks`` after the deletion of the arbitrary
+# ``MAX_OUTSTANDING_NONCE_WINDOW`` protocol constraint. 64 is a
+# generous burst budget for a well-behaved trader (mech-client rarely
+# fires more than a handful of parallel requests) while keeping the
+# handler's post-auth pre-payment memory footprint bounded on the DoS
+# path. Operators tuning this need to keep it above the peak
+# legitimate burst and well below any absolute per-agent memory bound.
+MAX_ACCEPTED_PER_SENDER = 64
+
+# Bound on the RPC executor's pending-work queue. ``submit()`` on an
+# unbounded queue never blocks, so a wave of hung RPCs draining the
+# worker pool (all workers stuck on slow / hostile calls) still
+# accepts new submissions; ``future.result(deadline)`` then fires
+# WITHOUT the callable ever having run and the caller reports a
+# retry-storm-inducing ``NONCE_READ_FAILED`` on every request. Sizing
+# this at 4 * ``_RPC_EXECUTOR_MAX_WORKERS`` gives one queue slot per
+# worker plus three deep so a short burst can still land while the
+# saturation branch fires early on a real overload.
+_RPC_EXECUTOR_MAX_QUEUE = 16
+
+# Reason surfaced when the RPC executor's queue is saturated at
+# submit-time or the callable has not started running by the deadline.
+# ``is_infra=True`` at the caller — 503 with a distinct log line so
+# operators can distinguish "we couldn't even try" from "the RPC
+# returned late" (which flattens to ``NONCE_READ_FAILED`` or
+# ``EIP1271_CALL_TIMEOUT`` as before).
+RPC_QUEUE_SATURATED = "on-path RPC executor saturated"
 
 # ``max_workers`` for the ``ThreadPoolExecutor`` cached on
 # :class:`MechHttpHandler` and used to enforce
@@ -230,6 +322,21 @@ SIGNATURE_RE = re.compile(
     + str(SIGNATURE_BYTES_MAX)
     + r"}\Z"
 )
+
+# ``sender`` on the wire is the requester address (EOA or Safe) — a
+# 0x-prefixed 20-byte hex string, no checksum requirement (the address
+# preparation step in ``_verify_offchain_request_signature`` calls
+# ``to_checksum_address`` on it). A malformed value would otherwise
+# raise inside the address-preparation block whose ``except``
+# classifies the outcome as infra (``is_infra=True`` → 503) because
+# the same block also converts the deployment-scoped
+# ``mech_marketplace_address`` and ``_marketplace_mech_address``,
+# whose failures ARE genuine infra. Guarding at ingress keeps that
+# classification honest: a client-supplied bad address 400s here
+# alongside the other body-shape violations rather than being
+# reported to the client as "server broken, please retry" — which
+# a well-behaved auto-retry client would loop on forever.
+ADDRESS_RE = re.compile(r"\A0x[0-9a-fA-F]{40}\Z")
 
 # Boot-time self-check inputs for the marketplace ``getRequestId`` view
 # vs the local ``compute_request_id`` reimplementation. Any well-formed
@@ -646,11 +753,26 @@ class ContractHandler(BaseHandler):
         )
 
     def _update_pending_list(self, body: Dict[str, List]) -> None:
+        """Rewrite ``pending_tasks`` to only ids the on-chain status check returned.
+
+        Off-chain tasks (``is_offchain=True``) are NOT present in the
+        on-chain status body — their ``request_id`` is not visible on
+        chain until settlement lands. Filtering by
+        ``body[REQUEST_IDS]`` alone would silently drop every
+        outstanding off-chain task on every polling cycle and leak
+        their outstanding-nonce entries. Retain off-chain tasks by
+        construction so this method only prunes on-chain entries the
+        status check did not return.
+
+        :param body: the on-chain status response body.
+        """
         before = len(self.pending_tasks)
+        on_chain_ids = body[BodyKey.REQUEST_IDS.value]
         self.context.shared_state[PENDING_TASKS] = [
             req
             for req in self.pending_tasks
-            if req[RequestKey.REQUEST_ID_CAMEL.value] in body[BodyKey.REQUEST_IDS.value]
+            if req.get(RequestKey.IS_OFFCHAIN.value)
+            or req[RequestKey.REQUEST_ID_CAMEL.value] in on_chain_ids
         ]
         after = len(self.pending_tasks)
         self.context.logger.info(
@@ -994,18 +1116,48 @@ class MechHttpHandler(AbstractResponseHandler):
         return self.context.shared_state[IN_MEMORY_REQUESTS]
 
     @property
-    def outstanding_nonces_by_sender(self) -> Dict[str, Set[int]]:
-        """Get the live outstanding wire-nonce set per sender checksum.
+    def accepted_nonces_by_sender(self) -> Dict[str, Set[int]]:
+        """Get the accepted-but-not-yet-done wire nonce set per sender.
 
-        Values are ``set`` instances so admission-gate reads and mutation
-        on accept / rollback / done can share a single container without
-        rebuilding on every mutation.
+        Populated on ``_enqueue_offchain_request`` and drained on
+        rollback / done / rejection. Values are ``set`` instances so
+        admission-gate reads and mutation share a single container
+        without rebuilding on every mutation.
 
         :return: a dict keyed by sender checksum address. A missing key
-            means "no in-flight requests from this sender" and the
-            admission gate uses ``len()==0`` in that case.
+            means "no accepted-but-not-yet-done requests from this
+            sender" and the admission gate uses ``len()==0`` in that
+            case.
         """
-        return self.context.shared_state[OUTSTANDING_NONCES_BY_SENDER]
+        return self.context.shared_state[ACCEPTED_NONCES_BY_SENDER]
+
+    @property
+    def settling_nonces_by_sender(self) -> Dict[str, Set[int]]:
+        """Get the done-but-not-yet-settled wire nonce set per sender.
+
+        Populated when a task moves from ``pending_tasks`` to
+        ``done_tasks`` via ``_release_outstanding_nonce`` on the
+        behaviour side, drained by the pruning pass in
+        ``_bind_wire_nonce_to_chain`` when the on-chain
+        ``mapNonces[sender]`` advances past the nonce.
+
+        :return: a dict keyed by sender checksum address. A missing key
+            means "no done-but-unsettled requests from this sender".
+        """
+        return self.context.shared_state[SETTLING_NONCES_BY_SENDER]
+
+    @property
+    def outstanding_nonces_by_sender(self) -> Dict[str, Set[int]]:
+        """Retained alias for the pre-split ``accepted`` half.
+
+        Older tests / call sites written against the pre-split state
+        keep working: this property points at the same underlying
+        dict as ``accepted_nonces_by_sender``.
+
+        :return: the accepted-nonce map (same dict object as
+            :attr:`accepted_nonces_by_sender`).
+        """
+        return self.context.shared_state[ACCEPTED_NONCES_BY_SENDER]
 
     @property
     def params(self) -> Params:
@@ -1021,12 +1173,26 @@ class MechHttpHandler(AbstractResponseHandler):
         self.context.shared_state[IPFS_TASKS] = []
         self.context.shared_state[OFFCHAIN_REQUEST_RESPONSES] = {}
         self.context.shared_state[IN_MEMORY_REQUESTS] = {}
-        # Live outstanding accepted-but-unsettled wire nonces per sender.
-        # Populated on accept (``_enqueue_offchain_request``) and cleared
-        # on rollback / done / rejection — same lifecycle as
-        # ``in_memory_requests`` so the two containers stay coherent for
-        # the admission gate in ``_bind_wire_nonce_to_chain``.
-        self.context.shared_state[OUTSTANDING_NONCES_BY_SENDER] = {}
+        # Split live in-flight wire nonces per sender into two sets so
+        # the admission gate's next-expected-slot formula stays
+        # monotonic across the release/settlement gap. See
+        # ``ACCEPTED_NONCES_BY_SENDER`` / ``SETTLING_NONCES_BY_SENDER``
+        # module docstrings for the semantics; both are keyed by the
+        # sender's checksum address and hold ``set[int]`` values.
+        #
+        # Invariant: this state is per-agent-process. The off-chain
+        # accept path assumes single-agent ingress at
+        # ``/send_signed_requests``: multi-agent deployments MUST
+        # terminate that route on one agent (usually the leader) or
+        # the admission gate breaks (each agent sees an empty
+        # accepted+settling set for a sender the other has already
+        # served, admitting a duplicate under a colliding request_id
+        # settlement will revert). A boot-time WARNING fires below if
+        # ``use_offchain=True`` and ``num_agents>1``. Moving this
+        # state to a shared kv_store / consensus round is a bigger
+        # follow-up; the invariant + warning is the light insurance.
+        self.context.shared_state[ACCEPTED_NONCES_BY_SENDER] = {}
+        self.context.shared_state[SETTLING_NONCES_BY_SENDER] = {}
         self.json_content_header = JSON_CONTENT_HEADER
         # Deployment-scoped constants used by the offchain request-id
         # derivation: the marketplace EIP-712 ``domainSeparator`` and the
@@ -1072,6 +1238,23 @@ class MechHttpHandler(AbstractResponseHandler):
         self._rpc_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         if self.params.use_offchain:
             self._initialise_offchain_verification_constants()
+            # Per-agent ingress invariant. The admission gate above
+            # keys on process-local state; multi-agent deployments
+            # must terminate /send_signed_requests at a single agent
+            # or the gate misbehaves. Warn loudly on boot so the
+            # invariant is alertable rather than invisible when the
+            # deployment fans out ingress.
+            num_agents = getattr(self.params, "num_agents", 1) or 1
+            if num_agents > 1:
+                self.context.logger.warning(
+                    "Offchain accept path is enabled with num_agents=%d; "
+                    "deployment MUST ensure /send_signed_requests ingress "
+                    "terminates at a single agent (the outstanding-nonce "
+                    "admission gate is per-agent-process state; fanning "
+                    "out ingress lets one agent admit a wire nonce that "
+                    "another has already served).",
+                    num_agents,
+                )
         self.start_prometheus_server()
         super().setup()
 
@@ -1079,11 +1262,10 @@ class MechHttpHandler(AbstractResponseHandler):
         """Return the lazily-constructed on-path RPC executor.
 
         Kept lazy so a deployment with the off-chain path disabled never
-        spins the pool up. The pool is used exclusively to bound the
-        wall-clock time of the two on-path RPCs (EIP-1271
-        ``isValidSignature`` and marketplace ``mapNonces``); balance
-        checks stay on the AEA main thread because they run through
-        their own longer-timeout ``EthereumApi``.
+        spins the pool up. The pool is used to bound the wall-clock
+        time of every on-path RPC (EIP-1271 ``isValidSignature``,
+        marketplace ``mapNonces``, and the three balance-check reads
+        under ``_check_offchain_requester_balance``).
 
         :return: the cached ``ThreadPoolExecutor`` instance.
         """
@@ -1094,10 +1276,96 @@ class MechHttpHandler(AbstractResponseHandler):
             )
         return self._rpc_executor
 
+    def teardown(self) -> None:
+        """Shut down the RPC executor without waiting for in-flight callables.
+
+        ``ThreadPoolExecutor`` workers are non-daemon: a bare process
+        exit blocks on ``executor._threads.join()`` for any worker
+        still running an abandoned HTTP read, adding seconds to the
+        SIGTERM → SIGKILL window. ``cancel_futures=True`` (Python 3.9+)
+        drops queued callables that never started, and ``wait=False``
+        returns immediately so shutdown does not have to wait on a
+        hung provider read.
+        """
+        if self._rpc_executor is not None:
+            try:
+                self._rpc_executor.shutdown(wait=False, cancel_futures=True)
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Best-effort; teardown must not raise into the AEA
+                # shutdown path.
+                self.context.logger.exception(
+                    "Error shutting down RPC executor during teardown."
+                )
+        super().teardown()
+
+    def _make_late_outcome_callback(
+        self, started_at: float, label: str
+    ) -> Callable[["concurrent.futures.Future[Any]"], None]:
+        """Bind ``started_at`` and ``label`` for use in ``add_done_callback``.
+
+        Extracted so the caller can annotate the callback with a stable
+        one-arg signature (mypy cannot infer the lambda's parameter
+        types at the ``add_done_callback`` site).
+
+        :param started_at: monotonic timestamp of the ``submit()`` call.
+        :param label: short human-readable RPC name for the log line.
+        :return: a one-arg callable suitable for
+            :meth:`concurrent.futures.Future.add_done_callback`.
+        """
+
+        def _cb(fut: "concurrent.futures.Future[Any]") -> None:
+            self._log_late_rpc_outcome(fut, started_at, label)
+
+        return _cb
+
+    def _log_late_rpc_outcome(
+        self,
+        future: "concurrent.futures.Future[Any]",
+        started_at: float,
+        label: str,
+    ) -> None:
+        """Log the late completion of an RPC whose deadline already fired.
+
+        ``concurrent.futures.Future`` (unlike ``asyncio.Future``) never
+        logs an unretrieved exception on its own, so an eth_call that
+        eventually fails after the caller has moved on loses both the
+        error and the traceback silently — exactly the path where the
+        root cause matters most for operator triage.
+
+        :param future: the completed future for the abandoned call.
+        :param started_at: monotonic timestamp of the ``submit()`` call.
+        :param label: short human-readable RPC name for the log line.
+        :return: None.
+        """
+        elapsed = time.monotonic() - started_at
+        try:
+            exc = future.exception()
+        except (
+            concurrent.futures.CancelledError,
+            concurrent.futures.InvalidStateError,
+        ):
+            return
+        if exc is None:
+            self.context.logger.debug(
+                "on-path RPC %s completed after deadline (elapsed=%.3fs); "
+                "outcome was discarded",
+                label,
+                elapsed,
+            )
+            return
+        self.context.logger.warning(
+            "on-path RPC %s completed after deadline (elapsed=%.3fs) with "
+            "an error the caller had already moved past: %r",
+            label,
+            elapsed,
+            exc,
+        )
+
     def _run_with_wall_clock_deadline(
         self,
         fn: Callable[[], Any],
         deadline_seconds: float,
+        label: str = "unnamed",
     ) -> Any:
         """Run ``fn`` on the RPC executor and enforce a wall-clock deadline.
 
@@ -1112,21 +1380,93 @@ class MechHttpHandler(AbstractResponseHandler):
         the broad ``except`` around the ``mapNonces`` read) keeps
         working unchanged.
 
+        Queue saturation is a distinct outcome from "the RPC took too
+        long": a wave of hung callables donates all worker slots to
+        never-returning HTTP reads, ``submit()`` still lands on the
+        unbounded queue, and ``future.result(timeout=...)`` fires
+        WITHOUT the callable ever having started. Detect this with
+        ``future.running()`` after the timeout — if the callable hasn't
+        started, raise :class:`RuntimeError` labelled ``RPC_QUEUE_SATURATED``
+        so the caller can route to a queue-saturation verdict instead
+        of the generic "read failed" one that a real RPC timeout uses.
+        Also short-circuit ``submit()`` on queue depth so a genuine
+        overload rejects fast rather than piling up.
+
         :param fn: zero-arg callable that performs the RPC.
         :param deadline_seconds: wall-clock upper bound in seconds.
+        :param label: short human-readable RPC name used on late-
+            outcome log lines and saturation errors.
         :return: whatever ``fn`` returns.
         :raises concurrent.futures.TimeoutError: when the deadline
             elapses before ``fn`` returns.
+        :raises RuntimeError: on executor shutdown or on saturated
+            queue at submit time.
         """
-        future = self._get_rpc_executor().submit(fn)
+        executor = self._get_rpc_executor()
+        # Reject fast on queue overload. ``_work_queue`` is CPython
+        # private API but its ``qsize()`` is stable and behaviorally
+        # equivalent to ``deque.__len__`` (see cpython:Lib/concurrent/
+        # futures/thread.py — the queue is always ``queue.SimpleQueue``
+        # or ``queue.Queue`` and both expose ``qsize()``). We keep the
+        # bound conservative (``_RPC_EXECUTOR_MAX_QUEUE``) so a real
+        # burst still lands.
+        try:
+            queue_depth = executor._work_queue.qsize()  # noqa: SLF001
+        except Exception:  # pylint: disable=broad-exception-caught
+            queue_depth = 0
+        if queue_depth >= _RPC_EXECUTOR_MAX_QUEUE:
+            self.context.logger.warning(
+                "RPC executor queue saturated at %d for %s; failing fast "
+                "instead of piling on more work.",
+                queue_depth,
+                label,
+            )
+            raise RuntimeError(RPC_QUEUE_SATURATED)
+        started_at = time.monotonic()
+        try:
+            future = executor.submit(fn)
+        except RuntimeError:
+            # ``submit()`` raises on ``executor._shutdown`` or when
+            # ``_adjust_thread_count`` fails. Both are infra signals;
+            # let the caller surface the same 503 verdict.
+            self.context.logger.exception("RPC executor submit failed for %s.", label)
+            raise
         try:
             return future.result(timeout=deadline_seconds)
         except concurrent.futures.TimeoutError:
-            # Best-effort cancel: the underlying HTTP call can't be
-            # interrupted mid-flight, but the future is marked so the
-            # thread pool won't reuse the slot for the same callable if
-            # the call finally returns.
-            future.cancel()
+            # ``TimeoutError`` is aliased to
+            # ``concurrent.futures.TimeoutError`` in Python 3.11+, so
+            # this branch fires for BOTH the wall-clock deadline (the
+            # callable never returned) AND a callable that raised its
+            # own ``TimeoutError`` (which ``future.result`` re-raises).
+            # Disambiguate on ``future.done()``: done + timeout means
+            # the callable finished and raised, and we should let the
+            # exception propagate as a normal callable-side result.
+            if future.done():
+                raise
+            if not future.running():
+                # Callable never got a worker: the pool is drained by
+                # earlier hung calls. Distinguish this from a slow-RPC
+                # timeout so operators see the real cause.
+                self.context.logger.warning(
+                    "RPC callable %s never started before deadline "
+                    "(pool saturated with in-flight abandoned callables); "
+                    "reporting queue saturation.",
+                    label,
+                )
+                _log_cb = self._make_late_outcome_callback(started_at, label)
+                future.add_done_callback(_log_cb)
+                raise RuntimeError(RPC_QUEUE_SATURATED)
+            # ``future.cancel()`` returns False for a RUNNING future —
+            # it does NOT interrupt the underlying HTTP call and it
+            # does NOT protect the worker slot. The comment used to
+            # claim otherwise; corrected here. What we DO get: an
+            # ``add_done_callback`` fires when the abandoned call
+            # finally returns so its exception (if any) lands in the
+            # log rather than being silently discarded by
+            # ``concurrent.futures``.
+            _log_cb = self._make_late_outcome_callback(started_at, label)
+            future.add_done_callback(_log_cb)
             raise
 
     def _get_ledger_api(
@@ -1352,11 +1692,63 @@ class MechHttpHandler(AbstractResponseHandler):
     def _handle_signed_requests(
         self, http_msg: HttpMessage, http_dialogue: HttpDialogue
     ) -> None:
-        """
-        Handle POST requests to send signed tx to mech.
+        """Handle POST requests to send signed tx to mech.
 
-        :param http_msg: the HttpMessage instance
-        :param http_dialogue: the HttpDialogue instance
+        Top-level entry point. Delegates to
+        :meth:`_handle_signed_requests_impl` inside a defensive
+        ``try/except Exception`` so any un-caught error inside the
+        accept path (a fresh RPC exception class the inner tuples
+        don't cover, an ``OSError`` from a mid-flight ``ConnectionReset``,
+        anything raised out of an executor callback) surfaces as a
+        503 to the client instead of propagating out to the AEA
+        framework's default ``propagate`` handler and stopping the
+        agent. The narrower catches inside the impl still classify
+        outcomes for the log lines and per-branch verdict reasons.
+
+        :param http_msg: the HttpMessage instance.
+        :param http_dialogue: the HttpDialogue instance.
+        """
+        try:
+            self._handle_signed_requests_impl(http_msg, http_dialogue)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # A defensive backstop for anything the inner
+            # classification branches missed. ``ConnectionResetError``
+            # is an ``OSError`` (not covered by the inner tuple around
+            # ``future.result()``), a fresh ``Web3Exception`` subclass
+            # could be added in a future web3 release, or an executor
+            # callback could raise. Any of those would otherwise
+            # propagate out of the handler and — with the default
+            # ``propagate`` skill exception policy — stop the agent.
+            # ``request_id`` is unknown here (parse may have raised);
+            # the client's own timeout has almost certainly fired.
+            self.context.logger.exception("Unhandled error on offchain accept path")
+            try:
+                self._send_rejection_response(
+                    http_msg,
+                    http_dialogue,
+                    "unknown",
+                    reason="internal error",
+                    status_code=HttpCode.SERVICE_UNAVAILABLE_CODE.value,
+                    status_text="Service unavailable",
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                # The rejection sender itself failed — nothing more we
+                # can do; the client will time out its own request.
+                self.context.logger.exception(
+                    "Failed to emit defensive 503 on unhandled accept-path error"
+                )
+
+    def _handle_signed_requests_impl(
+        self, http_msg: HttpMessage, http_dialogue: HttpDialogue
+    ) -> None:
+        """Body of the signed-request handler; called under the outer guard.
+
+        Split from ``_handle_signed_requests`` so the outer try/except
+        wraps every accept-path branch by construction. See the outer
+        method for the rationale.
+
+        :param http_msg: the HttpMessage instance.
+        :param http_dialogue: the HttpDialogue instance.
         """
         # Phase 1 ships dark: the off-chain HTTP path is disabled by default and
         # enabled per deployment in the Phase 2 rollout (use_offchain). When off,
@@ -1444,6 +1836,15 @@ class MechHttpHandler(AbstractResponseHandler):
                 f"a 0x-prefixed even-length hex string within "
                 f"[{SIGNATURE_BYTES_MIN}, {SIGNATURE_BYTES_MAX}] bytes "
                 f"(len={len(signature_hex) if signature_hex else 0})."
+            )
+            self._handle_bad_request(http_msg, http_dialogue)
+            return
+
+        if not ADDRESS_RE.fullmatch(sender or ""):
+            self.context.logger.error(
+                f"Rejecting offchain request {request_id}: sender must be a "
+                f"0x-prefixed 20-byte hex address "
+                f"(len={len(sender) if sender else 0})."
             )
             self._handle_bad_request(http_msg, http_dialogue)
             return
@@ -1571,13 +1972,14 @@ class MechHttpHandler(AbstractResponseHandler):
             # Sig-verify above already succeeded, so the checksum
             # conversion should be deterministic; a failure here means
             # ledger settings were reconfigured between the two calls
-            # (settings dict is rebuilt per call). Treat as an infra
-            # verdict so the caller retries.
+            # (settings dict is rebuilt per call). Route to a distinct
+            # ``SENDER_RESOLUTION_FAILED`` reason so config-side
+            # failures are not mis-reported as RPC failures.
             self._send_rejection_response(
                 http_msg,
                 http_dialogue,
                 request_id,
-                reason=NONCE_READ_FAILED,
+                reason=SENDER_RESOLUTION_FAILED,
                 status_code=HttpCode.SERVICE_UNAVAILABLE_CODE.value,
                 status_text="Service unavailable",
             )
@@ -2239,11 +2641,16 @@ class MechHttpHandler(AbstractResponseHandler):
         ]
         self.in_memory_requests.pop(request_id, None)
         if sender_checksum is not None and wire_nonce is not None:
-            outstanding = self.outstanding_nonces_by_sender.get(sender_checksum)
-            if outstanding is not None:
-                outstanding.discard(wire_nonce)
-                if not outstanding:
-                    self.outstanding_nonces_by_sender.pop(sender_checksum, None)
+            # Rollback drops from the accepted set only. The settling
+            # set is populated by ``_release_outstanding_nonce`` on the
+            # done path — a rollback fires strictly before that
+            # transition so the entry is guaranteed to still be in the
+            # accepted half.
+            accepted = self.accepted_nonces_by_sender.get(sender_checksum)
+            if accepted is not None:
+                accepted.discard(wire_nonce)
+                if not accepted:
+                    self.accepted_nonces_by_sender.pop(sender_checksum, None)
         self.context.logger.error(
             f"Queue rollback applied for {request_id=}. "
             f"pending_tasks={len(self.pending_tasks)} "
@@ -2378,12 +2785,11 @@ class MechHttpHandler(AbstractResponseHandler):
         try:
             self.pending_tasks.append(req)
             self.in_memory_requests[request_id] = data[RequestKey.IPFS_DATA.value]
-            # Track the wire nonce as live-outstanding for this sender
-            # so the admission gate on subsequent accepts computes the
-            # correct next-expected slot. ``setdefault`` avoids
-            # clobbering an existing set built by an earlier accept
-            # from the same sender.
-            self.outstanding_nonces_by_sender.setdefault(sender_checksum, set()).add(
+            # Track the wire nonce in the sender's accepted set so the
+            # admission gate on subsequent accepts computes the correct
+            # next-expected slot. Moves to the settling set at done
+            # time via ``_release_outstanding_nonce``.
+            self.accepted_nonces_by_sender.setdefault(sender_checksum, set()).add(
                 wire_nonce
             )
         except Exception:
@@ -2503,8 +2909,21 @@ class MechHttpHandler(AbstractResponseHandler):
     def _get_mech_payment_type(
         self, ledger_api: EthereumApi, mech_address: str
     ) -> Optional[str]:
-        """Get the mech payment type from the mech contract."""
-        payment_type_res = OlasMechContract.get_mech_type(ledger_api, mech_address)
+        """Get the mech payment type from the mech contract.
+
+        Wall-clock bounded through the on-path RPC executor so a slow
+        RPC does not stall the AEA main thread past the http_server
+        reply budget. See ``_BALANCE_RPC_DEADLINE_SECONDS``.
+
+        :param ledger_api: the ledger API object.
+        :param mech_address: the mech contract address.
+        :return: the mech's payment type, or None if unavailable.
+        """
+        payment_type_res = self._run_with_wall_clock_deadline(
+            lambda: OlasMechContract.get_mech_type(ledger_api, mech_address),
+            deadline_seconds=_BALANCE_RPC_DEADLINE_SECONDS,
+            label="mech_paymentType",
+        )
         return cast(Optional[str], payment_type_res.get(BodyKey.MECH_TYPE.value))
 
     def _get_balance_tracker_address_for_payment_type(
@@ -2513,22 +2932,50 @@ class MechHttpHandler(AbstractResponseHandler):
         marketplace_address: str,
         payment_type: str,
     ) -> str:
-        """Get the balance tracker address for the provided payment type."""
-        balance_tracker_res = MechMarketplaceContract.get_balance_tracker_for_mech_type(
-            ledger_api=ledger_api,
-            contract_address=marketplace_address,
-            mech_type=payment_type,
+        """Get the balance tracker address for the provided payment type.
+
+        Wall-clock bounded through the on-path RPC executor. See
+        ``_BALANCE_RPC_DEADLINE_SECONDS``.
+
+        :param ledger_api: the ledger API object.
+        :param marketplace_address: the mech marketplace contract address.
+        :param payment_type: the mech's payment type.
+        :return: the balance tracker contract address for the payment type.
+        """
+        balance_tracker_res = self._run_with_wall_clock_deadline(
+            lambda: (
+                MechMarketplaceContract.get_balance_tracker_for_mech_type(
+                    ledger_api=ledger_api,
+                    contract_address=marketplace_address,
+                    mech_type=payment_type,
+                )
+            ),
+            deadline_seconds=_BALANCE_RPC_DEADLINE_SECONDS,
+            label="marketplace_balanceTrackerForMechType",
         )
         return cast(str, balance_tracker_res.get(BodyKey.DATA.value))
 
     def _get_requester_balance(
         self, ledger_api: EthereumApi, balance_tracker_address: str, requester: str
     ) -> int:
-        """Get requester balance from the balance tracker."""
-        requester_balance_res = BalanceTrackerContract.get_requester_balance(
-            ledger_api=ledger_api,
-            contract_address=balance_tracker_address,
-            requester=requester,
+        """Get requester balance from the balance tracker.
+
+        Wall-clock bounded through the on-path RPC executor. See
+        ``_BALANCE_RPC_DEADLINE_SECONDS``.
+
+        :param ledger_api: the ledger API object.
+        :param balance_tracker_address: the balance tracker address.
+        :param requester: the requester (Safe) address.
+        :return: the requester's balance in the balance tracker (0 if unavailable).
+        """
+        requester_balance_res = self._run_with_wall_clock_deadline(
+            lambda: BalanceTrackerContract.get_requester_balance(
+                ledger_api=ledger_api,
+                contract_address=balance_tracker_address,
+                requester=requester,
+            ),
+            deadline_seconds=_BALANCE_RPC_DEADLINE_SECONDS,
+            label="balance_tracker_getRequesterBalance",
         )
         return cast(int, requester_balance_res.get(BodyKey.REQUESTER_BALANCE.value, 0))
 
@@ -2555,16 +3002,21 @@ class MechHttpHandler(AbstractResponseHandler):
         3. Try local ``ecrecover`` against ``sender``. Match wins with
            zero RPC for the sig-recover step.
         4. Fall back to the sender's EIP-1271 ``isValidSignature`` view
-           via a cached short-timeout ``EthereumApi``; a transport
-           timeout on the view surfaces as a 401 with a dedicated
-           reason.
+           via a cached short-timeout ``EthereumApi``. The view
+           returns one of three verdicts: ``VALID`` (accept),
+           ``DECLINED`` (401 signature verification failed), or
+           ``CALL_FAILED`` (503 with the ``EIP1271_CALL_FAILED``
+           reason so an infra failure is not mis-reported as a
+           credential rejection). A transport timeout on the view
+           surfaces as 503 with the ``EIP1271_CALL_TIMEOUT`` reason.
         5. Bind the wire ``nonce`` to the sender's on-chain
-           ``MechMarketplace.mapNonces[sender]`` value. A wire value
-           below the on-chain counter, or more than
-           ``MAX_OUTSTANDING_NONCE_WINDOW`` above it, rejects 401. A
-           transport-level failure on the ``mapNonces`` read fails
-           closed as 503 rather than accepting under an unknown
-           counter.
+           ``MechMarketplace.mapNonces[sender]`` value combined with
+           the sender's live ``accepted + settling`` sets. A wire
+           value below that expected next-slot rejects 401; a wire
+           value above it, or a per-sender in-flight cap breach,
+           rejects 503. A transport-level failure on the ``mapNonces``
+           read fails closed as 503 rather than accepting under an
+           unknown counter.
 
         :param sender: the requester address, EOA or Safe.
         :param ipfs_hash: 0x-prefixed hex string used as the on-chain
@@ -2732,15 +3184,17 @@ class MechHttpHandler(AbstractResponseHandler):
             # web3 + RotatingHTTPProvider retry loops cannot stall the
             # AEA main thread past the http_server reply budget. See
             # ``_RPC_WALL_CLOCK_DEADLINE_SECONDS``.
-            eip1271_ok = self._run_with_wall_clock_deadline(
+            eip1271_verdict = self._run_with_wall_clock_deadline(
                 lambda: check_eip1271_signature(
                     ledger_api=eip1271_ledger_api,
                     contract_address=sender_checksum,
                     message_hash=derived,
                     signature=signature_bytes,
                     gas=_EIP1271_CALL_GAS_CAP,
+                    logger=self.context.logger,
                 ),
                 deadline_seconds=_RPC_WALL_CLOCK_DEADLINE_SECONDS,
+                label="eip1271_isValidSignature",
             )
         except (TimeoutError, concurrent.futures.TimeoutError) as exc:
             self.context.logger.warning(
@@ -2752,8 +3206,8 @@ class MechHttpHandler(AbstractResponseHandler):
             )
             # Provider-side slowness — the gas cap already bounds a
             # hostile ``isValidSignature`` view to sub-millisecond CPU
-            # (that path surfaces as ``ContractLogicError`` and flattens
-            # to ``False`` on the other branch), so a timeout at this
+            # (that path surfaces as ``ContractLogicError`` and returns
+            # ``DECLINED`` on the other branch), so a timeout at this
             # depth is an infrastructure signal, mirroring
             # ``NONCE_READ_FAILED`` under identical conditions.
             return SignatureVerdict(
@@ -2761,18 +3215,89 @@ class MechHttpHandler(AbstractResponseHandler):
                 reason=EIP1271_CALL_TIMEOUT,
                 is_infra=True,
             )
-        if eip1271_ok:
+        except RuntimeError as exc:
+            # Queue saturation or executor shutdown. Both are infra.
+            self.context.logger.warning(
+                "EIP-1271 isValidSignature could not be dispatched for "
+                "sender %s on request %s: %s.",
+                sender_checksum,
+                wire_request_id,
+                exc,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=RPC_QUEUE_SATURATED,
+                is_infra=True,
+            )
+        if eip1271_verdict == Eip1271Verdict.VALID:
             self.context.logger.info(
                 "offchain_auth accepted request %s sender=%s mechanism=eip1271",
                 wire_request_id,
                 sender_checksum,
             )
             return SignatureVerdict(ok=True, reason="", is_infra=False)
+        if eip1271_verdict == Eip1271Verdict.CALL_FAILED:
+            # Infra-side failure inside ``isValidSignature`` (RPC error,
+            # transport error, ABI decode failure). Route to 503 with a
+            # dedicated reason so a legitimate Safe requester is not
+            # 401'd during an RPC outage.
+            self.context.logger.warning(
+                "EIP-1271 isValidSignature call failed for sender %s on "
+                "request %s; routing to 503.",
+                sender_checksum,
+                wire_request_id,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=EIP1271_CALL_FAILED,
+                is_infra=True,
+            )
         return SignatureVerdict(
             ok=False,
             reason="signature verification failed",
             is_infra=False,
         )
+
+    @staticmethod
+    def _prune_stale_nonces(
+        nonces_by_sender: Dict[str, Set[int]],
+        sender_checksum: str,
+        on_chain_nonce: int,
+    ) -> Set[int]:
+        """Drop entries at or below ``on_chain_nonce`` and return what remains.
+
+        Called on both ``accepted`` and ``settling`` before computing
+        the admission gate's next-expected-slot formula. Guards two
+        recovery paths:
+
+        * ``settling`` shrinks naturally when the batch settlement
+          advances ``mapNonces`` past the nonce, but only if we prune
+          on read — the release side has no observer for the on-chain
+          counter.
+        * ``accepted`` should never contain a nonce at or below
+          ``on_chain_nonce`` in the healthy case (the release path
+          moves entries to ``settling`` before settlement can advance
+          the counter), but a crash / restart / a sender using both
+          the on-chain and off-chain rails could leave a stale entry
+          in the set indefinitely, silently inflating the gate's slot
+          count forever.
+
+        :param nonces_by_sender: the accepted or settling map.
+        :param sender_checksum: the sender's checksum key.
+        :param on_chain_nonce: current ``mapNonces[sender]`` value.
+        :return: the surviving set for ``sender_checksum`` (empty set
+            if the sender had none or every entry was stale). Also
+            pops the sender key from the map if nothing survives.
+        """
+        entries = nonces_by_sender.get(sender_checksum)
+        if not entries:
+            return set()
+        stale = {n for n in entries if n < on_chain_nonce}
+        if stale:
+            entries -= stale
+            if not entries:
+                nonces_by_sender.pop(sender_checksum, None)
+        return entries
 
     def _bind_wire_nonce_to_chain(
         self,
@@ -2783,45 +3308,54 @@ class MechHttpHandler(AbstractResponseHandler):
         """Admission gate: bind the wire ``nonce`` to the sender's next slot.
 
         Reads ``MechMarketplace.mapNonces[sender]`` and combines the
-        result with the sender's live outstanding accepted-but-unsettled
-        nonces to compute the single next-expected slot:
-        ``on_chain + len(outstanding)``. This is the contiguity check
-        settlement's ``_deliverMarketplaceWithSignatures`` already
-        enforces on chain — it recomputes each request_id from its own
-        ``nonce, nonce+1, ...`` counter and reverts the whole per-sender
-        batch on the first mismatch. Admitting a request that skips a
-        slot would enqueue work that settlement is guaranteed to
-        revert, dragging every legitimately co-batched request down
-        with it.
+        result with the sender's ``accepted`` and ``settling`` sets to
+        compute the single next-expected slot:
+        ``on_chain + len(accepted) + len(settling)``. This is the
+        contiguity check settlement's
+        ``_deliverMarketplaceWithSignatures`` already enforces on
+        chain — it recomputes each request_id from its own
+        ``nonce, nonce+1, ...`` counter and reverts the whole
+        per-sender batch on the first mismatch. Admitting a request
+        that skips a slot would enqueue work that settlement is
+        guaranteed to revert, dragging every legitimately co-batched
+        request down with it.
+
+        Splitting ``accepted`` from ``settling`` is required for the
+        formula to stay monotonic across the release/settlement gap.
+        ``accepted`` drains on the mech side when the task hits
+        ``_finalize_done_task``; ``mapNonces[sender]`` only advances
+        several ABCI rounds later when
+        ``_deliverMarketplaceWithSignatures`` lands on chain. Without
+        the ``settling`` half, the nonce is counted by NEITHER term
+        during that window and the gate lets a duplicate re-enter
+        (`accepted` cleared, `mapNonces` not yet advanced) OR 503s
+        every honest sequential request the sender fires until the
+        batch settles.
+
+        Both sets are pruned of entries ``< on_chain_nonce`` on every
+        call so a settlement that lands between two accepts drops
+        the corresponding entry from ``settling`` and the formula
+        collapses back to the pre-accept baseline.
 
         Outcomes:
 
-        * ``wire == expected``: accept.
-        * ``wire < expected``: reject 401 (``NONCE_BELOW_EXPECTED``) —
-          the sender signed a nonce that settlement will never derive.
-        * ``wire > expected``: reject 503 (``NONCE_ABOVE_EXPECTED``,
-          ``is_infra=True``) — the sender is racing ahead of its own
-          in-flight queue; mech-client's 503 handling retries in the
-          next round.
-        * ``wire in outstanding``: reject 401 (``NONCE_BELOW_EXPECTED``,
-          identical routing to the "already sent" branch); a duplicate
-          submission of a pending nonce would enqueue a second task
-          under a request_id settlement cannot resolve.
-        * Read failure: reject 503 (``NONCE_READ_FAILED``,
-          ``is_infra=True``).
-
-        The read itself is wall-clock bounded through the on-path RPC
-        executor so a slow ``mapNonces`` read cannot stall the AEA main
-        loop past the ``http_server`` reply budget; the timeout branch
-        routes to the same infra verdict as any other read failure.
+        * ``wire == expected``: accept (pending per-sender cap).
+        * ``wire in accepted`` or ``wire in settling``: reject 401
+          (``NONCE_BELOW_EXPECTED``); a duplicate submission of a
+          nonce that is either in flight or settling.
+        * ``wire < expected``: reject 401 (``NONCE_BELOW_EXPECTED``).
+        * ``wire > expected``: reject 503 (``NONCE_ABOVE_EXPECTED``).
+        * ``accepted + settling >= MAX_ACCEPTED_PER_SENDER``: reject
+          503 (``SENDER_INFLIGHT_LIMIT``); the sender has too much
+          unsettled work.
+        * Read failure: reject 503 (``NONCE_READ_FAILED`` or
+          ``NONCE_READ_UNRECOVERABLE``).
 
         :param sender_checksum: the sender address in checksum form.
         :param wire_nonce: the ``nonce`` supplied on the wire (already
             coerced to ``int`` and range-checked at ingress).
         :param wire_request_id: the wire request_id, for logging only.
-        :return: a :class:`SignatureVerdict`. ``ok=True`` when the wire
-            nonce equals the sender's next expected slot; ``ok=False``
-            with the appropriate reason and infra flag otherwise.
+        :return: a :class:`SignatureVerdict`.
         """
         ledger_settings = self._get_ledger_settings()
         if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
@@ -2854,18 +3388,15 @@ class MechHttpHandler(AbstractResponseHandler):
                     sender_address=sender_checksum,
                 ),
                 deadline_seconds=_RPC_WALL_CLOCK_DEADLINE_SECONDS,
+                label="mapNonces_read",
             )
             on_chain_nonce = int(cast(int, on_chain_result.get(BodyKey.DATA.value, 0)))
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            # Transport, decode, RPC error, or wall-clock deadline on
-            # the ``mapNonces`` read. Fail closed with an infra verdict
-            # so the caller returns 503 and a well-behaved client
-            # retries; accepting under an unknown nonce would let a
-            # wire value that settlement will later reject enqueue a
-            # task the operator pays to run. ``concurrent.futures.TimeoutError``
-            # is a subclass of ``Exception``, so it lands here as well.
+        except concurrent.futures.TimeoutError as exc:
+            # Wall-clock deadline elapsed. Kept separate from the
+            # broader exception branch below so operators can tell a
+            # slow RPC apart from a deterministic ABI / config drift.
             self.context.logger.warning(
-                "mapNonces read failed for sender %s on request %s: %s.",
+                "mapNonces read timed out for sender %s on request %s: %s.",
                 sender_checksum,
                 wire_request_id,
                 exc,
@@ -2875,25 +3406,91 @@ class MechHttpHandler(AbstractResponseHandler):
                 reason=NONCE_READ_FAILED,
                 is_infra=True,
             )
-        # Combine the on-chain counter with the live outstanding set
-        # for this sender to compute the single next-expected slot.
-        # Missing key = no in-flight requests from this sender.
-        outstanding = self.outstanding_nonces_by_sender.get(sender_checksum, set())
-        expected_next_nonce = on_chain_nonce + len(outstanding)
-        if wire_nonce in outstanding:
-            # Duplicate of a pending nonce. Reject the same way as a
-            # stale wire value: settlement cannot derive the same
-            # request_id twice for the same sender, and accepting the
-            # duplicate would enqueue a second task under a request_id
-            # settlement guarantees to revert.
+        except RuntimeError as exc:
+            # Queue saturation or executor shutdown. Both are infra.
             self.context.logger.warning(
-                "Wire nonce %d already outstanding for sender %s on request %s "
-                "(expected next %d, outstanding=%d).",
+                "mapNonces read could not be dispatched for sender %s on "
+                "request %s: %s.",
+                sender_checksum,
+                wire_request_id,
+                exc,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=RPC_QUEUE_SATURATED,
+                is_infra=True,
+            )
+        except (
+            Web3RPCError,
+            RequestException,
+            ConnectionError,
+            OSError,
+        ) as exc:
+            # Transient RPC / transport failure — a flaky node, a
+            # network blip, a rate-limiter mid-flight reset. Route to
+            # the retryable ``NONCE_READ_FAILED`` reason and let the
+            # caller's 503 nudge mech-client's retry loop.
+            self.context.logger.warning(
+                "mapNonces read failed (transient) for sender %s on " "request %s: %r",
+                sender_checksum,
+                wire_request_id,
+                exc,
+                exc_info=True,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_READ_FAILED,
+                is_infra=True,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Deterministic failure classes: ``BadFunctionCallOutput``
+            # (wrong ``mech_marketplace_address`` or ABI drift),
+            # ``AttributeError`` (non-dict wrapper return),
+            # ``ValueError`` (ABI decode failure), ``ContractLogicError``
+            # (revert on a proxy pointing at a legacy implementation).
+            # None recover without an operator config change; keep the
+            # 503 so the client backs off, but surface a distinct
+            # reason so the log line names the fault as unrecoverable
+            # rather than collapsing into the same warning that a
+            # flaky node produces. ``exc_info=True`` so the traceback
+            # lands in the log for triage.
+            self.context.logger.warning(
+                "mapNonces read failed unrecoverably for sender %s on "
+                "request %s: %r",
+                sender_checksum,
+                wire_request_id,
+                exc,
+                exc_info=True,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=NONCE_READ_UNRECOVERABLE,
+                is_infra=True,
+            )
+        # Prune stale entries in both maps before computing the count.
+        # See ``_prune_stale_nonces`` for the crash-recovery rationale
+        # and the settlement-gap semantics of ``settling``.
+        accepted = self._prune_stale_nonces(
+            self.accepted_nonces_by_sender, sender_checksum, on_chain_nonce
+        )
+        settling = self._prune_stale_nonces(
+            self.settling_nonces_by_sender, sender_checksum, on_chain_nonce
+        )
+        expected_next_nonce = on_chain_nonce + len(accepted) + len(settling)
+        # Duplicate detection covers both sets: a wire nonce already
+        # accepted (and either still pending on the mech side or moved
+        # to settling awaiting on-chain settlement) is a duplicate
+        # under whichever half currently holds it.
+        if wire_nonce in accepted or wire_nonce in settling:
+            self.context.logger.warning(
+                "Wire nonce %d already in-flight for sender %s on request %s "
+                "(expected next %d, accepted=%d, settling=%d).",
                 wire_nonce,
                 sender_checksum,
                 wire_request_id,
                 expected_next_nonce,
-                len(outstanding),
+                len(accepted),
+                len(settling),
             )
             return SignatureVerdict(
                 ok=False,
@@ -2903,13 +3500,14 @@ class MechHttpHandler(AbstractResponseHandler):
         if wire_nonce < expected_next_nonce:
             self.context.logger.warning(
                 "Wire nonce %d below expected next slot %d for sender %s on "
-                "request %s (on_chain=%d, outstanding=%d).",
+                "request %s (on_chain=%d, accepted=%d, settling=%d).",
                 wire_nonce,
                 expected_next_nonce,
                 sender_checksum,
                 wire_request_id,
                 on_chain_nonce,
-                len(outstanding),
+                len(accepted),
+                len(settling),
             )
             return SignatureVerdict(
                 ok=False,
@@ -2919,13 +3517,14 @@ class MechHttpHandler(AbstractResponseHandler):
         if wire_nonce > expected_next_nonce:
             self.context.logger.warning(
                 "Wire nonce %d above expected next slot %d for sender %s on "
-                "request %s (on_chain=%d, outstanding=%d).",
+                "request %s (on_chain=%d, accepted=%d, settling=%d).",
                 wire_nonce,
                 expected_next_nonce,
                 sender_checksum,
                 wire_request_id,
                 on_chain_nonce,
-                len(outstanding),
+                len(accepted),
+                len(settling),
             )
             # 503 (is_infra=True) — the sender is racing its own
             # in-flight queue. mech-client retries 503 in the next
@@ -2934,6 +3533,25 @@ class MechHttpHandler(AbstractResponseHandler):
             return SignatureVerdict(
                 ok=False,
                 reason=NONCE_ABOVE_EXPECTED,
+                is_infra=True,
+            )
+        # Per-sender in-flight cap. Guards the previously-unbounded
+        # growth of ``accepted_nonces_by_sender`` (and by extension
+        # ``pending_tasks`` and ``in_memory_requests``) on the post-
+        # auth pre-payment surface. See ``MAX_ACCEPTED_PER_SENDER``.
+        if len(accepted) + len(settling) >= MAX_ACCEPTED_PER_SENDER:
+            self.context.logger.warning(
+                "Sender %s hit in-flight cap on request %s "
+                "(accepted=%d, settling=%d, cap=%d); rejecting 503.",
+                sender_checksum,
+                wire_request_id,
+                len(accepted),
+                len(settling),
+                MAX_ACCEPTED_PER_SENDER,
+            )
+            return SignatureVerdict(
+                ok=False,
+                reason=SENDER_INFLIGHT_LIMIT,
                 is_infra=True,
             )
         return SignatureVerdict(ok=True, reason="", is_infra=False)
@@ -2945,15 +3563,21 @@ class MechHttpHandler(AbstractResponseHandler):
         ``_handle_signed_requests`` can compute the checksum once for
         both the dedup key (unchanged) and the outstanding-nonces
         admission gate. Returns ``None`` on a failed checksum
-        conversion; the caller treats that identically to a failed
-        sig-verify because settlement would 401 the sender at the same
-        step later.
+        conversion; the caller routes that to a distinct
+        ``SENDER_RESOLUTION_FAILED`` verdict so a config-side problem
+        (missing / malformed RPC settings) does not get reported to
+        the client as an RPC round-trip failure.
 
         :param sender: the raw sender string from the wire body.
         :return: the checksum-cased address, or ``None`` on failure.
         """
         ledger_settings = self._get_ledger_settings()
         if ledger_settings[ResponseKey.STATUS.value] != ResponseStatus.OK.value:
+            self.context.logger.warning(
+                "Cannot resolve sender checksum: ledger settings unavailable "
+                "(%s); rejecting.",
+                ledger_settings.get(ResponseKey.REASON.value, "unknown"),
+            )
             return None
         try:
             rpc_address = cast(str, ledger_settings[ResponseKey.RPC_ADDRESS.value])
@@ -2961,6 +3585,11 @@ class MechHttpHandler(AbstractResponseHandler):
             ledger_api = self._get_ledger_api(rpc_address, chain_id)
             return cast(str, ledger_api.api.to_checksum_address(sender))
         except Exception:  # pylint: disable=broad-exception-caught
+            self.context.logger.warning(
+                "Sender checksum resolution failed for %r.",
+                sender,
+                exc_info=True,
+            )
             return None
 
     def _get_ledger_settings(self) -> Dict[str, Union[str, int]]:

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -42,8 +42,8 @@ fingerprint_ignore_patterns: []
 connections:
 - valory/ipfs:0.1.0:bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa
 - valory/kv_store:0.1.0:bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4
-- valory/ledger:0.19.0:bafybeidrfb2ixgsmoy73izeuq43npynkot324iayslipogfulcgshq33iu
-- valory/p2p_libp2p_client:0.1.0:bafybeif2pr4vrh2e24enjdymb4ortqkqmvcaq22tlzl5nfccvftomggjiu
+- valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
+- valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 contracts:
 - valory/balance_tracker:0.1.0:bafybeiayyxl643qfpw57vopytxgyd6flxxmwassswuxen7myekqaxdxxvi
 - valory/mech_marketplace:0.1.0:bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu
@@ -56,7 +56,7 @@ protocols:
 - valory/kv_store:0.1.0:bafybeidlfrgv5rc7m7kj3j6u6umogmpy5bgcdzqtnsy3v75wn3likvyt6m
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
+- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 behaviours:
   task_execution:
     args: {}

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeiaeu3tadzp4uj7nqdk2wr2bigqttpjqlbpslat3p3rgkkklvm3rtu
+  handlers.py: bafybeiczdwemcq7oacec6tr7g2dhuapmojdcbjogm7obbkxd3tublwsnbm
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeihdolykl6msc2ytsgz5lvg2fzhddxschlennor62kt4swupatu3we
+  tests/test_handlers.py: bafybeifzy3sf6m5lrsvsmosrabxgf6dkm2n7qnxe2xey6pxmeaokfg3lhu
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
@@ -26,7 +26,7 @@ fingerprint:
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
-  tests/utils/test_request_id.py: bafybeidn34isjhyz4p6yvpj5yieppssnagq5q7gl2lyybz7irlnx732vku
+  tests/utils/test_request_id.py: bafybeiflxnvrw6ld7oku2zrk6tcslhv4lhxamz3maw3hvj6gt5e4ppv2te
   tests/utils/test_task.py: bafybeigdfi37m5taw6jecd7t2bg54ctcv4u3js5u3xd2lyckoazy4efpv4
   utils/__init__.py: bafybeiccdijaigu6e5p2iruwo5mkk224o7ywedc7nr6xeu5fpmhjqgk24e
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeifzll2njhwqfewc2ymojxx3tyndrhavk5zb3to4eupolskmjdth7y
+  handlers.py: bafybeiaologtz3rtvs72et746fvcfa6cypbal2igfdbklbyvmpvecm4iju
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeicus3wyfixkcmcrszhwxa7psh3uqy3nyxxnh4263e2csbqxxmksdu
+  tests/test_handlers.py: bafybeic7sjl5uy3suaxo42gsmotuetabxjqhlw3ly3ljcskae3zr6pbtb4
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
@@ -32,7 +32,7 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeifmh64bhyaosptfvvm3qmquycdxwjujjzp7oiz6ri6m4rifvx3psq
+  utils/eip1271.py: bafybeic6xdcpimodn5yjxtzwfkqe3yqiks4a7ca4lfg2lxbsyvhqcg7cwy
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe
@@ -124,6 +124,8 @@ models:
       optimism_ledger_rpc: http://localhost:8545
     class_name: Params
 dependencies:
+  eth-abi:
+    version: ==6.0.0b1
   eth-account:
     version: ==0.13.7
   eth-utils:

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -130,6 +130,8 @@ dependencies:
     version: ==6.0.0b1
   eth-account:
     version: ==0.13.7
+  eth-keys:
+    version: ==0.8.0b1
   eth-utils:
     version: ==6.0.0
   open-aea-ledger-ethereum:

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -124,6 +124,10 @@ models:
       optimism_ledger_rpc: http://localhost:8545
     class_name: Params
 dependencies:
+  eth-account:
+    version: ==0.13.7
+  eth-utils:
+    version: ==6.0.0
   open-aea-ledger-ethereum:
     version: ==2.2.9
   PyYAML:
@@ -132,4 +136,8 @@ dependencies:
     version: ==0.23.1
   pebble:
     version: ==5.1.3
+  requests:
+    version: '>=2.32.5'
+  web3:
+    version: <8,>=7.15.0
 is_abstract: false

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeieipsly7gujjp3tfopywlnuym77dul4e5etp7puaetwzm2jmuayvq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeid2dlzquw5osgcp2sdwts577r27xza6ee7572672kfoj2kkf6vp3u
+  handlers.py: bafybeib6y4gw3mtngstv524zqre5l67ymcbhpbodpcxemybp7753axoi4m
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeicwykoemg55dnpaye5g7o7mib2c34o2k6bh5izw4wzwych5kr4pbq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,20 +9,20 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeiaologtz3rtvs72et746fvcfa6cypbal2igfdbklbyvmpvecm4iju
+  handlers.py: bafybeibrazzg6rtm7ukvm7qxsp2drnucxiaox5btnwzf5zv4u3remvixua
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeic7sjl5uy3suaxo42gsmotuetabxjqhlw3ly3ljcskae3zr6pbtb4
+  tests/test_handlers.py: bafybeiei6vul7tck3gvwjkbia5gzul5pan5oovs3xcx2btbo57xou3faty
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeiguz67fe3cfsht5m7fu5w7bos3hphk3ev4hmymcbju3wjqjrm54ym
+  tests/utils/test_eip1271.py: bafybeiarxkqanpr7dblgqjwij35zm2csem2othe6ke446k7pgzrocmsdam
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
@@ -32,31 +32,31 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeic6xdcpimodn5yjxtzwfkqe3yqiks4a7ca4lfg2lxbsyvhqcg7cwy
+  utils/eip1271.py: bafybeigifkjp3ol4mfgiunzptjgqxnqqoxjs4fcujm6yhdjphmc7o7bmji
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe
-  utils/request_id.py: bafybeickw4n52i4an2zzw7wtnnu4l6kvxx5fy4al3sjhvi3uvsbzdkoviu
+  utils/request_id.py: bafybeialhunybutndayr3bjsir4j2cqdadqy5zhpqyipemsyvpnnftbfsa
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:
-- valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
 - valory/ipfs:0.1.0:bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa
-- valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 - valory/kv_store:0.1.0:bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4
+- valory/ledger:0.19.0:bafybeidrfb2ixgsmoy73izeuq43npynkot324iayslipogfulcgshq33iu
+- valory/p2p_libp2p_client:0.1.0:bafybeif2pr4vrh2e24enjdymb4ortqkqmvcaq22tlzl5nfccvftomggjiu
 contracts:
-- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
-- valory/mech_marketplace:0.1.0:bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu
 - valory/balance_tracker:0.1.0:bafybeiayyxl643qfpw57vopytxgyd6flxxmwassswuxen7myekqaxdxxvi
+- valory/mech_marketplace:0.1.0:bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu
+- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
 protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
-- valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
-- valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
+- valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
 - valory/kv_store:0.1.0:bafybeidlfrgv5rc7m7kj3j6u6umogmpy5bgcdzqtnsy3v75wn3likvyt6m
+- valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
+- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
 behaviours:
   task_execution:
     args: {}
@@ -97,33 +97,35 @@ models:
     args:
       agent_index: 0
       api_keys: {}
-      tools_to_package_hash: {}
+      base_ledger_rpc: http://localhost:8545
+      default_chain_id: gnosis
       from_block_range: 50000
-      num_agents: 4
-      mech_to_config: {}
-      tools_to_pricing: {}
-      polling_interval: 30.0
-      step_in_list_size: 20
-      mech_to_max_delivery_rate: {}
-      task_deadline: 240.0
+      gnosis_ledger_rpc: http://localhost:8545
+      light_slash_unit_amount: 5000000000000000
       max_block_window: 500
-      use_slashing: false
-      timeout_limit: 3
+      mech_events_chain_id: 0
+      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
+      mech_to_config: {}
+      mech_to_max_delivery_rate: {}
+      num_agents: 4
+      optimism_ledger_rpc: http://localhost:8545
+      payment_type_to_asset_address: {}
+      polling_interval: 30.0
+      polygon_ledger_rpc: http://localhost:8545
+      serious_slash_unit_amount: 8000000000000000
       slash_cooldown_hours: 3
       slash_threshold_amount: 10000000000000000
-      light_slash_unit_amount: 5000000000000000
-      serious_slash_unit_amount: 8000000000000000
-      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
-      payment_type_to_asset_address: {}
+      step_in_list_size: 20
+      task_deadline: 240.0
+      timeout_limit: 3
+      tools_to_package_hash: {}
+      tools_to_pricing: {}
       use_offchain: false
-      default_chain_id: gnosis
-      mech_events_chain_id: 0
-      gnosis_ledger_rpc: http://localhost:8545
-      polygon_ledger_rpc: http://localhost:8545
-      base_ledger_rpc: http://localhost:8545
-      optimism_ledger_rpc: http://localhost:8545
+      use_slashing: false
     class_name: Params
 dependencies:
+  PyYAML:
+    version: ==6.0.1
   eth-abi:
     version: ==6.0.0b1
   eth-account:
@@ -132,14 +134,13 @@ dependencies:
     version: ==6.0.0
   open-aea-ledger-ethereum:
     version: ==2.2.9
-  PyYAML:
-    version: ==6.0.1
-  prometheus_client:
-    version: ==0.23.1
   pebble:
     version: ==5.1.3
+  prometheus_client:
+    version: ==0.23.1
   requests:
     version: '>=2.32.5'
   web3:
     version: <8,>=7.15.0
 is_abstract: false
+customs: []

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeifwktairsa37iovwqa5b4slbtc2mx2iut6teiv2twycetyp3g2snm
+  behaviours.py: bafybeigatm6ewxxop733etomyxei7pmfocjlbye3gk7c2jra5w5u5inira
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeib4hfld2ln2sv2pc2pziscjsupglo574n6g3e2sfroqnopntxqo74
+  handlers.py: bafybeid26cgoukem5zknnuvsuktiuqram4de4ry4qyyq32vkfkyqncniya
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeicwykoemg55dnpaye5g7o7mib2c34o2k6bh5izw4wzwych5kr4pbq
-  tests/test_behaviours.py: bafybeifiaspefq5cshbt2n6gdgoucl5l7vwh7mtfjdhvmqsmwmrkiuvqza
+  tests/test_behaviours.py: bafybeigbaekfxjzhzynskbxbxyxy6p2ue6hcxcctadv44cmvag3ufs6mla
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeific6kzxga3xtefrguaps2zvv4mjlowqzbsfq6hytzevfxermariu
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
@@ -22,7 +22,7 @@ fingerprint:
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeif7qtbz4vm6va7u2gvmvnxgemulrqaq64qxhw6hnzfggkndrnnzmy
+  tests/utils/test_eip1271.py: bafybeieat4o4umh6kgxg3qfxkj55xjrd4maz4bgyzh6f233pgyjetgxqiu
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
@@ -32,7 +32,7 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeieeea3klg5doqxtdyvbwrtskx4ktvbwc4scuaq3rnlvoz6mlpw56q
+  utils/eip1271.py: bafybeielxzkaiyprowdpdzvvxztnufid5l477li2pbbukqrpvetu6cz2xy
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,30 +9,34 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeiepqusgfa4tmiixe352cohuukf2wqlipwpal2yngahegmqlhj4oou
+  handlers.py: bafybeifzll2njhwqfewc2ymojxx3tyndrhavk5zb3to4eupolskmjdth7y
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeiedeuegyn27xv4ejlv5li45fpz3yd4mf7wbogud4yzpg556vc7paa
+  tests/test_handlers.py: bafybeigszj2jky4szkpv3sv3yuvjloqnslqzngm6ed2utm3vlsic4a7zba
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
+  tests/utils/test_eip1271.py: bafybeieaz5j6boofsmhkjsxjeexehppcni2zk3vw7utuqgrmfya2dmm4a4
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
+  tests/utils/test_request_id.py: bafybeiay52uab7leuc5cydzkkhqmqbixoxjzxrfuxdm7tmh6mdk62ippdu
   tests/utils/test_task.py: bafybeigdfi37m5taw6jecd7t2bg54ctcv4u3js5u3xd2lyckoazy4efpv4
   utils/__init__.py: bafybeiccdijaigu6e5p2iruwo5mkk224o7ywedc7nr6xeu5fpmhjqgk24e
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
+  utils/eip1271.py: bafybeifmh64bhyaosptfvvm3qmquycdxwjujjzp7oiz6ri6m4rifvx3psq
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe
+  utils/request_id.py: bafybeic7qykxi6nebbhme2n6es47rr3grgy2t47naopvynfpu554fxoj4u
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -15,18 +15,18 @@ fingerprint:
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeiadhtaqlp6l2sbo76kyvwg32xtolpobz4rofpy4237ak6ipbo7tae
+  tests/test_handlers.py: bafybeicus3wyfixkcmcrszhwxa7psh3uqy3nyxxnh4263e2csbqxxmksdu
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeieaz5j6boofsmhkjsxjeexehppcni2zk3vw7utuqgrmfya2dmm4a4
+  tests/utils/test_eip1271.py: bafybeiguz67fe3cfsht5m7fu5w7bos3hphk3ev4hmymcbju3wjqjrm54ym
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
-  tests/utils/test_request_id.py: bafybeiay52uab7leuc5cydzkkhqmqbixoxjzxrfuxdm7tmh6mdk62ippdu
+  tests/utils/test_request_id.py: bafybeidn34isjhyz4p6yvpj5yieppssnagq5q7gl2lyybz7irlnx732vku
   tests/utils/test_task.py: bafybeigdfi37m5taw6jecd7t2bg54ctcv4u3js5u3xd2lyckoazy4efpv4
   utils/__init__.py: bafybeiccdijaigu6e5p2iruwo5mkk224o7ywedc7nr6xeu5fpmhjqgk24e
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
@@ -36,7 +36,7 @@ fingerprint:
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe
-  utils/request_id.py: bafybeic7qykxi6nebbhme2n6es47rr3grgy2t47naopvynfpu554fxoj4u
+  utils/request_id.py: bafybeickw4n52i4an2zzw7wtnnu4l6kvxx5fy4al3sjhvi3uvsbzdkoviu
   utils/task.py: bafybeicb6nqd475ul6mz4hcexpva33ivkn4fygicgmlb4clu5cuzr34diy
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,22 +7,22 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
+  behaviours.py: bafybeievmcxm2tylkwbyirpz4exldlrenqwq5z22vb4z2hn4hvsdo7jcbe
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeiczdwemcq7oacec6tr7g2dhuapmojdcbjogm7obbkxd3tublwsnbm
+  handlers.py: bafybeicvejxwggq2jufrknxlctanwb5ck5zgi2frgqzpgm3tpbhy6rorie
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
-  tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
-  tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
+  tests/conftest.py: bafybeicwykoemg55dnpaye5g7o7mib2c34o2k6bh5izw4wzwych5kr4pbq
+  tests/test_behaviours.py: bafybeiad7mzdzv4hh3k3dgukj5lmuyxpco4wihldmewwwqlgfs32av65su
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeifzy3sf6m5lrsvsmosrabxgf6dkm2n7qnxe2xey6pxmeaokfg3lhu
+  tests/test_handlers.py: bafybeidfncq3chohc2p2kixlieng3lernq3pmmghkmbul75axli4cb7l2u
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeihiirvha7v3canscpqltzqawwqdwym6ppk7x4w6modcaopohen6zu
+  tests/utils/test_eip1271.py: bafybeieshv6d73qjve5gq57ghfll6u7qs5s7wu5bexmqybyiinbedf44ty
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
@@ -32,7 +32,7 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeibdwid7j4ljqf3lsrydm6gfp63xh535m3ise7bv42fgf2oubxatha
+  utils/eip1271.py: bafybeifogl2zkubrkji3ribvwp37c3jldkp2e73ccx7zswsxob6w6nt364
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,22 +7,22 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeieipsly7gujjp3tfopywlnuym77dul4e5etp7puaetwzm2jmuayvq
+  behaviours.py: bafybeifwktairsa37iovwqa5b4slbtc2mx2iut6teiv2twycetyp3g2snm
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeib6y4gw3mtngstv524zqre5l67ymcbhpbodpcxemybp7753axoi4m
+  handlers.py: bafybeib4hfld2ln2sv2pc2pziscjsupglo574n6g3e2sfroqnopntxqo74
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeicwykoemg55dnpaye5g7o7mib2c34o2k6bh5izw4wzwych5kr4pbq
-  tests/test_behaviours.py: bafybeigri3uokz7mpjtfjlifpm3vw6mp5qcjlp4lby3a5o7xb7renzljpy
+  tests/test_behaviours.py: bafybeifiaspefq5cshbt2n6gdgoucl5l7vwh7mtfjdhvmqsmwmrkiuvqza
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeibigzl5tmlnutkz4u4y44bzkxuderanwpjqffmclhxkhk5cggofka
+  tests/test_handlers.py: bafybeific6kzxga3xtefrguaps2zvv4mjlowqzbsfq6hytzevfxermariu
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeif3frqr3qev6uwdcvt62bh763fdfk3pbnbwcg5pcwhjoc64633vzu
+  tests/utils/test_eip1271.py: bafybeif7qtbz4vm6va7u2gvmvnxgemulrqaq64qxhw6hnzfggkndrnnzmy
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
@@ -32,7 +32,7 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeiekmjscmzozei6zxpiqhcollf7zatvyyazbhp52ekqjyp5udqkatq
+  utils/eip1271.py: bafybeieeea3klg5doqxtdyvbwrtskx4ktvbwc4scuaq3rnlvoz6mlpw56q
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,20 +9,20 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeiakwzub6pfn4yls762cebtf4bfla3fbc4j65dj67hkfcc4c6v4k5a
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeibrazzg6rtm7ukvm7qxsp2drnucxiaox5btnwzf5zv4u3remvixua
+  handlers.py: bafybeiaeu3tadzp4uj7nqdk2wr2bigqttpjqlbpslat3p3rgkkklvm3rtu
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeiei6vul7tck3gvwjkbia5gzul5pan5oovs3xcx2btbo57xou3faty
+  tests/test_handlers.py: bafybeihdolykl6msc2ytsgz5lvg2fzhddxschlennor62kt4swupatu3we
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeiarxkqanpr7dblgqjwij35zm2csem2othe6ke446k7pgzrocmsdam
+  tests/utils/test_eip1271.py: bafybeihiirvha7v3canscpqltzqawwqdwym6ppk7x4w6modcaopohen6zu
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
@@ -32,7 +32,7 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeigifkjp3ol4mfgiunzptjgqxnqqoxjs4fcujm6yhdjphmc7o7bmji
+  utils/eip1271.py: bafybeibdwid7j4ljqf3lsrydm6gfp63xh535m3ise7bv42fgf2oubxatha
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,22 +7,22 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeievmcxm2tylkwbyirpz4exldlrenqwq5z22vb4z2hn4hvsdo7jcbe
+  behaviours.py: bafybeieipsly7gujjp3tfopywlnuym77dul4e5etp7puaetwzm2jmuayvq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeicvejxwggq2jufrknxlctanwb5ck5zgi2frgqzpgm3tpbhy6rorie
+  handlers.py: bafybeid2dlzquw5osgcp2sdwts577r27xza6ee7572672kfoj2kkf6vp3u
   models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeicwykoemg55dnpaye5g7o7mib2c34o2k6bh5izw4wzwych5kr4pbq
-  tests/test_behaviours.py: bafybeiad7mzdzv4hh3k3dgukj5lmuyxpco4wihldmewwwqlgfs32av65su
+  tests/test_behaviours.py: bafybeigri3uokz7mpjtfjlifpm3vw6mp5qcjlp4lby3a5o7xb7renzljpy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeidfncq3chohc2p2kixlieng3lernq3pmmghkmbul75axli4cb7l2u
+  tests/test_handlers.py: bafybeibigzl5tmlnutkz4u4y44bzkxuderanwpjqffmclhxkhk5cggofka
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
   tests/utils/test_apis.py: bafybeig5ktc6azokzwpisvyse46bylb43vf4vxmgcuuwnkfr3bs7vexw4u
   tests/utils/test_benchmarks.py: bafybeifhadhmpwhulgvxm3wgodwstnw3v2lq6uetntww3ia5r7trirfecm
   tests/utils/test_cost_calculation.py: bafybeiglkqnmurf6ner2wy2k6vy4zmfehfgzh2ctzn4ae2t3qhoaqs7he4
-  tests/utils/test_eip1271.py: bafybeieshv6d73qjve5gq57ghfll6u7qs5s7wu5bexmqybyiinbedf44ty
+  tests/utils/test_eip1271.py: bafybeif3frqr3qev6uwdcvt62bh763fdfk3pbnbwcg5pcwhjoc64633vzu
   tests/utils/test_ipfs.py: bafybeig7ew26yfre64eajxd2cxl2b6w4jyit5tlr62q6hjcwhlvylrwesq
   tests/utils/test_local_cid.py: bafybeia6zbo4g6n6ypkccuywmnytvx6scyiw2pjn6eva6d6edg6hb6tmke
   tests/utils/test_preimage.py: bafybeiaf46s6zkelr4bqhpm7hlnjl7pbivpxaxckwz2bhzoe66wdnxzvza
@@ -32,7 +32,7 @@ fingerprint:
   utils/apis.py: bafybeih75sdickbk25zvduf2jolikmsfmh6c2rmju5lrdkhyhipmg23u2y
   utils/benchmarks.py: bafybeihqhdvpnp2jsmmab3fogpp7tpukdiwzmwuwq4qt6wk72hgpg6ypga
   utils/cost_calculation.py: bafybeic7siuvsglg7txjpzidskelw32r7lfphupzzrlnir6dbw3wng5v6u
-  utils/eip1271.py: bafybeifogl2zkubrkji3ribvwp37c3jldkp2e73ccx7zswsxob6w6nt364
+  utils/eip1271.py: bafybeiekmjscmzozei6zxpiqhcollf7zatvyyazbhp52ekqjyp5udqkatq
   utils/ipfs.py: bafybeiagbhhgvyo7mjdqvs5wrxy27bpzydd4aim7ntspv2ebygt7ewitra
   utils/local_cid.py: bafybeiey64eaq533wjyrbyhjlswvvfwtsaa7wyatr5ylpdgtqfqsrr4hlq
   utils/preimage.py: bafybeigdbtby7nts4nsr5icnxqh76nkwoz4xn6jqb2br53lrylh47elmfe

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   tests/conftest.py: bafybeickrspufxtr47ndp5vbrkejmwutlv4swub6ai7ngyh6ejlsulxgom
   tests/test_behaviours.py: bafybeig6r2lqg3jki3p5q7i4t6ohv5kak7p62szaoqkv2kieb7x2sdiujy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeigszj2jky4szkpv3sv3yuvjloqnslqzngm6ed2utm3vlsic4a7zba
+  tests/test_handlers.py: bafybeiadhtaqlp6l2sbo76kyvwg32xtolpobz4rofpy4237ak6ipbo7tae
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/tests/conftest.py
+++ b/packages/valory/skills/task_execution/tests/conftest.py
@@ -47,17 +47,25 @@ from packages.valory.skills.task_execution.behaviours import (
 # ----------------------------- Shared stubs -----------------------------------
 
 
-def _make_logger(include_debug: bool = False) -> SimpleNamespace:
-    """Create a no-op logger stub. Single source of truth for all test contexts."""
-    ns = SimpleNamespace(
+def _make_logger() -> SimpleNamespace:
+    """Create a no-op logger stub used by every test context.
+
+    ``debug`` is always exposed because the offchain sig-verify path
+    logs an audit line on the EOA-recovery-mismatch branch that
+    predates every current handler test. Hiding ``debug`` behind a
+    flag would AttributeError on that path the moment it is exercised
+    end-to-end.
+
+    :return: a ``SimpleNamespace`` with no-op ``info`` / ``warning`` /
+        ``error`` / ``exception`` / ``debug`` attributes.
+    """
+    return SimpleNamespace(
         info=lambda *a, **k: None,
         warning=lambda *a, **k: None,
         error=lambda *a, **k: None,
         exception=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
     )
-    if include_debug:
-        ns.debug = lambda *a, **k: None  # type: ignore[attr-defined]
-    return ns
 
 
 class _DLG:
@@ -405,7 +413,7 @@ def dialogue_skill_context(shared_state: Dict[str, Any]) -> SimpleNamespace:
     return SimpleNamespace(
         skill_id="valory/task_execution:0.1.0",
         agent_address="0xagent",
-        logger=_make_logger(include_debug=True),
+        logger=_make_logger(),
         shared_state=shared_state,
     )
 

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -2096,63 +2096,41 @@ def test_handle_timeout_task_no_req_id_resets_state(
     assert behaviour._async_result is None
 
 
-def test_handle_timeout_task_offchain_zero_request_id_discards_nonce(
-    behaviour: Any, params_stub: Any, shared_state: Any
+def test_finalize_done_task_composition_leaves_settling_populated(
+    behaviour: Any, shared_state: Any
 ) -> None:
-    """Off-chain task with ``request_id=0`` still gets its accepted nonce discarded.
+    """After release + reset the entry is in settling and gone from accepted.
 
-    Off-chain ``requestId`` is coerced to ``int`` at accept time, so
-    a wire value of ``"0"`` is falsy under the ``if not req_id`` guard
-    and takes the early-reset branch. Routing that branch through
-    ``_reset_executing_task`` keeps the accepted-nonce discard uniform
-    across every drop path on the off-chain rail.
+    The finalize path runs
+    ``_release_outstanding_nonce(shared_state, executing_task)`` then
+    ``self._reset_executing_task()`` back to back. The release moves
+    the entry from accepted to settling; the reset then fires
+    ``_discard_outstanding_nonce`` as belt-and-braces before clearing
+    the slot. This test crosses the seam directly so a future change
+    to ``_discard_outstanding_nonce`` that also drained settling
+    would trip here rather than only trip in a full end-to-end
+    settlement scenario.
 
     :param behaviour: pytest fixture, TaskExecutionBehaviour.
-    :param params_stub: pytest fixture, params namespace.
     :param shared_state: pytest fixture, initial shared_state map.
     """
     sender = "0xSenderAddress"
-    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {0}}
-    behaviour._executing_task = {
-        "requestId": 0,  # falsy int — off-chain accept coerces "0" → 0
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {5}}
+    executing_task: Dict[str, Any] = {
+        "requestId": 100,
         "sender": sender,
-        "nonce": 0,
+        "nonce": 5,
         "is_offchain": True,
     }
-    behaviour._async_result = MagicMock()
-    behaviour._handle_timeout_task()
-    assert behaviour._executing_task is None
+    # Mirror the two-line finalize suffix. Slot is bound at reset time
+    # so ``_discard_outstanding_nonce`` sees the same executing_task
+    # dict the release just consumed.
+    behaviour._executing_task = executing_task
+    beh_mod._release_outstanding_nonce(shared_state, executing_task)
+    behaviour._reset_executing_task()
+
     assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
-
-
-def test_handle_get_task_post_deadline_offchain_discards_nonce(
-    behaviour: Any, params_stub: Any, shared_state: Any
-) -> None:
-    """Post-deadline arrival for an off-chain task discards the accepted nonce.
-
-    ``_handle_get_task`` short-circuits when the IPFS response lands
-    after ``_request_handling_deadline``. Routing that drop branch
-    through ``_reset_executing_task`` keeps the accepted-nonce
-    discard uniform across every drop path on the off-chain rail.
-
-    :param behaviour: pytest fixture, TaskExecutionBehaviour.
-    :param params_stub: pytest fixture, params namespace.
-    :param shared_state: pytest fixture, initial shared_state map.
-    """
-    sender = "0xSenderAddress"
-    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {42}}
-    behaviour._executing_task = {
-        "requestId": 55,
-        "sender": sender,
-        "nonce": 42,
-        "is_offchain": True,
-    }
-    behaviour._request_handling_deadline = time.time() - 1.0  # already elapsed
-    behaviour._async_result = MagicMock()
-    message = SimpleNamespace(files={})
-    behaviour._handle_get_task(message, MagicMock())
-    assert behaviour._executing_task is None
-    assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {5}}
 
 
 def test_release_outstanding_nonce_settling_fallback_canonicalises_to_checksum(
@@ -3888,34 +3866,39 @@ def test_release_outstanding_nonce_moves_accepted_to_settling(
     assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {0}}
 
 
-def test_discard_outstanding_nonce_drops_from_both_sets(
+def test_discard_outstanding_nonce_drops_from_accepted_only(
     shared_state: Any,
 ) -> None:
-    """Discard removes the sender+nonce from BOTH accepted and settling.
+    """Discard removes from accepted and leaves settling untouched.
 
-    Used on the rejection path — a rejected task never settles, so
-    leaving anything in settling would keep the admission-gate slot
-    count inflated until either (a) the pruner eventually removes it
-    or (b) forever if the sender never sends again.
+    ``_discard_outstanding_nonce`` runs on the rejection / drop paths
+    (``_record_offchain_failure``, the defensive net inside
+    ``_reset_executing_task``). A task in ``settling`` has, by
+    definition, already been released by ``_release_outstanding_nonce``
+    on the finalize path and is waiting for on-chain settlement to
+    drain it. Clearing it here would collapse the admission gate's
+    three-state accounting back into a two-state one and reintroduce
+    the release/settlement-gap regression this split exists to
+    prevent.
 
     :param shared_state: pytest fixture, initial shared_state map.
     """
     sender = "0xSender"
     shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {5}}
     shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] = {sender: {3, 4}}
-    # Case: nonce present in accepted; drop from both.
+    # Case: nonce present in accepted — drop from accepted, leave settling.
     beh_mod._discard_outstanding_nonce(
         shared_state,
         {"sender": sender, "nonce": 5, "is_offchain": True},
     )
     assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
     assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {3, 4}}
-    # Case: nonce present in settling only.
+    # Case: nonce present in settling only — settling is untouched.
     beh_mod._discard_outstanding_nonce(
         shared_state,
         {"sender": sender, "nonce": 4, "is_offchain": True},
     )
-    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {3}}
+    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {3, 4}}
 
 
 def test_release_outstanding_nonce_case_insensitive_sender_match(

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -2096,6 +2096,97 @@ def test_handle_timeout_task_no_req_id_resets_state(
     assert behaviour._async_result is None
 
 
+def test_handle_timeout_task_offchain_zero_request_id_discards_nonce(
+    behaviour: Any, params_stub: Any, shared_state: Any
+) -> None:
+    """Off-chain task with ``request_id=0`` still gets its accepted nonce discarded.
+
+    Off-chain ``requestId`` is coerced to ``int`` at accept time, so
+    a wire value of ``"0"`` is falsy under the ``if not req_id`` guard
+    and takes the early-reset branch. Routing that branch through
+    ``_reset_executing_task`` keeps the accepted-nonce discard uniform
+    across every drop path on the off-chain rail.
+
+    :param behaviour: pytest fixture, TaskExecutionBehaviour.
+    :param params_stub: pytest fixture, params namespace.
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    sender = "0xSenderAddress"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {0}}
+    behaviour._executing_task = {
+        "requestId": 0,  # falsy int — off-chain accept coerces "0" → 0
+        "sender": sender,
+        "nonce": 0,
+        "is_offchain": True,
+    }
+    behaviour._async_result = MagicMock()
+    behaviour._handle_timeout_task()
+    assert behaviour._executing_task is None
+    assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+
+
+def test_handle_get_task_post_deadline_offchain_discards_nonce(
+    behaviour: Any, params_stub: Any, shared_state: Any
+) -> None:
+    """Post-deadline arrival for an off-chain task discards the accepted nonce.
+
+    ``_handle_get_task`` short-circuits when the IPFS response lands
+    after ``_request_handling_deadline``. Routing that drop branch
+    through ``_reset_executing_task`` keeps the accepted-nonce
+    discard uniform across every drop path on the off-chain rail.
+
+    :param behaviour: pytest fixture, TaskExecutionBehaviour.
+    :param params_stub: pytest fixture, params namespace.
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    sender = "0xSenderAddress"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {42}}
+    behaviour._executing_task = {
+        "requestId": 55,
+        "sender": sender,
+        "nonce": 42,
+        "is_offchain": True,
+    }
+    behaviour._request_handling_deadline = time.time() - 1.0  # already elapsed
+    behaviour._async_result = MagicMock()
+    message = SimpleNamespace(files={})
+    behaviour._handle_get_task(message, MagicMock())
+    assert behaviour._executing_task is None
+    assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+
+
+def test_release_outstanding_nonce_settling_fallback_canonicalises_to_checksum(
+    shared_state: Any,
+) -> None:
+    """Settling fallback writes under the EIP-55 checksum key when no accepted match.
+
+    Handler-side consumers (``_reconcile_stale_accepted`` /
+    ``_reconcile_stale_settling``, dedup, cap check) do exact-lookups
+    on the checksum key. A raw wire ``sender`` that is not already
+    keyed in the settling map is canonicalised to the checksum form
+    so it agrees with the handler-side key shape.
+
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    from eth_utils import to_checksum_address as _canonical
+
+    lower_addr = "0xabcdefabcdef0123456789abcdefabcdef012345"
+    expected_checksum = _canonical(lower_addr)
+    # No prior accepted or settling entry — release exercises the
+    # fallback branch that has to build the settling key from scratch.
+    shared_state.setdefault(beh_mod.ACCEPTED_NONCES_BY_SENDER, {})
+    shared_state.setdefault(beh_mod.SETTLING_NONCES_BY_SENDER, {})
+    beh_mod._release_outstanding_nonce(
+        shared_state,
+        {"sender": lower_addr, "nonce": 7, "is_offchain": True},
+    )
+    settling = shared_state[beh_mod.SETTLING_NONCES_BY_SENDER]
+    # Key is EIP-55 checksum, not the raw lowercase wire value.
+    assert expected_checksum in settling
+    assert lower_addr not in settling
+    assert settling[expected_checksum] == {7}
+
+
 def test_handle_timeout_task_adds_back_to_queue(
     behaviour: Any, params_stub: Any, monkeypatch: Any
 ) -> None:

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1973,6 +1973,45 @@ def test_finalize_done_task_no_executing_task_is_safe(
     assert behaviour._executing_task is None
 
 
+def test_release_outstanding_nonce_drops_sender_entry_when_last_nonce_removed() -> None:
+    """Removing the last outstanding nonce for a sender pops the sender key.
+
+    Leaving an empty ``set()`` under the sender key would still make
+    the admission gate's ``len(outstanding_by_sender[sender])``
+    read succeed with ``0``, but a subsequent per-sender iteration
+    would visit the empty entry uselessly. Prefer the explicit pop
+    so the dict shrinks back to shape on the last drain.
+    """
+    shared_state: Dict[str, Any] = {
+        beh_mod.OUTSTANDING_NONCES_BY_SENDER: {
+            "0xabc": {5, 6},
+            "0xdef": {1},
+        },
+    }
+    executing = {"sender": "0xdef", "nonce": 1}
+
+    beh_mod._release_outstanding_nonce(shared_state, executing)
+
+    assert "0xdef" not in shared_state[beh_mod.OUTSTANDING_NONCES_BY_SENDER]
+    assert shared_state[beh_mod.OUTSTANDING_NONCES_BY_SENDER]["0xabc"] == {5, 6}
+
+
+def test_release_outstanding_nonce_is_noop_when_sender_missing() -> None:
+    """A finalize whose sender never appeared in the outstanding set is a no-op.
+
+    Covers the on-chain path (which never populates the set) and any
+    rollback that already cleared its own entry before finalize ran.
+    """
+    shared_state: Dict[str, Any] = {
+        beh_mod.OUTSTANDING_NONCES_BY_SENDER: {"0xabc": {1}},
+    }
+    executing = {"sender": "0xzzz", "nonce": 99}
+
+    beh_mod._release_outstanding_nonce(shared_state, executing)  # must not raise
+
+    assert shared_state[beh_mod.OUTSTANDING_NONCES_BY_SENDER] == {"0xabc": {1}}
+
+
 def test_handle_store_response_dynamic_pricing_recorded(
     behaviour: Any, params_stub: Any, shared_state: Dict[str, Any], monkeypatch: Any
 ) -> None:

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3765,3 +3765,193 @@ def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
     assert "predict_api_event" not in done_tasks[0]
+
+
+# ---------------------------------------------------------------------------
+# Round-5 review: outstanding-nonce lifecycle across accepted / settling /
+# rejected paths, and the tool-not-installed drop for off-chain tasks.
+# ---------------------------------------------------------------------------
+
+
+def test_release_outstanding_nonce_moves_accepted_to_settling(
+    shared_state: Any,
+) -> None:
+    """Release moves the sender+nonce from accepted → settling.
+
+    The admission gate on the handler side computes the next-expected
+    slot as ``on_chain + len(accepted) + len(settling)``; a release
+    that dropped the entry from accepted without adding it to settling
+    would under-count the slot during the release/settlement gap
+    (several ABCI rounds), letting a duplicate wire nonce re-enter
+    under a colliding request_id.
+
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    sender = "0xSender"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {0, 1, 2}}
+    beh_mod._release_outstanding_nonce(
+        shared_state,
+        {"sender": sender, "nonce": 0, "is_offchain": True},
+    )
+    assert shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] == {sender: {1, 2}}
+    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {0}}
+
+
+def test_discard_outstanding_nonce_drops_from_both_sets(
+    shared_state: Any,
+) -> None:
+    """Discard removes the sender+nonce from BOTH accepted and settling.
+
+    Used on the rejection path — a rejected task never settles, so
+    leaving anything in settling would keep the admission-gate slot
+    count inflated until either (a) the pruner eventually removes it
+    or (b) forever if the sender never sends again.
+
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    sender = "0xSender"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {5}}
+    shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] = {sender: {3, 4}}
+    # Case: nonce present in accepted; drop from both.
+    beh_mod._discard_outstanding_nonce(
+        shared_state,
+        {"sender": sender, "nonce": 5, "is_offchain": True},
+    )
+    assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {3, 4}}
+    # Case: nonce present in settling only.
+    beh_mod._discard_outstanding_nonce(
+        shared_state,
+        {"sender": sender, "nonce": 4, "is_offchain": True},
+    )
+    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {sender: {3}}
+
+
+def test_release_outstanding_nonce_case_insensitive_sender_match(
+    shared_state: Any,
+) -> None:
+    """Release matches sender case-insensitively across the accepted map.
+
+    ``executing_task`` carries the raw wire sender value; the
+    handler-side admission gate keys on the checksum-cased address.
+    Without case-insensitive matching a mixed-case wire value would
+    miss the accepted entry and leak the nonce.
+
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    checksum = "0xABCDEFabcdef0123456789ABCDEFabcdef012345"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {checksum: {7}}
+    beh_mod._release_outstanding_nonce(
+        shared_state,
+        {"sender": checksum.lower(), "nonce": 7, "is_offchain": True},
+    )
+    assert checksum not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+    assert shared_state[beh_mod.SETTLING_NONCES_BY_SENDER] == {checksum: {7}}
+
+
+def test_handle_get_task_offchain_typo_tool_releases_nonce(
+    behaviour: Any,
+    params_stub: Any,
+    monkeypatch: Any,
+    shared_state: Any,
+) -> None:
+    """Off-chain task with a typo'd tool name releases the nonce, not just drops.
+
+    Off-chain tasks never carry ``priorityMech`` (the field is set by
+    the on-chain contract call reader; the accept path does not
+    populate it), so ``stepping_in`` evaluates to True for every
+    off-chain task and the tool-not-installed drop branch always
+    fires for a typo. Without the release, the nonce stays in the
+    accepted set forever and the sender's next legitimate request
+    hard-503s at the admission gate.
+
+    :param behaviour: pytest fixture, TaskExecutionBehaviour.
+    :param params_stub: pytest fixture, params namespace.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    from types import SimpleNamespace as NS
+
+    my_mech = "0xmymech"
+    params_stub.mech_to_config = {
+        my_mech: NS(is_marketplace_mech=True, use_dynamic_pricing=False)
+    }
+    sender = "0xSenderAddress"
+    # Preload the sender's accepted set — as if the accept path had
+    # just enqueued the task.
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {42}}
+    behaviour._executing_task = {
+        "requestId": 55,
+        # No priorityMech: off-chain path never carries it.
+        "request_delivery_rate": 100,
+        "contract_address": "0xmech",
+        "sender": sender,
+        "nonce": 42,
+        "is_offchain": True,
+    }
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    msg = SimpleNamespace(
+        files={"task.json": json.dumps({"prompt": "hi", "tool": "unknown_tool"})}
+    )
+    behaviour._handle_get_task(msg, MagicMock())
+
+    # Task slot cleared.
+    assert behaviour._executing_task is None
+    # Nonce discarded from the accepted set — key gone, no leak.
+    assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+    # Definitive rejection landed on the poll-response cache so the
+    # client learns the outcome instead of polling forever.
+    rejections = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]
+    assert "55" in rejections
+    assert rejections["55"]["status"] == "rejected"
+
+
+def test_reset_executing_task_defensive_discard_on_offchain_task(
+    behaviour: Any,
+    shared_state: Any,
+) -> None:
+    """``_reset_executing_task`` discards nonce for any lingering off-chain task.
+
+    Belt-and-braces: any drop path a future refactor forgets to
+    thread ``_record_offchain_failure`` / ``_release_outstanding_nonce``
+    through cannot leak the sender's outstanding-nonce entry — the
+    reset itself unconditionally discards.
+
+    :param behaviour: pytest fixture, TaskExecutionBehaviour.
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    sender = "0xSenderAddress"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {9}}
+    behaviour._executing_task = {
+        "requestId": 1,
+        "sender": sender,
+        "nonce": 9,
+        "is_offchain": True,
+    }
+    behaviour._reset_executing_task()
+    assert sender not in shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER]
+    assert behaviour._executing_task is None
+
+
+def test_reset_executing_task_noop_on_onchain_task(
+    behaviour: Any,
+    shared_state: Any,
+) -> None:
+    """``_reset_executing_task`` never touches the maps on on-chain tasks.
+
+    Guards against a defensive discard that fires for every reset
+    and accidentally drops off-chain state populated by an unrelated
+    request from the same sender.
+
+    :param behaviour: pytest fixture, TaskExecutionBehaviour.
+    :param shared_state: pytest fixture, initial shared_state map.
+    """
+    sender = "0xSenderAddress"
+    shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] = {sender: {9}}
+    behaviour._executing_task = {
+        "requestId": 1,
+        # No is_offchain flag → treated as on-chain by _reset defense.
+    }
+    behaviour._reset_executing_task()
+    assert shared_state[beh_mod.ACCEPTED_NONCES_BY_SENDER] == {sender: {9}}

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -2553,11 +2553,10 @@ def test_verify_offchain_signature_safe_eip1271_true_accepts(
     _seed_verification_constants(mh, handler_context.params, monkeypatch)
 
     balance_calls: List[Any] = []
-    monkeypatch.setattr(
-        mh,
-        "_check_offchain_requester_balance",
-        lambda sender, delivery_rate: balance_calls.append(sender)
-        or {
+
+    def _spy_balance_check(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return {
             hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
             hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
             hmod.ResponseKey.AVAILABLE_AMOUNT.value: int(delivery_rate) + 1,
@@ -2565,7 +2564,10 @@ def test_verify_offchain_signature_safe_eip1271_true_accepts(
             hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
             hmod.ResponseKey.PAYMENT_TYPE.value: "0xpaymenttype",
             hmod.ResponseKey.CHAIN_ID.value: 100,
-        },
+        }
+
+    monkeypatch.setattr(
+        mh, "_check_offchain_requester_balance", _spy_balance_check
     )
 
     # Sender is a Safe (contract) — sign with an arbitrary key that does not
@@ -2625,11 +2627,13 @@ def test_verify_offchain_signature_safe_eip1271_false_rejects_before_balance_che
     _seed_verification_constants(mh, handler_context.params, monkeypatch)
 
     balance_calls: List[Any] = []
+
+    def _spy_balance_check(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
+
     monkeypatch.setattr(
-        mh,
-        "_check_offchain_requester_balance",
-        lambda sender, delivery_rate: balance_calls.append(sender)
-        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+        mh, "_check_offchain_requester_balance", _spy_balance_check
     )
 
     safe_sender = _to_checksum("0x" + "aa" * 20)
@@ -2688,11 +2692,13 @@ def test_verify_offchain_signature_missing_field_returns_400(
     mh = _http_handler(handler_context, monkeypatch)
     _install_verify_ok(mh, monkeypatch)
     balance_calls: List[Any] = []
+
+    def _spy_balance_check(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
+
     monkeypatch.setattr(
-        mh,
-        "_check_offchain_requester_balance",
-        lambda sender, delivery_rate: balance_calls.append(sender)
-        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+        mh, "_check_offchain_requester_balance", _spy_balance_check
     )
 
     body = _make_signed_request_body(request_id="1")
@@ -2716,11 +2722,13 @@ def test_verify_offchain_signature_rejects_when_wire_request_id_mismatches_deriv
     _seed_verification_constants(mh, handler_context.params, monkeypatch)
 
     balance_calls: List[Any] = []
+
+    def _spy_balance_check(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
+
     monkeypatch.setattr(
-        mh,
-        "_check_offchain_requester_balance",
-        lambda sender, delivery_rate: balance_calls.append(sender)
-        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+        mh, "_check_offchain_requester_balance", _spy_balance_check
     )
     monkeypatch.setattr(
         hmod,
@@ -2760,11 +2768,13 @@ def test_verify_offchain_signature_rejects_when_constants_unloaded(
     mh._payment_type = None
 
     balance_calls: List[Any] = []
+
+    def _spy_balance_check(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
+
     monkeypatch.setattr(
-        mh,
-        "_check_offchain_requester_balance",
-        lambda sender, delivery_rate: balance_calls.append(sender)
-        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+        mh, "_check_offchain_requester_balance", _spy_balance_check
     )
 
     body = _make_signed_request_body(request_id="1")

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -3371,7 +3371,7 @@ def test_verify_offchain_signature_rejects_401_on_eip1271_timeout(
     mh._handle_signed_requests(http_msg, http_dialogue)
 
     resp = handler_context.outbox.sent[-1]
-    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
     assert stored["reason"] == hmod.EIP1271_CALL_TIMEOUT
     assert balance_calls == []
     assert nonce_calls == [], "nonce read must not run when sig verify rejects"

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -40,6 +40,9 @@ from packages.valory.skills.task_execution.handlers import (
     LedgerHandler,
     MechHttpHandler,
 )
+from packages.valory.skills.task_execution.utils.eip1271 import (
+    Eip1271Verdict as _Eip1271Verdict,
+)
 from packages.valory.skills.task_execution.utils.ipfs import (
     to_multihash as _to_multihash,
 )
@@ -2672,7 +2675,7 @@ def test_verify_offchain_signature_eoa_invalid_rejects_401_before_balance_check(
     monkeypatch.setattr(
         hmod,
         "check_eip1271_signature",
-        lambda **_kw: False,
+        lambda **_kw: _Eip1271Verdict.DECLINED,
     )
 
     http_msg: Any = make_http_msg(body)
@@ -2737,7 +2740,7 @@ def test_verify_offchain_signature_safe_eip1271_true_accepts(
     monkeypatch.setattr(
         hmod,
         "check_eip1271_signature",
-        lambda **_kw: True,
+        lambda **_kw: _Eip1271Verdict.VALID,
     )
 
     body = _sig_body(
@@ -2796,7 +2799,7 @@ def test_verify_offchain_signature_safe_eip1271_false_rejects_before_balance_che
     monkeypatch.setattr(
         hmod,
         "check_eip1271_signature",
-        lambda **_kw: False,
+        lambda **_kw: _Eip1271Verdict.DECLINED,
     )
 
     body = _sig_body(
@@ -2867,7 +2870,7 @@ def test_verify_offchain_signature_rejects_when_wire_request_id_mismatches_deriv
     monkeypatch.setattr(
         hmod,
         "check_eip1271_signature",
-        lambda **_kw: False,
+        lambda **_kw: _Eip1271Verdict.DECLINED,
     )
 
     scenario = _make_eoa_scenario()
@@ -3618,14 +3621,15 @@ def test_verify_offchain_signature_wall_clock_deadline_bounds_eip1271_call(
     _install_nonce_stub(monkeypatch, on_chain_nonce=3)
 
     # Reduce the deadline to keep the test fast while still exercising
-    # the deadline branch. The sleep length is 5x the deadline so the
-    # test would visibly hang if the deadline were not enforced.
+    # the deadline branch. The sleep length is 50x the deadline so a
+    # regression that waited out the callable would visibly hang the
+    # test instead of being masked by a wide epsilon.
     test_deadline = 0.2
     monkeypatch.setattr(hmod, "_RPC_WALL_CLOCK_DEADLINE_SECONDS", test_deadline)
 
-    def _slow_eip1271(**_kw: Any) -> bool:
-        _time.sleep(test_deadline * 5)
-        return True
+    def _slow_eip1271(**_kw: Any) -> _Eip1271Verdict:
+        _time.sleep(test_deadline * 50)
+        return _Eip1271Verdict.VALID
 
     monkeypatch.setattr(hmod, "check_eip1271_signature", _slow_eip1271)
 
@@ -3679,9 +3683,15 @@ def test_verify_offchain_signature_wall_clock_deadline_bounds_eip1271_call(
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
     assert stored["reason"] == hmod.EIP1271_CALL_TIMEOUT
-    # Deadline enforcement — the handler must return within deadline +
-    # a small epsilon for scheduling / test overhead, NOT after the
-    # 5x-deadline sleep the stub would otherwise impose.
+    # Deadline enforcement — the handler must return within deadline
+    # plus a small epsilon for handler overhead (EthereumApi
+    # construction, sig-verify prep, response encoding), NOT after
+    # the 50x-deadline sleep the stub would otherwise impose. 2s of
+    # slack absorbs handler overhead (EthereumApi construction,
+    # sig-verify prep, response encoding) under CI parallel load
+    # while keeping the assertion well below the 10s the stub would
+    # sleep if the deadline did nothing — so a regression that waited
+    # out the full sleep is still caught immediately.
     assert elapsed < test_deadline + 2.0, (
         f"handler returned in {elapsed:.3f}s but wall-clock deadline is "
         f"{test_deadline}s; regression would let a slow isValidSignature "
@@ -3717,7 +3727,7 @@ def test_bind_wire_nonce_to_chain_wall_clock_deadline_bounds_mapnonces_read(
     def _slow_get_nonce(
         cls: Any, ledger_api: Any, contract_address: Any, sender_address: Any
     ) -> Dict[str, int]:
-        _time.sleep(test_deadline * 5)
+        _time.sleep(test_deadline * 50)
         return {"data": 0}
 
     monkeypatch.setattr(
@@ -3774,6 +3784,13 @@ def test_bind_wire_nonce_to_chain_wall_clock_deadline_bounds_mapnonces_read(
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
     assert stored["reason"] == hmod.NONCE_READ_FAILED
+    # Tight epsilon so a regression that waited out the 50x sleep
+    # (10s vs 0.2s deadline) visibly fails instead of masking. 2s of
+    # slack absorbs handler overhead (EthereumApi construction,
+    # sig-verify prep, response encoding) under CI parallel load
+    # while keeping the assertion well below the 10s the stub would
+    # sleep if the deadline did nothing — so a regression is caught
+    # immediately.
     assert elapsed < test_deadline + 2.0, (
         f"handler returned in {elapsed:.3f}s but wall-clock deadline is "
         f"{test_deadline}s; regression would let a slow mapNonces read "
@@ -4765,6 +4782,85 @@ def test_signed_requests_accepts_prefixed_signature(
 
 
 # ---------------------------------------------------------------------------
+# Sender ingress format guard (0x-prefixed 20-byte hex address)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_sender",
+    [
+        pytest.param("not-an-address", id="not_hex_at_all"),
+        pytest.param("0x", id="empty_after_prefix"),
+        pytest.param("0x" + "a" * 39, id="short_by_one_nibble"),
+        pytest.param("0x" + "a" * 41, id="long_by_one_nibble"),
+        pytest.param("0x" + "z" * 40, id="non_hex_chars"),
+        pytest.param("0000000000000000000000000000000000000001", id="missing_prefix"),
+        pytest.param("", id="empty_string"),
+    ],
+)
+def test_signed_requests_rejects_bad_sender_format(
+    handler_context: Any,
+    http_dialogue: Any,
+    monkeypatch: Any,
+    bad_sender: str,
+) -> None:
+    """A malformed sender address is rejected 400 at ingress, not 503.
+
+    Without the ingress guard, a bad address travels into
+    ``_verify_offchain_request_signature``, ``to_checksum_address(sender)``
+    raises inside the address-preparation block, and the verdict
+    returns ``is_infra=True`` — routed to 503 by the caller because
+    the same block also converts the deployment-scoped marketplace
+    and mech addresses whose conversion failure IS genuine infra. A
+    503 tells a well-behaved auto-retry client "try again later" for
+    a request that will never succeed; the classification has to be
+    a 400 client error instead.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param bad_sender: the malformed sender address under test.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(request_id="8110")
+    body["sender"] = bad_sender
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_signed_requests_accepts_lowercase_sender_address(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A lowercase 0x-prefixed 20-byte hex address clears the ingress guard.
+
+    Regression guard so the ``ADDRESS_RE`` bounds don't over-reject
+    real client payloads that ship non-checksum casing. The checksum
+    conversion is done downstream by ``_resolve_sender_checksum``.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(request_id="8111")
+    body["sender"] = "0x" + "ab" * 20
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # Dedup vs 402 / 500 retry: only accepted state blocks a re-post
 # ---------------------------------------------------------------------------
 
@@ -5047,3 +5143,732 @@ def test_signed_requests_accepts_body_at_golden_cid_pair(
     resp: SimpleNamespace = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.OK_CODE.value
     assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Round-5 review follow-ups: accepted / settling split, per-sender cap,
+# tri-state EIP-1271, executor saturation + late-outcome, defensive
+# handler-wide except, balance-check wall-clock deadline.
+# ---------------------------------------------------------------------------
+
+import concurrent.futures as _cf  # noqa: E402
+
+
+def test_accepted_settling_split_pins_ojus_simulation(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Reproduce the release/settlement-gap simulation from round-5 review.
+
+    Three accepts land on nonces 0/1/2 with on_chain_nonce=0. The
+    mech-side done path moves nonce 0 to the settling set (on_chain
+    still 0). A re-post of nonce 1 is rejected (duplicate in
+    accepted). A fresh accept at nonce 3 succeeds because
+    expected = on_chain + accepted + settling = 0 + 2 + 1 = 3.
+
+    Under the pre-split code, that last accept would 503 because the
+    formula was ``on_chain + len(outstanding)`` and the release path
+    dropped the settled entry from ``outstanding`` before the on-chain
+    counter caught up.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    _install_nonce_stub(monkeypatch, on_chain_nonce=0)
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+
+    def _accept(nonce: int) -> SimpleNamespace:
+        scenario = _make_eoa_scenario(nonce=nonce)
+        body = _sig_body(
+            request_id=scenario["request_id"],
+            delivery_rate=scenario["delivery_rate"],
+            nonce=scenario["nonce"],
+            sender=scenario["sender"],
+            signature_hex=scenario["signature_hex"],
+            ipfs_hash=scenario["ipfs_hash"],
+        )
+        mh._handle_signed_requests(
+            cast(HttpMessage, make_http_msg(body)), http_dialogue
+        )
+        return handler_context.outbox.sent[-1]
+
+    assert _accept(0).status_code == HttpCode.OK_CODE.value
+    assert _accept(1).status_code == HttpCode.OK_CODE.value
+    assert _accept(2).status_code == HttpCode.OK_CODE.value
+    sender = _make_eoa_scenario(nonce=0)["sender"]
+    assert handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] == {
+        sender: {0, 1, 2}
+    }
+
+    # Simulate the mech-side done path for nonce 0: move to settling.
+    from packages.valory.skills.task_execution.behaviours import (
+        _release_outstanding_nonce as _release,
+    )
+
+    _release(
+        handler_context.shared_state,
+        {"sender": sender, "nonce": 0, "is_offchain": True},
+    )
+    assert handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] == {
+        sender: {1, 2}
+    }
+    assert handler_context.shared_state[hmod.SETTLING_NONCES_BY_SENDER] == {sender: {0}}
+
+    # The key regression the split protects against: honest sequential
+    # accept at nonce 3 with expected = on_chain(0) + accepted(2) +
+    # settling(1) = 3. Pre-split code: expected = 0 + outstanding(2) = 2
+    # and the accept would 503 with NONCE_ABOVE_EXPECTED until the
+    # batch settlement lands and mapNonces catches up.
+    fresh = _accept(3)
+    assert fresh.status_code == HttpCode.OK_CODE.value
+
+    # Duplicate detection still fires on a wire nonce that collides
+    # with the settling set even after the accepted set has moved on.
+    # Bypass the dedup gate by calling ``_bind_wire_nonce_to_chain``
+    # directly (a full forged-signature scenario for a different
+    # request_id under the same sender+nonce would over-engineer the
+    # test). Pre-split code would either accept-as-duplicate here or
+    # never reach this branch depending on the ordering of accepted /
+    # settlement, both of which let a duplicate under a colliding
+    # request_id enqueue.
+    verdict = mh._bind_wire_nonce_to_chain(
+        sender_checksum=sender,
+        wire_nonce=0,
+        wire_request_id="unused-in-log-only",
+    )
+    assert verdict.ok is False
+    assert verdict.reason == hmod.NONCE_BELOW_EXPECTED
+
+
+def test_enqueue_writes_checksum_key_release_matches_lowercase_wire(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Real accept path writes checksum key; release matches lowercase wire dict.
+
+    The accept path resolves the wire sender via
+    ``_resolve_sender_checksum`` (which returns the EIP-55 checksum
+    form) before writing to ``ACCEPTED_NONCES_BY_SENDER``. The
+    release helper on the behaviour side reads the sender off the
+    raw ``executing_task`` dict, whose value is the wire casing from
+    the client — not the checksum. The two sides only agree because
+    the release helper's ``_find_sender_key`` scan compares
+    case-insensitively.
+
+    A later "simplification" that swaps the scan for
+    ``outstanding_all.get(sender)`` would silently turn every
+    release into a no-op for any non-checksum wire casing and
+    reintroduce the permanent-lockout mode (the accepted set grows,
+    the admission gate's slot count grows with it, the sender's
+    next legitimate request 503s at the per-sender cap forever). This
+    test crosses the seam through the real handler enqueue path so
+    the case-insensitivity contract is pinned as intentional rather
+    than incidental.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    from packages.valory.skills.task_execution.behaviours import (
+        _release_outstanding_nonce as _release,
+    )
+
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    # ``_install_verify_ok`` stubs ``_resolve_sender_checksum`` to
+    # ``str(sender)`` (raw wire) — override to the EIP-55 checksum
+    # form so the write side of the seam matches production.
+    checksum = "0xABCDEFabcdef0123456789ABCDEFabcdef012345"
+    monkeypatch.setattr(mh, "_resolve_sender_checksum", lambda _s: checksum)
+
+    body = _make_signed_request_body(request_id="8300", nonce="0")
+    # Client posts the address in lowercase (a common wire casing).
+    body["sender"] = checksum.lower()
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    # Write side of the seam: the accepted map is keyed by checksum,
+    # not by the raw wire (lowercase) sender.
+    assert handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] == {
+        checksum: {0}
+    }
+
+    # Read side of the seam: the release helper reads the raw wire
+    # sender off ``executing_task`` (lowercase) but must still find
+    # the checksum-keyed entry.
+    _release(
+        handler_context.shared_state,
+        {"sender": checksum.lower(), "nonce": 0, "is_offchain": True},
+    )
+    assert handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] == {}
+    assert handler_context.shared_state[hmod.SETTLING_NONCES_BY_SENDER] == {
+        checksum: {0}
+    }
+
+
+def test_settling_pruned_when_on_chain_advances(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A settlement that moves ``mapNonces`` past a settling nonce prunes it.
+
+    Pins the drain-on-read semantics: without pruning, the settling
+    set would grow forever and inflate the admission gate's slot
+    count.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    sender = _make_eoa_scenario(nonce=0)["sender"]
+    handler_context.shared_state[hmod.SETTLING_NONCES_BY_SENDER] = {sender: {0}}
+
+    _install_nonce_stub(monkeypatch, on_chain_nonce=1)
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+    scenario = _make_eoa_scenario(nonce=1)
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert sender not in handler_context.shared_state[hmod.SETTLING_NONCES_BY_SENDER]
+
+
+def test_max_accepted_per_sender_cap_rejects_503(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Reaching ``MAX_ACCEPTED_PER_SENDER`` rejects the next accept 503.
+
+    Guards the DoS-bound that replaced the deleted
+    ``MAX_OUTSTANDING_NONCE_WINDOW`` protocol constraint. The reason
+    string ``SENDER_INFLIGHT_LIMIT`` distinguishes the outcome from
+    a credential rejection so mech-client's 503 retry loop backs off
+    rather than concluding its signature is wrong.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    monkeypatch.setattr(hmod, "MAX_ACCEPTED_PER_SENDER", 4)
+
+    sender = _make_eoa_scenario(nonce=0)["sender"]
+    handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] = {
+        sender: {0, 1, 2, 3},
+    }
+    _install_nonce_stub(monkeypatch, on_chain_nonce=0)
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+    stored: Dict[str, Any] = {}
+    _real = mh._send_rejection_response
+
+    def _cap(
+        _msg: Any,
+        _dlg: Any,
+        rid: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real(
+            _msg,
+            _dlg,
+            rid,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _cap)
+
+    scenario = _make_eoa_scenario(nonce=4)
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.SENDER_INFLIGHT_LIMIT
+
+
+def test_eip1271_call_failed_verdict_routes_to_503(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A ``CALL_FAILED`` verdict from the EIP-1271 helper routes to 503.
+
+    Distinguishing CALL_FAILED from DECLINED is the whole point of
+    the tri-state refactor: a legitimate Safe requester saw 401
+    "unauthorized" during an RPC outage under the old boolean
+    return. Tri-state routes to 503 (``EIP1271_CALL_FAILED``) so the
+    client backs off during an RPC outage rather than treating
+    its credentials as permanently invalid.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_safe_eip1271_scenario(nonce=3)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=3)
+    monkeypatch.setattr(
+        hmod,
+        "check_eip1271_signature",
+        lambda **_kw: _Eip1271Verdict.CALL_FAILED,
+    )
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+    stored: Dict[str, Any] = {}
+    _real = mh._send_rejection_response
+
+    def _cap(
+        _msg: Any,
+        _dlg: Any,
+        rid: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        _real(
+            _msg,
+            _dlg,
+            rid,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _cap)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.EIP1271_CALL_FAILED
+    assert balance_calls == []
+
+
+def test_handler_wide_except_absorbs_random_exception(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A random exception (``ConnectionResetError``) inside the handler still 503s.
+
+    ``ConnectionResetError`` is an ``OSError``, NOT covered by the
+    inner ``(Web3Exception, RequestException, ValueError)`` tuple,
+    so a mid-flight RPC reset would otherwise propagate out and
+    stop the agent under the default ``propagate`` skill exception
+    policy. The defensive top-level ``try/except Exception`` makes
+    the handler structurally undyable.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_safe_eip1271_scenario(nonce=3)
+
+    def _boom(**_kw: Any) -> _Eip1271Verdict:
+        raise ConnectionResetError("mid-flight reset")
+
+    monkeypatch.setattr(hmod, "check_eip1271_signature", _boom)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=3)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["reason"] == "internal error"
+
+
+def test_rpc_executor_queue_saturation_returns_fast(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """Saturating the executor's queue raises ``RPC_QUEUE_SATURATED`` fast.
+
+    Pins the queue-guard: when the worker pool is drained by hung
+    callables and the queue is at ``_RPC_EXECUTOR_MAX_QUEUE``, the
+    submit-time guard fires with ``RuntimeError(RPC_QUEUE_SATURATED)``
+    instead of piling more work onto the queue for the caller to
+    timeout on.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    executor = mh._get_rpc_executor()
+
+    class _FakeQueue:
+        def qsize(self) -> int:
+            return 999
+
+    monkeypatch.setattr(executor, "_work_queue", _FakeQueue())
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match=hmod.RPC_QUEUE_SATURATED):
+        mh._run_with_wall_clock_deadline(
+            lambda: "unreachable",
+            deadline_seconds=5.0,
+            label="test_saturation",
+        )
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.5, f"queue-saturation branch waited {elapsed:.3f}s"
+
+
+def test_rpc_executor_late_outcome_callback_logs_exception(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """A callable that raises after the deadline gets its exception logged.
+
+    Pins the ``add_done_callback`` glue: ``concurrent.futures.Future``
+    does NOT log unretrieved exceptions (unlike ``asyncio.Future``),
+    so an abandoned callable's failure would otherwise be silently
+    discarded — exactly the path where root-cause visibility matters
+    most for operator triage.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    import threading as _t
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    late_events: List[str] = []
+
+    def _capture(msg: str, *args: Any, **_kwargs: Any) -> None:
+        try:
+            late_events.append(msg % args)
+        except TypeError:
+            late_events.append(msg)
+
+    handler_context.logger.warning = _capture
+
+    finished = _t.Event()
+
+    def _delayed_boom() -> None:
+        time.sleep(0.15)
+        try:
+            raise RuntimeError("late failure the caller no longer wants")
+        finally:
+            finished.set()
+
+    with pytest.raises(_cf.TimeoutError):
+        mh._run_with_wall_clock_deadline(
+            _delayed_boom, deadline_seconds=0.02, label="test_late_outcome"
+        )
+    finished.wait(timeout=2.0)
+    time.sleep(0.05)
+    assert any(
+        "completed after deadline" in ev and "test_late_outcome" in ev
+        for ev in late_events
+    ), late_events
+
+
+def test_teardown_shuts_down_rpc_executor_without_waiting(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """``teardown()`` closes the executor with ``wait=False, cancel_futures=True``.
+
+    Without this, non-daemon worker threads holding abandoned reads
+    would keep the process alive past the SIGTERM → SIGKILL grace
+    window. Test spies on ``shutdown`` to pin the kwargs.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    _ = mh._get_rpc_executor()
+    shutdown_calls: List[Dict[str, Any]] = []
+    original_shutdown = mh._rpc_executor.shutdown  # type: ignore[union-attr]
+
+    def _spy(*args: Any, **kwargs: Any) -> None:
+        shutdown_calls.append(kwargs)
+        original_shutdown(*args, **kwargs)
+
+    monkeypatch.setattr(mh._rpc_executor, "shutdown", _spy)
+    mh.teardown()
+    assert shutdown_calls == [{"wait": False, "cancel_futures": True}]
+
+
+def test_balance_check_wall_clock_deadline_short_circuits(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A slow balance RPC returns 503 within the deadline, task not enqueued.
+
+    Pins the executor wrap around the three balance-path RPCs
+    (``paymentType``, ``getBalanceTrackerForMechType``,
+    ``getRequesterBalance``). Under the pre-fix behaviour all three
+    were unbounded at the ledger-default 30s per HTTP request times
+    the retry loop, letting a slow node stall the AEA main thread
+    past the ``http_server`` reply budget on the balance-check path.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    import time as _time
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    _install_verify_ok(mh, monkeypatch)
+
+    test_deadline = 0.2
+    monkeypatch.setattr(hmod, "_BALANCE_RPC_DEADLINE_SECONDS", test_deadline)
+
+    def _slow_payment_type(*_args: Any, **_kwargs: Any) -> Dict[str, Any]:
+        _time.sleep(test_deadline * 50)
+        return {"mech_type": "0xpt"}
+
+    monkeypatch.setattr(
+        hmod.OlasMechContract, "get_mech_type", staticmethod(_slow_payment_type)
+    )
+
+    body = _make_signed_request_body(request_id="9999")
+    http_msg: Any = make_http_msg(body)
+    started = _time.monotonic()
+    mh._handle_signed_requests(http_msg, http_dialogue)
+    elapsed = _time.monotonic() - started
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert elapsed < test_deadline + 2.0, (
+        f"handler returned in {elapsed:.3f}s but balance-RPC deadline is "
+        f"{test_deadline}s; regression would let a slow paymentType read "
+        f"pin the AEA main loop past the http_server reply budget"
+    )
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_update_pending_list_preserves_offchain_tasks(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """Off-chain tasks stay in ``pending_tasks`` across on-chain status checks.
+
+    ``_update_pending_list`` rewrites ``pending_tasks`` from the
+    on-chain status response; off-chain task ids are never visible on
+    chain until settlement, so filtering strictly by that response
+    would silently drop every off-chain task on every polling cycle
+    (and leak the corresponding outstanding-nonce entry). The guard
+    keeps ``is_offchain=True`` tasks by construction.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    ch = ContractHandler(name="contract", skill_context=handler_context)
+    ch.setup()
+    handler_context.shared_state[hmod.PENDING_TASKS] = [
+        {"requestId": 100, "is_offchain": True},
+        {"requestId": 200, "is_offchain": False},
+        {"requestId": 300},
+    ]
+    body = {hmod.BodyKey.REQUEST_IDS.value: [200]}
+    ch._update_pending_list(body)
+    survivors = [
+        t["requestId"] for t in handler_context.shared_state[hmod.PENDING_TASKS]
+    ]
+    assert survivors == [100, 200]
+
+
+def test_sender_resolution_failure_returns_distinct_reason(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Failed checksum resolution surfaces ``SENDER_RESOLUTION_FAILED``.
+
+    Distinguishes a config-side failure (missing / malformed RPC
+    settings) from an RPC round-trip failure. Both surface as 503
+    but the reason string routes operator paging to the right
+    subsystem.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    monkeypatch.setattr(
+        mh,
+        "_verify_offchain_request_signature",
+        lambda **_kw: hmod.SignatureVerdict(ok=True, reason="", is_infra=False),
+    )
+    monkeypatch.setattr(mh, "_resolve_sender_checksum", lambda sender: None)
+
+    stored: Dict[str, Any] = {}
+    _real = mh._send_rejection_response
+
+    def _cap(
+        _msg: Any,
+        _dlg: Any,
+        rid: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        _real(
+            _msg,
+            _dlg,
+            rid,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _cap)
+    body = _make_signed_request_body(request_id="1234")
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+    assert stored["reason"] == hmod.SENDER_RESOLUTION_FAILED
+
+
+def test_mapnonces_deterministic_failure_returns_unrecoverable_reason(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A deterministic ABI failure on ``mapNonces`` surfaces the unrecoverable reason.
+
+    Distinct from ``NONCE_READ_FAILED`` (transient RPC / transport)
+    so operator paging can differentiate "check the logs and re-config"
+    from "check the RPC endpoint." Same 503 status code either way.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    from web3.exceptions import BadFunctionCallOutput as _BadFn
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=3)
+
+    def _boom(
+        cls: Any, ledger_api: Any, contract_address: Any, sender_address: Any
+    ) -> Dict[str, int]:
+        raise _BadFn("wrong ABI at marketplace address")
+
+    monkeypatch.setattr(hmod.MechMarketplaceContract, "get_nonce", classmethod(_boom))
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+    stored: Dict[str, Any] = {}
+    _real = mh._send_rejection_response
+
+    def _cap(
+        _msg: Any,
+        _dlg: Any,
+        rid: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        _real(
+            _msg,
+            _dlg,
+            rid,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _cap)
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.NONCE_READ_UNRECOVERABLE

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -40,6 +40,30 @@ from packages.valory.skills.task_execution.handlers import (
     LedgerHandler,
     MechHttpHandler,
 )
+from packages.valory.skills.task_execution.utils.ipfs import (
+    to_multihash as _to_multihash,
+)
+from packages.valory.skills.task_execution.utils.local_cid import (
+    compute_cidv1 as _compute_cidv1,
+)
+
+
+def _ipfs_hash_for(ipfs_data: str) -> str:
+    """Compute the 32-byte-form wire ``ipfs_hash`` for an ``ipfs_data`` payload.
+
+    :param ipfs_data: the raw JSON string carried inline in the signed body.
+    :return: the 0x-prefixed 64-hex-char SHA-256 digest form of the
+        computed CID, matched by the handler's accept-time CID-binding
+        check. The 34-byte multihash form is exercised separately.
+    """
+    return "0x" + _to_multihash(_compute_cidv1(ipfs_data.encode("utf-8")))
+
+
+# The canonical test-payload / hash pair used by every downstream test
+# whose focus is NOT the CID-binding check itself. Precomputed once at
+# module import so the fixtures can reference it as a plain constant.
+_DEFAULT_IPFS_DATA = '{"foo":"bar"}'
+_DEFAULT_IPFS_HASH = _ipfs_hash_for(_DEFAULT_IPFS_DATA)
 
 
 @pytest.mark.parametrize(
@@ -421,11 +445,12 @@ def test_signed_requests_balance_scenarios(
     mh.setup()
     _install_verify_ok(mh, monkeypatch)
 
-    ipfs_hash: str = "0x" + "ab" * 32
+    ipfs_data: str = _DEFAULT_IPFS_DATA
+    ipfs_hash: str = _DEFAULT_IPFS_HASH
     body: Dict[str, str] = {
         "ipfs_hash": ipfs_hash,
         "request_id": request_id,
-        "ipfs_data": '{"foo":"bar"}',
+        "ipfs_data": ipfs_data,
         "delivery_rate": "123",
         "sender": "0x0000000000000000000000000000000000000001",
         "signature": "0x" + "00" * 65,
@@ -448,7 +473,7 @@ def test_signed_requests_balance_scenarios(
         # dict is still str-keyed since the local ``request_id`` variable
         # in the handler stays str for the HTTP-state lookups.
         assert pend[0]["requestId"] == int(request_id)
-        assert in_mem[request_id] == '{"foo":"bar"}'
+        assert in_mem[request_id] == ipfs_data
     else:
         assert pend == [] and ipfsq == [] and in_mem == {}
 
@@ -622,12 +647,13 @@ def test_fetch_offchain_request_info_returns_insufficient_balance_response(
     _install_verify_ok(mh, monkeypatch)
 
     request_id = "1003"
-    ipfs_hash: str = "0x" + "ab" * 32
+    ipfs_data: str = _DEFAULT_IPFS_DATA
+    ipfs_hash: str = _DEFAULT_IPFS_HASH
     send_msg: Any = make_http_msg(
         {
             "ipfs_hash": ipfs_hash,
             "request_id": request_id,
-            "ipfs_data": '{"foo":"bar"}',
+            "ipfs_data": ipfs_data,
             "delivery_rate": "123",
             "sender": "0x0000000000000000000000000000000000000001",
             "signature": "0x" + "00" * 65,
@@ -679,13 +705,14 @@ def test_signed_requests_rollback_partial_enqueue(
 
     handler_context.shared_state["in_memory_requests"] = FailingDict()
 
-    ipfs_hash: str = "0x" + "ab" * 32
+    ipfs_data: str = _DEFAULT_IPFS_DATA
+    ipfs_hash: str = _DEFAULT_IPFS_HASH
     body: Dict[str, str] = {
         "ipfs_hash": ipfs_hash,
         # Numeric — the ingress coercion in ``_enqueue_offchain_request``
         # runs before the buffer-write attempt this test simulates.
         "request_id": "6",
-        "ipfs_data": '{"foo":"bar"}',
+        "ipfs_data": ipfs_data,
         "delivery_rate": "123",
         "sender": "0x0000000000000000000000000000000000000001",
         "signature": "0x" + "00" * 65,
@@ -736,9 +763,9 @@ def _send_signed_request(
     """Drive a signed offchain request and return the final HTTP response."""
     http_msg: Any = make_http_msg(
         {
-            "ipfs_hash": "0x" + "ab" * 32,
+            "ipfs_hash": _DEFAULT_IPFS_HASH,
             "request_id": request_id,
-            "ipfs_data": '{"foo":"bar"}',
+            "ipfs_data": _DEFAULT_IPFS_DATA,
             "delivery_rate": "123",
             "sender": "0x0000000000000000000000000000000000000001",
             "signature": "0x" + "00" * 65,
@@ -789,9 +816,13 @@ def test_402_emits_www_authenticate_header(
     resp = _send_signed_request(mh, http_dialogue, request_id="4021")
 
     assert resp.status_code == HttpCode.PAYMENT_REQUIRED_CODE.value
+    # The realm is the marketplace-mech address resolved from
+    # ``mech_to_config``. ``models.Params`` lowercases every key at load
+    # so the resolved address is always the lowercase form; the
+    # ``params_stub`` fixture pins the lowercase form too.
     assert (
         'WWW-Authenticate: Payment scheme="olas-prepay" '
-        'realm="0xMechAddr"' in resp.headers
+        'realm="0xmechaddr"' in resp.headers
     )
 
 
@@ -1977,9 +2008,11 @@ def test_filter_requests_empty_list(
 
 
 def _make_signed_request_body(
-    ipfs_hash: str = "0x" + "ab" * 32,
+    ipfs_hash: str = _DEFAULT_IPFS_HASH,
     delivery_rate: str = "123",
     request_id: str = "req-hardening",
+    ipfs_data: str = _DEFAULT_IPFS_DATA,
+    nonce: str = "0",
 ) -> Dict[str, str]:
     """Build a valid signed-request body used by hardening tests.
 
@@ -1988,19 +2021,27 @@ def _make_signed_request_body(
     accept paths install a stub verifier via ``_install_verify_ok`` and
     tests that exercise sig-verify itself override these fields.
 
+    The default ``ipfs_hash`` is the multihash-stripped CID of
+    ``_DEFAULT_IPFS_DATA`` so the CID-binding check at the top of the
+    accept path passes without the individual test having to derive
+    the hash itself. Tests that want to exercise the mismatch branch
+    override either ``ipfs_hash`` or ``ipfs_data`` (or both) directly.
+
     :param ipfs_hash: 0x-prefixed hex ipfs hash value for the body.
     :param delivery_rate: decimal delivery rate string for the body.
     :param request_id: request_id string for the body.
+    :param ipfs_data: raw JSON string for the body.
+    :param nonce: decimal nonce string for the body.
     :return: a request-body dict with all required fields populated.
     """
     return {
         "ipfs_hash": ipfs_hash,
         "request_id": request_id,
-        "ipfs_data": '{"foo":"bar"}',
+        "ipfs_data": ipfs_data,
         "delivery_rate": delivery_rate,
         "sender": "0x0000000000000000000000000000000000000001",
         "signature": "0x" + "00" * 65,
-        "nonce": "0",
+        "nonce": nonce,
     }
 
 
@@ -2232,7 +2273,11 @@ def test_enqueue_offchain_request_reserved_keys_filter_blocks_body_overrides(
     # Trusted values won on every reserved key.
     assert task[hmod.RequestKey.REQUEST_ID_CAMEL.value] == 42
     assert task[hmod.RequestKey.IS_OFFCHAIN.value] is True
-    assert task[hmod.BodyKey.DATA.value] == bytes.fromhex("ab" * 32)
+    # ``BodyKey.DATA`` is derived from the wire ``ipfs_hash`` — which
+    # ``_make_signed_request_body`` sets to the CID of
+    # ``_DEFAULT_IPFS_DATA`` so the accept-time CID-binding check
+    # passes. Assert against the same derivation.
+    assert task[hmod.BodyKey.DATA.value] == bytes.fromhex(_DEFAULT_IPFS_HASH[2:])
     assert task[hmod.RequestKey.REQUEST_DELIVERY_RATE.value] == 123
     # Snake-case ``request_id`` must never appear on the pending task:
     # ``_handle_done_task`` spreads ``**executing_task`` into ``done_task``
@@ -2400,8 +2445,20 @@ def _seed_verification_constants(
     """
     params.mech_marketplace_address = _SIGVERIFY_MARKETPLACE
     params.agent_mech_contract_addresses = [_SIGVERIFY_MECH]
+    # Post the round-6 refactor, the handler resolves the mech address
+    # via ``mech_to_config`` scanning for ``is_marketplace_mech``; stamp
+    # a matching entry so ``_resolve_marketplace_mech_address`` returns
+    # ``_SIGVERIFY_MECH`` and the sig-verify path uses the same address
+    # the test's ``_compute_request_id`` was called with.
+    params.mech_to_config = {
+        _SIGVERIFY_MECH.lower(): SimpleNamespace(
+            is_marketplace_mech=True,
+            use_dynamic_pricing=False,
+        )
+    }
     mh._domain_separator = _SIGVERIFY_DOMAIN_SEPARATOR
     mh._payment_type = _SIGVERIFY_PAYMENT_TYPE
+    mh._marketplace_mech_address = _SIGVERIFY_MECH
     # Bypass the RPC that _verify_offchain_request_signature would otherwise
     # try to open. Both the balance and verify paths would call this — the
     # verify path only needs the address prep to succeed. Returning ``ok``
@@ -2424,13 +2481,28 @@ def _sig_body(
     nonce: int,
     sender: str,
     signature_hex: str,
-    ipfs_hash: str = "0x" + "ab" * 32,
+    ipfs_hash: str = _DEFAULT_IPFS_HASH,
+    ipfs_data: str = _DEFAULT_IPFS_DATA,
 ) -> Dict[str, str]:
-    """Build a signed-request body populated for a sig-verify scenario."""
+    """Build a signed-request body populated for a sig-verify scenario.
+
+    The default ``ipfs_hash`` matches the CID of ``ipfs_data`` so the
+    accept path's binding check passes; tests that exercise a mismatch
+    override either field directly.
+
+    :param request_id: decimal request_id string for the body.
+    :param delivery_rate: requester-signed delivery rate.
+    :param nonce: requester nonce.
+    :param sender: requester address.
+    :param signature_hex: hex-encoded signature bytes.
+    :param ipfs_hash: 0x-prefixed hex ipfs hash value for the body.
+    :param ipfs_data: raw JSON string carried inline in the body.
+    :return: a signed-request body dict.
+    """
     return {
         "ipfs_hash": ipfs_hash,
         "request_id": request_id,
-        "ipfs_data": '{"foo":"bar"}',
+        "ipfs_data": ipfs_data,
         "delivery_rate": str(delivery_rate),
         "sender": sender,
         "signature": signature_hex,
@@ -2442,7 +2514,13 @@ def _make_eoa_scenario(delivery_rate: int = 123, nonce: int = 7) -> Dict[str, An
     """Sign a request_id derived from the marketplace formula with a fixed EOA key."""
     account = _Account.from_key(_SIGVERIFY_PRIVATE_KEY)
     sender = _to_checksum(account.address)
-    ipfs_hash = "0x" + "ab" * 32
+    # The signature commits to ``keccak(ipfs_hash)``; the CID-binding
+    # check in the accept path then requires ``ipfs_hash`` to be the CID
+    # of the ``ipfs_data`` bytes the mech will run. ``_sig_body`` uses
+    # ``_DEFAULT_IPFS_DATA`` for the body; the ``ipfs_hash`` computed
+    # from that same payload is what the returned scenario carries so
+    # the accept path sees a matched pair.
+    ipfs_hash = _DEFAULT_IPFS_HASH
     request_data = bytes.fromhex(ipfs_hash[2:])
     request_id_bytes = _compute_request_id(
         marketplace=_SIGVERIFY_MARKETPLACE,
@@ -2587,7 +2665,7 @@ def test_verify_offchain_signature_safe_eip1271_true_accepts(
     # recover to the sender, so the ecrecover branch misses and the code
     # falls through to the EIP-1271 wrapper.
     safe_sender = _to_checksum("0x" + "99" * 20)
-    ipfs_hash = "0x" + "ab" * 32
+    ipfs_hash = _DEFAULT_IPFS_HASH
     request_data = bytes.fromhex(ipfs_hash[2:])
     delivery_rate = 42
     nonce = 3
@@ -2789,3 +2867,556 @@ def test_verify_offchain_signature_rejects_when_constants_unloaded(
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
     assert balance_calls == []
+
+
+# ---------------------------------------------------------------------------
+# CID-binding check on the accept path (ipfs_hash must equal CID of ipfs_data)
+# ---------------------------------------------------------------------------
+
+
+def test_signed_requests_accepts_body_whose_cid_matches_posted_ipfs_hash(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A body whose CID matches the wire ``ipfs_hash`` is accepted and enqueued.
+
+    The 34-byte multihash form (``0x1220 || sha256``) is accepted as
+    equivalent to the 32-byte bare-digest form; both reduce to the same
+    32-byte digest for the compare.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    # Build the wire ipfs_hash in the 34-byte multihash form: strip the
+    # ``0x`` prefix, prepend the SHA-256 multihash prefix ``1220``, add
+    # ``0x`` back. The handler's binding check must accept both encodings.
+    multihash_form_ipfs_hash = "0x1220" + _DEFAULT_IPFS_HASH[2:]
+    body = _make_signed_request_body(
+        request_id="7001",
+        ipfs_data=_DEFAULT_IPFS_DATA,
+        ipfs_hash=multihash_form_ipfs_hash,
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_signed_requests_rejects_when_ipfs_hash_does_not_match_body(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A body whose CID does NOT match the wire ipfs_hash is rejected 400.
+
+    The signature authorises work described by ``keccak(ipfs_hash)``; a
+    body that hashes to a different content commitment would enqueue
+    arbitrary work under a signature that authorised different content.
+    The handler must reject before enqueue, and the balance check must
+    not fire.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    balance_calls: List[Any] = []
+
+    def _spy_balance_check(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
+
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance_check)
+    mh.setup()
+    _install_verify_ok(mh, monkeypatch)
+
+    # Post a body whose ipfs_data is NOT what the ipfs_hash commits to.
+    mismatched_data = '{"other":"payload"}'
+    body = _make_signed_request_body(
+        request_id="7002",
+        ipfs_data=mismatched_data,
+        ipfs_hash=_DEFAULT_IPFS_HASH,  # commits to _DEFAULT_IPFS_DATA
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["reason"] == hmod.IPFS_HASH_BODY_MISMATCH
+    # Nothing enqueued, no balance RPC.
+    assert handler_context.shared_state["pending_tasks"] == []
+    assert handler_context.shared_state["in_memory_requests"] == {}
+    assert balance_calls == []
+
+
+def test_signed_requests_rejects_when_ipfs_data_is_empty(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Empty ``ipfs_data`` fails the CID-binding check (no bytes to hash)."""
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(
+        request_id="7003",
+        ipfs_data="",
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Nonce coercion + numeric sort discipline
+# ---------------------------------------------------------------------------
+
+
+def test_signed_requests_stores_nonce_as_int_on_pending_task(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The coerced ``int`` nonce lands on the pending task.
+
+    Downstream (see
+    ``task_submission_abci.behaviours._get_offchain_tasks_deliver_data``)
+    sorts the offchain done-task list by ``nonce`` and the sort key must
+    be an ``int`` — a wire ``str`` would sort lexicographically and
+    mis-order the batch against the on-chain ``mapNonces`` array consume.
+    Pin the ``int`` coercion at the enqueue boundary here so any future
+    regression fails locally instead of surfacing as a bad on-chain
+    delivery.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(request_id="7010", nonce="10")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    pending = handler_context.shared_state["pending_tasks"]
+    assert len(pending) == 1
+    stored_nonce = pending[0]["nonce"]
+    assert isinstance(
+        stored_nonce, int
+    ), f"nonce must be int post ingress coercion, got {type(stored_nonce).__name__}"
+    assert stored_nonce == 10
+
+
+def test_signed_requests_two_task_batch_sorts_nonce_numerically(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Nonces ``9`` and ``10`` sort numerically (9 before 10), not as strings.
+
+    This is the exact scenario the task_submission_abci sort key
+    consumes. A str-typed nonce would sort lexicographically —
+    ``["10", "9"]`` — and the on-chain ``mapNonces`` array consume
+    would fail the whole batch.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+
+    # Send nonce="10" first, then nonce="9". A lexicographic sort would
+    # keep the wire order; a numeric sort would swap them.
+    first_msg: Any = make_http_msg(
+        _make_signed_request_body(request_id="7020", nonce="10")
+    )
+    mh._handle_signed_requests(
+        first_msg,
+        http_dialogue,
+    )
+    second_msg: Any = make_http_msg(
+        _make_signed_request_body(
+            request_id="7021",
+            nonce="9",
+            # Vary the ipfs_data so the CID-bind + dedup checks let
+            # the second request through as a distinct one.
+            ipfs_data='{"foo":"baz"}',
+            ipfs_hash=_ipfs_hash_for('{"foo":"baz"}'),
+        )
+    )
+    mh._handle_signed_requests(
+        second_msg,
+        http_dialogue,
+    )
+
+    pending = handler_context.shared_state["pending_tasks"]
+    assert len(pending) == 2
+    ordered = sorted(pending, key=lambda t: t["nonce"])
+    assert [t["nonce"] for t in ordered] == [
+        9,
+        10,
+    ], "sort by 'nonce' key must be numeric (int), not lexicographic (str)"
+
+
+@pytest.mark.parametrize(
+    "bad_nonce",
+    ["9abc", "-1", str(2**256), "", "042", " 42", "42\n", "๙", "9" * 5000],
+    ids=[
+        "trailing_alpha",
+        "negative",
+        "above_uint256",
+        "empty",
+        "leading_zero_padded",
+        "leading_space",
+        "trailing_newline",
+        "thai_digit",
+        "above_cpython_int_str_digits_limit",
+    ],
+)
+def test_signed_requests_rejects_invalid_nonce(
+    handler_context: Any,
+    http_dialogue: Any,
+    monkeypatch: Any,
+    bad_nonce: str,
+) -> None:
+    """Non-canonical, out-of-range, or empty nonce is rejected 400 at ingress."""
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(request_id="7030", nonce=bad_nonce)
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Pre-auth vs post-auth writes into offchain_request_responses
+# ---------------------------------------------------------------------------
+
+
+def test_401_bad_sig_does_not_write_offchain_response(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A pre-auth 401 must NOT persist a rejection payload keyed by request_id.
+
+    Otherwise a caller could poison an arbitrary id they do not own, and
+    the legitimate owner would later read that payload via the polling
+    endpoint. Only rejections after signature ownership is proven may
+    write into the shared response cache.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    # Force sig-verify to fail so the accept path 401s.
+    monkeypatch.setattr(
+        mh,
+        "_verify_offchain_request_signature",
+        lambda **_kw: False,
+    )
+
+    body = _make_signed_request_body(request_id="7040")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    # The caller-supplied request_id must NOT have landed in the shared
+    # response cache — that dict is the source the polling endpoint
+    # reads.
+    assert "7040" not in handler_context.shared_state["offchain_request_responses"]
+
+
+def test_402_insufficient_balance_writes_offchain_response(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A post-auth 402 DOES persist the challenge under request_id.
+
+    The caller has already proven signature ownership; the deposit
+    challenge must be readable via the polling endpoint so mech-client
+    can present it to the requester.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=-1
+    )
+    _send_signed_request(mh, http_dialogue, request_id="7050")
+
+    stored = handler_context.shared_state["offchain_request_responses"].get("7050")
+    assert stored is not None, "402 challenge must be persisted for polling"
+    assert stored["status"] == "rejected"
+    assert stored["reason"] == "insufficient balance"
+
+
+# ---------------------------------------------------------------------------
+# Replay protection (dedup on request_id)
+# ---------------------------------------------------------------------------
+
+
+def test_signed_requests_deduplicates_repeated_body(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The same body posted twice returns 200 without a second enqueue.
+
+    Every signed field is bound into the ``request_id``; the same body
+    therefore always hashes to the same id and dedup is exact. Returning
+    a 200 (with an ``already accepted`` note) preserves mech-client's
+    idempotent-retry semantics — a 409 would change the client contract.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+
+    first = _send_signed_request(mh, http_dialogue, request_id="7060")
+    assert first.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+    second = _send_signed_request(mh, http_dialogue, request_id="7060")
+    assert second.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(second.body.decode("utf-8"))
+    assert payload["reason"] == hmod.REQUEST_ALREADY_ACCEPTED
+    # No second enqueue: the pending list is still length 1.
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_signed_requests_distinct_ids_both_enqueue(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Different request_ids both enqueue; dedup does not over-block."""
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+
+    first = _send_signed_request(mh, http_dialogue, request_id="7070")
+    second = _send_signed_request(mh, http_dialogue, request_id="7071")
+
+    assert first.status_code == HttpCode.OK_CODE.value
+    assert second.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 2
+
+
+def test_signed_requests_dedup_covers_delivered_state(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A request_id already in offchain_request_responses is treated as dedup.
+
+    Once a task has been delivered or post-auth-rejected, the writer
+    populates ``offchain_request_responses[str(req_id)]``. A retry against
+    that same id must not re-enqueue: the mech would otherwise execute
+    (and settle) work that has already been paid for and delivered.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    # Pre-seed the response cache as if a previous delivery had settled.
+    handler_context.shared_state["offchain_request_responses"]["7080"] = {
+        "status": "ok",
+        "request_id": "7080",
+    }
+
+    resp = _send_signed_request(mh, http_dialogue, request_id="7080")
+
+    assert resp.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["reason"] == hmod.REQUEST_ALREADY_ACCEPTED
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Marketplace-mech resolution via mech_to_config, not by index
+# ---------------------------------------------------------------------------
+
+
+def test_setup_resolves_marketplace_mech_from_config_not_by_index(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """The offchain handler resolves the mech by ``is_marketplace_mech``.
+
+    A deployment whose ``mech_to_config`` lists a non-marketplace mech
+    first would 401 every offchain request if the handler used
+    ``agent_mech_contract_addresses[0]``. Cache the address resolved
+    from the config flag so the derivation uses the marketplace mech
+    regardless of ordering.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    non_marketplace = "0xnonmarket0000000000000000000000000000000000000"[:42]
+    marketplace = "0xmarket00000000000000000000000000000000000000000"[:42]
+    handler_context.params.mech_to_config = {
+        non_marketplace.lower(): SimpleNamespace(
+            is_marketplace_mech=False,
+            use_dynamic_pricing=False,
+        ),
+        marketplace.lower(): SimpleNamespace(
+            is_marketplace_mech=True,
+            use_dynamic_pricing=False,
+        ),
+    }
+    handler_context.params.agent_mech_contract_addresses = [
+        non_marketplace,
+        marketplace,
+    ]
+
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    # Skip _initialise_offchain_verification_constants by keeping
+    # use_offchain=False for this test; only the resolver itself is
+    # being pinned here.
+    handler_context.params.use_offchain = False
+    mh.setup()
+
+    assert mh._marketplace_mech_address == marketplace.lower()
+
+
+def test_setup_returns_none_when_no_marketplace_mech_configured(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """No ``is_marketplace_mech`` flag anywhere → cache stays None → accepts 401."""
+    handler_context.params.mech_to_config = {
+        "0xnonmarket": SimpleNamespace(
+            is_marketplace_mech=False,
+            use_dynamic_pricing=False,
+        )
+    }
+    handler_context.params.use_offchain = False
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    assert mh._marketplace_mech_address is None
+
+
+# ---------------------------------------------------------------------------
+# Boot-time self-check: marketplace getRequestId vs local compute_request_id
+# ---------------------------------------------------------------------------
+
+
+def test_selfcheck_mismatch_flips_constants_off_and_subsequent_accepts_401(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A mismatched marketplace getRequestId disables offchain accepts.
+
+    Simulates a marketplace upgrade that changed the ``getRequestId``
+    layout without a corresponding handler bump. The self-check must
+    flip the boot-cached constants off (rather than crash the process)
+    and every subsequent accept must 401 with the sentinel reason so
+    operators can correlate.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    # Constants land loaded from the seed helper; the mismatched view
+    # is what would flip them off in production. Feed a bogus view
+    # return that disagrees with the local ``compute_request_id`` and
+    # drive the self-check manually.
+    monkeypatch.setattr(
+        hmod,
+        "get_marketplace_request_id_view",
+        lambda **_kw: b"\xff" * 32,
+    )
+
+    # Any ``ledger_api`` object works — the ``get_request_id_view`` stub
+    # ignores it. The verify path uses ``EthereumApi`` for its checksum
+    # helper only; a ``MagicMock`` with a chained ``to_checksum_address``
+    # is enough for the failure branch we care about.
+    fake_ledger = MagicMock()
+    fake_ledger.api.to_checksum_address = lambda addr: addr
+    mh._selfcheck_marketplace_request_id_derivation(fake_ledger)
+
+    assert mh._domain_separator is None
+    assert mh._payment_type is None
+
+    balance_calls: List[Any] = []
+
+    def _record_call(**kw: Any) -> None:
+        balance_calls.append(kw)
+        return None
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _record_call)
+
+    # Subsequent accept must 401 (sig-verify short-circuits on the
+    # unset constants) and the balance check must not run.
+    scenario = _make_eoa_scenario()
+    http_msg: Any = make_http_msg(
+        _sig_body(
+            request_id=scenario["request_id"],
+            delivery_rate=scenario["delivery_rate"],
+            nonce=scenario["nonce"],
+            sender=scenario["sender"],
+            signature_hex=scenario["signature_hex"],
+            ipfs_hash=scenario["ipfs_hash"],
+        )
+    )
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert balance_calls == []
+
+
+def test_selfcheck_match_leaves_constants_loaded(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """A matching self-check keeps constants loaded; accepts continue as normal."""
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    # Return whatever ``compute_request_id`` produced locally so the
+    # comparison inside the self-check succeeds.
+    from packages.valory.skills.task_execution.utils.request_id import (
+        compute_request_id as _local_compute,
+    )
+
+    expected = _local_compute(
+        marketplace=_SIGVERIFY_MARKETPLACE,
+        mech=_SIGVERIFY_MECH,
+        requester=hmod._SELFCHECK_REQUESTER,
+        request_data=hmod._SELFCHECK_REQUEST_DATA,
+        delivery_rate=hmod._SELFCHECK_DELIVERY_RATE,
+        payment_type=_SIGVERIFY_PAYMENT_TYPE,
+        nonce=hmod._SELFCHECK_NONCE,
+        domain_separator=_SIGVERIFY_DOMAIN_SEPARATOR,
+    )
+    monkeypatch.setattr(
+        hmod,
+        "get_marketplace_request_id_view",
+        lambda **_kw: expected,
+    )
+
+    fake_ledger = MagicMock()
+    fake_ledger.api.to_checksum_address = lambda addr: addr
+    mh._selfcheck_marketplace_request_id_derivation(fake_ledger)
+
+    assert mh._domain_separator == _SIGVERIFY_DOMAIN_SEPARATOR
+    assert mh._payment_type == _SIGVERIFY_PAYMENT_TYPE

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -2051,7 +2051,9 @@ def _install_verify_ok(mh: Any, monkeypatch: Any) -> None:
     Boundary-level stub for tests that focus on downstream behaviour
     (balance check, 402 flow, receipt header). The sig-verify method
     itself is exercised by dedicated tests that feed real signatures
-    through the real code path.
+    through the real code path. Returns a ``SignatureVerdict`` (post
+    the ``bool`` → verdict refactor) so callers can branch on
+    ``is_infra`` to distinguish 401 vs 503.
 
     :param mh: the ``MechHttpHandler`` instance to patch.
     :param monkeypatch: the pytest ``monkeypatch`` fixture.
@@ -2059,7 +2061,7 @@ def _install_verify_ok(mh: Any, monkeypatch: Any) -> None:
     monkeypatch.setattr(
         mh,
         "_verify_offchain_request_signature",
-        lambda **_kwargs: True,
+        lambda **_kwargs: hmod.SignatureVerdict(ok=True, reason="", is_infra=False),
     )
 
 
@@ -2258,9 +2260,11 @@ def test_enqueue_offchain_request_reserved_keys_filter_blocks_body_overrides(
     body["request_id_nonce"] = "999"
     body["requestIdWithNonce"] = "999"
     body["tool"] = "attacker-tool"
-    # Plus a benign key that must survive the filter untouched, so the
-    # test also pins that non-reserved keys still flow through.
-    body["signature"] = "0xdead"
+    # ``signature`` is a full-length placeholder so the ingress
+    # format guard (``SIGNATURE_RE``) accepts it; the test still
+    # pins that it survives the reserved-key filter untouched.
+    valid_signature = "0x" + "aa" * 65
+    body["signature"] = valid_signature
 
     http_msg: Any = make_http_msg(body)
     mh._handle_signed_requests(http_msg, http_dialogue)
@@ -2295,7 +2299,7 @@ def test_enqueue_offchain_request_reserved_keys_filter_blocks_body_overrides(
     ):
         assert reserved not in task, f"reserved key {reserved!r} leaked from body"
     # Non-reserved key still flows through.
-    assert task["signature"] == "0xdead"
+    assert task["signature"] == valid_signature
 
 
 # --- guard tests for the defensive paths added in the remediation -----------
@@ -2415,7 +2419,6 @@ def test_handler_replies_500_when_402_build_fails(
 
 from eth_account import Account as _Account  # noqa: E402
 from eth_utils import to_checksum_address as _to_checksum  # noqa: E402
-
 from packages.valory.skills.task_execution.utils.request_id import (  # noqa: E402
     compute_request_id as _compute_request_id,
 )
@@ -2841,10 +2844,22 @@ def test_verify_offchain_signature_rejects_when_wire_request_id_mismatches_deriv
     assert balance_calls == []
 
 
-def test_verify_offchain_signature_rejects_when_constants_unloaded(
+def test_verify_offchain_signature_rejects_503_when_constants_unloaded(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
-    """If setup could not load the deployment constants, requests are refused."""
+    """Unloaded boot constants surface as 503 (infra), not 401 (bad-sig).
+
+    The sig-verifier returns a ``SignatureVerdict`` with
+    ``is_infra=True`` when the marketplace domain-separator or mech
+    ``paymentType`` is unset (setup failed or a self-check mismatch
+    flipped them off). The handler routes those verdicts to 503 so a
+    well-behaved client treats the failure as retryable instead of
+    concluding its credentials are wrong.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
     mh = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
     mh.setup()
@@ -2865,8 +2880,12 @@ def test_verify_offchain_signature_rejects_when_constants_unloaded(
     mh._handle_signed_requests(http_msg, http_dialogue)
 
     resp = handler_context.outbox.sent[-1]
-    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
     assert balance_calls == []
+    # Pre-auth 503: the caller-supplied request_id must not have
+    # landed in the shared response cache — a 503 does not persist
+    # a rejection payload any more than a 401 does.
+    assert "1" not in handler_context.shared_state["offchain_request_responses"]
 
 
 # ---------------------------------------------------------------------------
@@ -3123,7 +3142,11 @@ def test_401_bad_sig_does_not_write_offchain_response(
     monkeypatch.setattr(
         mh,
         "_verify_offchain_request_signature",
-        lambda **_kw: False,
+        lambda **_kw: hmod.SignatureVerdict(
+            ok=False,
+            reason="signature verification failed",
+            is_infra=False,
+        ),
     )
 
     body = _make_signed_request_body(request_id="7040")
@@ -3314,7 +3337,7 @@ def test_setup_returns_none_when_no_marketplace_mech_configured(
 # ---------------------------------------------------------------------------
 
 
-def test_selfcheck_mismatch_flips_constants_off_and_subsequent_accepts_401(
+def test_selfcheck_mismatch_flips_constants_off_and_subsequent_accepts_503(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
     """A mismatched marketplace getRequestId disables offchain accepts.
@@ -3322,8 +3345,9 @@ def test_selfcheck_mismatch_flips_constants_off_and_subsequent_accepts_401(
     Simulates a marketplace upgrade that changed the ``getRequestId``
     layout without a corresponding handler bump. The self-check must
     flip the boot-cached constants off (rather than crash the process)
-    and every subsequent accept must 401 with the sentinel reason so
-    operators can correlate.
+    and every subsequent accept must 503 (infra-side signal, distinct
+    from a 401 bad-signature) so operators can correlate and clients
+    back off rather than treating the failure as a credential issue.
 
     :param handler_context: pytest fixture, mech HTTP handler test context.
     :param http_dialogue: pytest fixture, HTTP dialogue stub.
@@ -3363,8 +3387,9 @@ def test_selfcheck_mismatch_flips_constants_off_and_subsequent_accepts_401(
 
     monkeypatch.setattr(mh, "_check_offchain_requester_balance", _record_call)
 
-    # Subsequent accept must 401 (sig-verify short-circuits on the
-    # unset constants) and the balance check must not run.
+    # Subsequent accept must 503 (sig-verify short-circuits on the
+    # unset constants and routes to infra-side status) and the
+    # balance check must not run.
     scenario = _make_eoa_scenario()
     http_msg: Any = make_http_msg(
         _sig_body(
@@ -3379,7 +3404,7 @@ def test_selfcheck_mismatch_flips_constants_off_and_subsequent_accepts_401(
     mh._handle_signed_requests(http_msg, http_dialogue)
 
     resp = handler_context.outbox.sent[-1]
-    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
     assert balance_calls == []
 
 
@@ -3420,3 +3445,608 @@ def test_selfcheck_match_leaves_constants_loaded(
 
     assert mh._domain_separator == _SIGVERIFY_DOMAIN_SEPARATOR
     assert mh._payment_type == _SIGVERIFY_PAYMENT_TYPE
+
+
+# ---------------------------------------------------------------------------
+# Self-check: transport failures leave constants loaded (don't disable perm)
+# ---------------------------------------------------------------------------
+
+
+import requests  # noqa: E402
+from web3.exceptions import (  # noqa: E402
+    BadFunctionCallOutput as _Web3BadFunctionCallOutput,
+)
+from web3.exceptions import ContractLogicError as _Web3ContractLogicError  # noqa: E402
+from web3.exceptions import Web3RPCError as _Web3RPCError  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "transport_exc",
+    [
+        pytest.param(
+            requests.exceptions.ConnectionError("boom"), id="connection_error"
+        ),
+        pytest.param(requests.exceptions.ReadTimeout("slow"), id="read_timeout"),
+        pytest.param(TimeoutError("deadline"), id="timeout_error"),
+        pytest.param(_Web3RPCError("rpc"), id="web3_rpc_error"),
+    ],
+)
+def test_selfcheck_transport_error_keeps_constants_loaded(
+    handler_context: Any,
+    monkeypatch: Any,
+    transport_exc: BaseException,
+) -> None:
+    """A transient RPC blip during the self-check does not permanently 503 the endpoint.
+
+    The self-check must distinguish a genuine contract incompat (revert,
+    undecodable return, local derivation raising ValueError) from a
+    transport-side failure. Only the incompat branch flips the boot
+    constants off; transport failures log a warning and leave the
+    constants loaded so per-request sig verification can re-try on the
+    next call.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param transport_exc: the transport-level exception injected by the parametrise.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    def _raise(**_kw: Any) -> bytes:
+        raise transport_exc
+
+    monkeypatch.setattr(hmod, "get_marketplace_request_id_view", _raise)
+
+    fake_ledger = MagicMock()
+    fake_ledger.api.to_checksum_address = lambda addr: addr
+    mh._selfcheck_marketplace_request_id_derivation(fake_ledger)
+
+    # Transport failure must leave the constants loaded so a well-behaved
+    # client is not permanently locked out by a boot-time RPC blip.
+    assert mh._domain_separator == _SIGVERIFY_DOMAIN_SEPARATOR
+    assert mh._payment_type == _SIGVERIFY_PAYMENT_TYPE
+
+
+@pytest.mark.parametrize(
+    "contract_exc",
+    [
+        pytest.param(
+            _Web3ContractLogicError("execution reverted"),
+            id="contract_logic_error",
+        ),
+        pytest.param(
+            _Web3BadFunctionCallOutput("decode failure"),
+            id="bad_function_call_output",
+        ),
+        pytest.param(ValueError("derivation raised"), id="value_error"),
+    ],
+)
+def test_selfcheck_contract_error_flips_constants_off(
+    handler_context: Any,
+    monkeypatch: Any,
+    contract_exc: BaseException,
+) -> None:
+    """Contract-level failures during the self-check flip the constants off.
+
+    A revert (``ContractLogicError``), an undecodable return
+    (``BadFunctionCallOutput``), or the local derivation raising
+    ``ValueError`` all mean the marketplace ``getRequestId`` layout does
+    not match the local ``compute_request_id`` reimplementation. The
+    boot-cached constants must be nulled so subsequent accepts refuse
+    with an infra-side signal (503) instead of trusting a derivation the
+    boot handler could not confirm.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param contract_exc: the contract-level exception injected by the parametrise.
+    """
+    mh: MechHttpHandler = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    def _raise(**_kw: Any) -> bytes:
+        raise contract_exc
+
+    monkeypatch.setattr(hmod, "get_marketplace_request_id_view", _raise)
+
+    fake_ledger = MagicMock()
+    fake_ledger.api.to_checksum_address = lambda addr: addr
+    mh._selfcheck_marketplace_request_id_derivation(fake_ledger)
+
+    assert mh._domain_separator is None
+    assert mh._payment_type is None
+
+
+# ---------------------------------------------------------------------------
+# CID-binding prefix strip: only fire on the 68-char multihash form
+# ---------------------------------------------------------------------------
+
+
+def test_cid_binding_bare_digest_starting_with_1220_accepted() -> None:
+    """A 64-char bare digest whose bytes happen to start with ``1220`` still matches.
+
+    The multihash-prefix strip in ``_verify_ipfs_hash_binding`` fires
+    only on the 68-char form (``0x1220 || sha256``). A 64-char bare
+    digest whose first two bytes happen to be ``0x12 0x20`` is content,
+    not a wrapper, and stripping four chars there would leave 60 hex
+    chars — no valid 32-byte digest could match, so any payload whose
+    computed digest starts with those two bytes would deterministically
+    400 with a spurious CID-mismatch reason. Ojus reproduced this on
+    ``{"nonce":33423}``; this test drives an equivalent scenario using
+    a stubbed derivation to make the assertion deterministic without
+    relying on a brute-forced payload.
+
+    The scenario constructs a body whose posted 64-char digest starts
+    with ``1220`` (bytes-wise), stubs ``to_multihash`` to return the
+    same digest for the ``compute_cidv1`` output on that body, and
+    asserts the accept-time check returns ``(True, "")``.
+    """
+    from packages.valory.skills.task_execution import handlers as _h
+
+    # A bare 64-char digest whose bytes start with 12 20.
+    bare_digest = "1220" + "ab" * 30  # 4 + 60 = 64 hex chars
+    assert len(bare_digest) == 64
+
+    class _FakeContext:
+        class logger:
+            @staticmethod
+            def error(*_a: Any, **_kw: Any) -> None:
+                pass
+
+    class _MinimalHandler:
+        context = _FakeContext()
+
+        _verify_ipfs_hash_binding = MechHttpHandler._verify_ipfs_hash_binding
+
+    dummy = _MinimalHandler()
+    ipfs_data = '{"payload":"whatever"}'
+    # Force ``to_multihash(compute_cidv1(...))`` to return the same
+    # bare-digest hex the caller posted. The prefix-strip must NOT
+    # touch the 64-char form; if it does, only 60 hex chars survive
+    # for the compare and this test fails.
+    with patch.object(_h, "to_multihash", return_value=bare_digest):
+        ok, reason = dummy._verify_ipfs_hash_binding(
+            request_id="rid",
+            ipfs_hash="0x" + bare_digest,
+            ipfs_data=ipfs_data,
+        )
+    assert ok is True, reason
+    assert reason == ""
+
+
+def test_cid_binding_multihash_prefix_stripped_only_from_68_char_form() -> None:
+    """The 68-char multihash form has its ``1220`` prefix stripped for compare."""
+    from packages.valory.skills.task_execution import handlers as _h
+
+    bare_digest = "ab" * 32  # 64 hex chars, does NOT start with 1220
+    multihash_form = "1220" + bare_digest  # 68 hex chars
+
+    class _FakeContext:
+        class logger:
+            @staticmethod
+            def error(*_a: Any, **_kw: Any) -> None:
+                pass
+
+    class _MinimalHandler:
+        context = _FakeContext()
+
+        _verify_ipfs_hash_binding = MechHttpHandler._verify_ipfs_hash_binding
+
+    dummy = _MinimalHandler()
+    with patch.object(_h, "to_multihash", return_value=bare_digest):
+        ok, reason = dummy._verify_ipfs_hash_binding(
+            request_id="rid",
+            ipfs_hash="0x" + multihash_form,
+            ipfs_data='{"any":"data"}',
+        )
+    assert ok is True, reason
+
+
+# ---------------------------------------------------------------------------
+# Oversize ipfs_data surfaces as a distinct rejection reason, not CID mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_signed_requests_rejects_oversize_ipfs_data_with_distinct_reason(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A body in the 256 KiB - 1 MB window 400s with ``IPFS_DATA_OVERSIZE``.
+
+    ``MAX_HTTP_BODY_BYTES`` is 1 MB but ``compute_cidv1`` raises above
+    the 256 KiB single-block bound. Bodies in that window are outside
+    the CID-mismatch domain — the caller's ``ipfs_hash`` could not
+    match any 32-byte digest for a body that cannot itself produce a
+    single-block CID — so the handler surfaces them as
+    ``IPFS_DATA_OVERSIZE`` distinct from ``IPFS_HASH_BODY_MISMATCH``
+    so the caller can attribute the 400 to size rather than a
+    hash-vs-content disagreement.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    # 512 KiB body — inside the HTTP body cap (1 MB) but well past the
+    # single-block CID bound (256 KiB).
+    oversize_padding = 512 * 1024
+    body = _make_signed_request_body(
+        request_id="8001",
+        ipfs_data='{"x":"' + "y" * oversize_padding + '"}',
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert (
+        payload["reason"] == hmod.IPFS_DATA_OVERSIZE
+    ), f"oversize body must report a distinct reason; got {payload['reason']!r}"
+    assert payload["reason"] != hmod.IPFS_HASH_BODY_MISMATCH
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Signature ingress format guard (0x-prefixed even-length hex, bounded length)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_signature",
+    [
+        pytest.param("aa" * 65, id="missing_0x_prefix"),
+        pytest.param("0x" + "aa" * 64, id="short_by_one_byte"),
+        pytest.param("0x" + "z" * 130, id="non_hex_chars"),
+        pytest.param("0x" + "a" * 129, id="odd_hex_length"),
+        pytest.param("0x", id="empty_after_prefix"),
+        pytest.param("0x" + "aa" * 2049, id="above_upper_bound"),
+    ],
+)
+def test_signed_requests_rejects_bad_signature_format(
+    handler_context: Any,
+    http_dialogue: Any,
+    monkeypatch: Any,
+    bad_signature: str,
+) -> None:
+    """A malformed / missing-prefix / oversized signature is rejected 400 at ingress.
+
+    The settlement path does an unconditional ``bytes.fromhex(sig[2:])``
+    when it packs the on-chain payload; a body sent without the
+    mandatory ``0x`` would have its first hex byte silently truncated
+    there, the marketplace would revert with
+    ``IncorrectSignatureLength``, and the whole per-sender batch would
+    be dropped. Validating the format at ingress catches every bad
+    variant before enqueue.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param bad_signature: the malformed signature under test.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(request_id="8100")
+    body["signature"] = bad_signature
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_signed_requests_accepts_prefixed_signature(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A canonical ``0x`` + 65-byte hex signature clears the ingress format guard.
+
+    Regression guard so the ``SIGNATURE_RE`` bounds don't over-reject
+    real client payloads. The stubbed verifier is enough — this test
+    is aimed at the ingress format check, not the sig verifier itself.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(request_id="8101")
+    body["signature"] = "0x" + "ab" * 65
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dedup vs 402 / 500 retry: only accepted state blocks a re-post
+# ---------------------------------------------------------------------------
+
+
+def test_402_then_deposit_then_identical_retry_enqueues(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """After a 402, an identical retry re-runs the balance check and enqueues.
+
+    The 402 branch persists the challenge in
+    ``offchain_request_responses`` so the polling endpoint can surface
+    it. Dedup must not treat a stored rejection as "already accepted":
+    the caller's mech-client ``auto_deposit`` path deposits the
+    shortfall and re-posts the identical body, and this second POST
+    must re-run the balance check (now sufficient) and enqueue the
+    task. A dedup that blocked the retry would produce
+    ``deposit-but-no-work`` — the requester's balance would be debited
+    on chain later without the mech ever executing.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _install_verify_ok(mh, monkeypatch)
+
+    # The balance check returns "insufficient" on the first call and
+    # "sufficient" on every subsequent call — simulating a deposit
+    # landing between the two POSTs.
+    balance_calls: List[int] = []
+
+    def _flip_after_first_call(sender: str, delivery_rate: int) -> Dict[str, Any]:
+        balance_calls.append(delivery_rate)
+        if len(balance_calls) == 1:
+            available = int(delivery_rate) - 1
+        else:
+            available = int(delivery_rate) + 1
+        return {
+            hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+            hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
+            hmod.ResponseKey.AVAILABLE_AMOUNT.value: available,
+            hmod.ResponseKey.REASON.value: "ok",
+            hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+            hmod.ResponseKey.PAYMENT_TYPE.value: "0xpaymenttype",
+            hmod.ResponseKey.CHAIN_ID.value: 100,
+        }
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _flip_after_first_call)
+
+    request_id = "8200"
+    first = _send_signed_request(mh, http_dialogue, request_id=request_id)
+    assert first.status_code == HttpCode.PAYMENT_REQUIRED_CODE.value
+    assert (
+        handler_context.shared_state["offchain_request_responses"]
+        .get(request_id, {})
+        .get("status")
+        == hmod.ResponseStatus.REJECTED.value
+    )
+    assert handler_context.shared_state["pending_tasks"] == []
+
+    # Identical retry (mech-client's ``auto_deposit`` path re-posts the
+    # same body). Must not short-circuit into "already accepted".
+    second = _send_signed_request(mh, http_dialogue, request_id=request_id)
+    assert second.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(second.body.decode("utf-8"))
+    assert payload.get("reason") != hmod.REQUEST_ALREADY_ACCEPTED, payload
+    assert len(balance_calls) == 2, "balance check must run again on retry"
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_500_then_identical_retry_enqueues(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A prior 500 internal error does not block an identical retry.
+
+    ``_send_internal_error`` persists a REJECTED payload keyed by
+    ``request_id`` so the polling endpoint can surface the outcome.
+    The dedup helper must not treat that stored rejection as accepted;
+    the caller retries the identical body and the accept path must
+    run through balance-check and enqueue on the second POST.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _install_verify_ok(mh, monkeypatch)
+
+    # Pre-seed a REJECTED payload as if a prior 500 (or record-response
+    # rejection) had landed. The dedup helper must NOT treat this as
+    # accepted state.
+    request_id = "8210"
+    handler_context.shared_state["offchain_request_responses"][request_id] = {
+        "request_id": request_id,
+        "status": hmod.ResponseStatus.REJECTED.value,
+        "reason": "internal error",
+    }
+
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: {
+            hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+            hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
+            hmod.ResponseKey.AVAILABLE_AMOUNT.value: int(delivery_rate) + 10,
+            hmod.ResponseKey.REASON.value: "ok",
+            hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+            hmod.ResponseKey.PAYMENT_TYPE.value: "0xpaymenttype",
+            hmod.ResponseKey.CHAIN_ID.value: 100,
+        },
+    )
+
+    resp = _send_signed_request(mh, http_dialogue, request_id=request_id)
+    assert resp.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload.get("reason") != hmod.REQUEST_ALREADY_ACCEPTED, payload
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+    # Post-enqueue, the stale REJECTED payload was cleared.
+    assert request_id not in handler_context.shared_state["offchain_request_responses"]
+
+
+def test_dedup_still_blocks_delivered_state(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A non-REJECTED entry in the response cache still blocks re-enqueue.
+
+    Pins the other side of the dedup contract: an OK/delivered payload
+    from a prior successful settlement must still short-circuit into
+    the ``already accepted`` reply so the mech does not re-execute
+    (and settle) work that has already been paid for and delivered.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    request_id = "8220"
+    handler_context.shared_state["offchain_request_responses"][request_id] = {
+        "status": hmod.ResponseStatus.OK.value,
+        "request_id": request_id,
+    }
+    resp = _send_signed_request(mh, http_dialogue, request_id=request_id)
+    assert resp.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["reason"] == hmod.REQUEST_ALREADY_ACCEPTED
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Sig verifier verdict routing: infra failures 503, bad-caller failures 401
+# ---------------------------------------------------------------------------
+
+
+def test_infra_verdict_from_verify_routes_to_503(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A ``SignatureVerdict(is_infra=True)`` from the verifier surfaces as 503.
+
+    Server-side prerequisites (boot constants unset, ledger settings
+    missing, address preparation failure) sit outside the caller's
+    control, so the handler routes them to 503 ("try again later")
+    instead of 401 so a well-behaved client backs off instead of
+    treating the failure as a credential issue. Bad-caller outcomes
+    (recovery mismatch, malformed hex) stay 401.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    monkeypatch.setattr(
+        mh,
+        "_verify_offchain_request_signature",
+        lambda **_kw: hmod.SignatureVerdict(
+            ok=False,
+            reason="marketplace verification constants unavailable",
+            is_infra=True,
+        ),
+    )
+
+    body = _make_signed_request_body(request_id="8300")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["reason"] == "marketplace verification constants unavailable"
+    # No pre-auth persistence on 503 either.
+    assert "8300" not in handler_context.shared_state["offchain_request_responses"]
+
+
+def test_bad_sig_verdict_from_verify_stays_401(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A bad-caller verdict (``is_infra=False``) keeps the 401 status."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    monkeypatch.setattr(
+        mh,
+        "_verify_offchain_request_signature",
+        lambda **_kw: hmod.SignatureVerdict(
+            ok=False,
+            reason="signature verification failed",
+            is_infra=False,
+        ),
+    )
+    body = _make_signed_request_body(request_id="8301")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+
+
+# ---------------------------------------------------------------------------
+# Golden CID pair — end-to-end pin so the derivation stays in sync with
+# ipfs's real output as encoded by ``local_cid.compute_cidv1``.
+# ---------------------------------------------------------------------------
+
+
+def test_signed_requests_accepts_body_at_golden_cid_pair(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A hardcoded golden (data, digest) pair from the CID fixtures accepts.
+
+    The default ``_ipfs_hash_for`` helper derives the expected digest
+    from the same two functions the handler uses (``_to_multihash`` and
+    ``_compute_cidv1``), so it can only prove the two are internally
+    consistent. This test drives the accept path with a pair generated
+    from the real ``ipfs add --cid-version=1 --raw-leaves=false`` output
+    (see ``tests/utils/test_local_cid.py::_FIXTURES``) so a derivation
+    change that breaks parity with go-ipfs fails here loudly instead of
+    silently producing CIDs the on-chain commitment side no longer
+    accepts.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    # Content + expected CIDv1 — the ``small_json`` fixture from
+    # ``tests/utils/test_local_cid.py::_FIXTURES``. The go-ipfs
+    # output is a multibase base32 CID string; the wire ``ipfs_hash``
+    # is the 32-byte SHA-256 digest of the DAG-PB block, which is
+    # what ``to_multihash(compute_cidv1(...))`` produces.
+    golden_data = '{"requestId":"42","result":"ok"}'
+    golden_digest = "0x" + _to_multihash(_compute_cidv1(golden_data.encode("utf-8")))
+    # Confirm the golden derivation matches the corresponding go-ipfs
+    # CIDv1 fixture; this catches any drift between the pair used
+    # here and the real-ipfs fixture in ``test_local_cid.py``.
+    from packages.valory.skills.task_execution.utils.local_cid import (
+        compute_cidv1 as _lc_compute,
+    )
+
+    assert (
+        _lc_compute(golden_data.encode("utf-8"))
+        == "bafybeihjg4w34tu2zmlriemthl24wdynhfx2rpsiflv7wxmb4lsk34etlu"
+    ), "golden pair drifted vs the real-ipfs fixture; update in lock-step"
+
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+    body = _make_signed_request_body(
+        request_id="8400",
+        ipfs_data=golden_data,
+        ipfs_hash=golden_digest,
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp: SimpleNamespace = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(handler_context.shared_state["pending_tasks"]) == 1

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -2417,6 +2417,7 @@ def test_handler_replies_500_when_402_build_fails(
 # ---------------------------------------------------------------------------
 
 
+import requests as _requests_for_sigverify  # noqa: E402
 from eth_account import Account as _Account  # noqa: E402
 from eth_utils import to_checksum_address as _to_checksum  # noqa: E402
 from packages.valory.skills.task_execution.utils.request_id import (  # noqa: E402
@@ -2475,6 +2476,19 @@ def _seed_verification_constants(
             hmod.ResponseKey.RPC_ADDRESS.value: "http://127.0.0.1:1",
             hmod.ResponseKey.CHAIN_ID.value: 100,
         },
+    )
+    # Stub the on-chain ``mapNonces`` read on ``MechMarketplaceContract``
+    # so the sig-verify nonce-binding step does not attempt a real RPC
+    # against the placeholder endpoint stamped above. Returning 0 keeps
+    # the default scenario nonces (``0..16``) inside the accept window
+    # so happy-path tests still exercise the accept branch; tests that
+    # want a different on-chain value re-monkeypatch this attribute.
+    monkeypatch.setattr(
+        hmod.MechMarketplaceContract,
+        "get_nonce",
+        classmethod(
+            lambda cls, ledger_api, contract_address, sender_address: {"data": 0}
+        ),
     )
 
 
@@ -2886,6 +2900,529 @@ def test_verify_offchain_signature_rejects_503_when_constants_unloaded(
     # landed in the shared response cache — a 503 does not persist
     # a rejection payload any more than a 401 does.
     assert "1" not in handler_context.shared_state["offchain_request_responses"]
+
+
+# ---------------------------------------------------------------------------
+# Nonce binding to on-chain ``MechMarketplace.mapNonces[sender]`` and
+# EIP-1271 call safety limits (short timeout + gas cap + cached
+# ``EthereumApi``).
+# ---------------------------------------------------------------------------
+
+
+def _install_nonce_stub(monkeypatch: Any, on_chain_nonce: int) -> List[Dict[str, Any]]:
+    """Stub ``MechMarketplaceContract.get_nonce`` to return a fixed value.
+
+    Records the call args on a list so tests can assert on which sender
+    address the on-chain read was made against. Overrides the default
+    permissive stub installed by ``_seed_verification_constants``.
+
+    :param monkeypatch: the pytest ``monkeypatch`` fixture.
+    :param on_chain_nonce: the value returned as the on-chain
+        ``mapNonces[sender]`` counter.
+    :return: the shared list that captures per-call kwargs.
+    """
+    calls: List[Dict[str, Any]] = []
+
+    def _stub(
+        cls: Any, ledger_api: Any, contract_address: Any, sender_address: Any
+    ) -> Dict[str, int]:
+        calls.append(
+            {
+                "contract_address": contract_address,
+                "sender_address": sender_address,
+            }
+        )
+        return {"data": on_chain_nonce}
+
+    monkeypatch.setattr(hmod.MechMarketplaceContract, "get_nonce", classmethod(_stub))
+    return calls
+
+
+def _make_safe_eip1271_scenario(nonce: int) -> Dict[str, Any]:
+    """Build a Safe-shaped sig-verify scenario at a caller-chosen nonce.
+
+    The signature is signed with an arbitrary key that does NOT recover
+    to the Safe address so the ecrecover branch misses and the accept
+    path falls through to the EIP-1271 fallback. Test-side patches
+    control whether ``check_eip1271_signature`` returns True and
+    whether the on-chain ``mapNonces`` read matches.
+
+    :param nonce: the wire nonce embedded in the request body.
+    :return: dict with the fields the ``_sig_body`` helper needs.
+    """
+    safe_sender = _to_checksum("0x" + "77" * 20)
+    ipfs_hash = _DEFAULT_IPFS_HASH
+    request_data = bytes.fromhex(ipfs_hash[2:])
+    delivery_rate = 42
+    request_id_bytes = _compute_request_id(
+        marketplace=_SIGVERIFY_MARKETPLACE,
+        mech=_SIGVERIFY_MECH,
+        requester=safe_sender,
+        request_data=request_data,
+        delivery_rate=delivery_rate,
+        payment_type=_SIGVERIFY_PAYMENT_TYPE,
+        nonce=nonce,
+        domain_separator=_SIGVERIFY_DOMAIN_SEPARATOR,
+    )
+    arbitrary_sig = (
+        _Account.from_key("0x" + "33" * 32).unsafe_sign_hash(request_id_bytes).signature
+    )
+    return {
+        "sender": safe_sender,
+        "request_id": str(int.from_bytes(request_id_bytes, "big")),
+        "ipfs_hash": ipfs_hash,
+        "delivery_rate": delivery_rate,
+        "nonce": nonce,
+        "signature_hex": "0x" + arbitrary_sig.hex(),
+    }
+
+
+def _ok_balance_check(
+    delivery_rate: int = 42,
+) -> Dict[str, Any]:
+    """Return a balance-check ``ok`` response covering ``delivery_rate + 1``."""
+    return {
+        hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+        hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
+        hmod.ResponseKey.AVAILABLE_AMOUNT.value: int(delivery_rate) + 1,
+        hmod.ResponseKey.REASON.value: "ok",
+        hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+        hmod.ResponseKey.PAYMENT_TYPE.value: "0xpaymenttype",
+        hmod.ResponseKey.CHAIN_ID.value: 100,
+    }
+
+
+def test_verify_offchain_signature_accepts_when_wire_nonce_matches_on_chain(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Wire nonce equal to ``mapNonces[sender]`` accepts and enqueues.
+
+    Pins the exact-match lower boundary of the accepted nonce window.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=5)
+    nonce_calls = _install_nonce_stub(monkeypatch, on_chain_nonce=5)
+    monkeypatch.setattr(
+        mh, "_check_offchain_requester_balance", lambda **_kw: _ok_balance_check()
+    )
+    # Avoid the balance-check kwargs mismatch — the handler passes
+    # ``sender=`` and ``delivery_rate=`` positionally on some callers.
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(nonce_calls) == 1
+    assert nonce_calls[0]["sender_address"] == scenario["sender"]
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_verify_offchain_signature_accepts_when_wire_nonce_at_upper_window_edge(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Wire nonce at ``on_chain + MAX_OUTSTANDING_NONCE_WINDOW`` accepts.
+
+    Pins the exact-match upper boundary of the accepted window (15
+    over the on-chain value when the window is 16 — the on-chain
+    value 1 plus the window 15 equals the tested wire value 16).
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    on_chain = 1
+    wire = on_chain + hmod.MAX_OUTSTANDING_NONCE_WINDOW - 1
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=wire)
+    nonce_calls = _install_nonce_stub(monkeypatch, on_chain_nonce=on_chain)
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(nonce_calls) == 1
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_verify_offchain_signature_rejects_401_when_wire_nonce_below_on_chain(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Wire nonce below ``mapNonces[sender]`` rejects 401 before balance check."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=2)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=5)
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        # Delegate to the real path so the response is emitted normally.
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    _real_send_rejection = mh._send_rejection_response
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert stored["reason"] == hmod.NONCE_BELOW_CHAIN
+    assert balance_calls == [], "balance check must not run when nonce is stale"
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_verify_offchain_signature_rejects_401_when_wire_nonce_above_window(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Wire nonce more than ``MAX_OUTSTANDING_NONCE_WINDOW`` above on-chain rejects 401."""
+    on_chain = 4
+    wire = on_chain + hmod.MAX_OUTSTANDING_NONCE_WINDOW + 1
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=wire)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=on_chain)
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+    _real_send_rejection = mh._send_rejection_response
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert stored["reason"] == hmod.NONCE_ABOVE_WINDOW
+    assert balance_calls == []
+
+
+def test_verify_offchain_signature_returns_503_when_mapnonces_read_fails(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A transport failure on the ``mapNonces`` read returns 503, not 401.
+
+    Failing closed at the nonce read (rather than accepting) keeps a
+    request that settlement would later reject from enqueuing work the
+    operator pays to execute. A ``requests`` transport error is used
+    here because that is what a real RPC endpoint failure surfaces as.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=3)
+
+    def _boom(
+        cls: Any, ledger_api: Any, contract_address: Any, sender_address: Any
+    ) -> Dict[str, int]:
+        raise _requests_for_sigverify.exceptions.ConnectionError("rpc down")
+
+    monkeypatch.setattr(hmod.MechMarketplaceContract, "get_nonce", classmethod(_boom))
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+    _real_send_rejection = mh._send_rejection_response
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.NONCE_READ_FAILED
+    assert balance_calls == []
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_verify_offchain_signature_rejects_401_on_eip1271_timeout(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A transport timeout on the EIP-1271 call surfaces as 401 with the timeout reason.
+
+    Well-behaved Safes reply to ``isValidSignature`` in milliseconds; a
+    view that exceeds the provider-level HTTP timeout is more likely
+    hostile than transient, so returning 401 (instead of 503) prevents
+    infinite operator-paid retries. The nonce read after the sig
+    branch must NOT run in this case — the verdict has already
+    rejected, so no on-chain read is issued.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_safe_eip1271_scenario(nonce=3)
+    nonce_calls = _install_nonce_stub(monkeypatch, on_chain_nonce=3)
+
+    def _timeout(**_kw: Any) -> bool:
+        raise TimeoutError("isValidSignature slow")
+
+    monkeypatch.setattr(hmod, "check_eip1271_signature", _timeout)
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+    _real_send_rejection = mh._send_rejection_response
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert stored["reason"] == hmod.EIP1271_CALL_TIMEOUT
+    assert balance_calls == []
+    assert nonce_calls == [], "nonce read must not run when sig verify rejects"
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_get_ledger_api_caches_instance_per_rpc_and_chain_and_timeout(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """Repeated ``_get_ledger_api`` calls with the same key return the same instance.
+
+    The cache eliminates per-request ``RotatingHTTPProvider`` and
+    connection pool construction on the accept path. Different timeout
+    values are separately keyed so the short-timeout instance used for
+    the EIP-1271 view does not overwrite the ledger-default instance
+    used for balance checks.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+
+    construction_count = {"n": 0}
+    real_ctor = hmod.EthereumApi
+
+    def _counting_ctor(**kwargs: Any) -> Any:
+        construction_count["n"] += 1
+        return real_ctor(**kwargs)
+
+    monkeypatch.setattr(hmod, "EthereumApi", _counting_ctor)
+
+    # Same key, 100 accesses — one construction.
+    first = mh._get_ledger_api("http://127.0.0.1:1", 100)
+    for _ in range(99):
+        assert mh._get_ledger_api("http://127.0.0.1:1", 100) is first
+    assert construction_count["n"] == 1
+
+    # Different chain_id — new construction.
+    second = mh._get_ledger_api("http://127.0.0.1:1", 137)
+    assert second is not first
+    assert construction_count["n"] == 2
+
+    # Same rpc + chain but a short timeout — separate cache slot.
+    short = mh._get_ledger_api("http://127.0.0.1:1", 100, timeout_seconds=3.0)
+    assert short is not first
+    assert construction_count["n"] == 3
+    # Repeated short-timeout access — no extra construction.
+    assert mh._get_ledger_api("http://127.0.0.1:1", 100, timeout_seconds=3.0) is short
+    assert construction_count["n"] == 3
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -5317,6 +5317,91 @@ def test_enqueue_writes_checksum_key_release_matches_lowercase_wire(
     }
 
 
+def test_orphaned_accepted_entry_evicts_pending_task_and_writes_rejection(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Accepted entry below on-chain nonce is evicted with a rejection payload.
+
+    When the same sender fires an on-chain ``request()`` while an
+    off-chain task is still in ``pending_tasks``, ``mapNonces`` jumps
+    past the off-chain slot. The next off-chain accept from any
+    sender reconciles the accepted map: the orphaned entry is
+    dropped, its pending task is removed from ``pending_tasks`` and
+    ``in_memory_requests``, and a definitive rejection lands in
+    ``offchain_request_responses`` so the polling client sees a
+    terminal result instead of polling forever.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    sender = _make_eoa_scenario(nonce=0)["sender"]
+    orphaned_request_id = "9001"
+    orphaned_task = {
+        hmod.RequestKey.REQUEST_ID_CAMEL.value: int(orphaned_request_id),
+        hmod.RequestKey.IS_OFFCHAIN.value: True,
+        "sender": sender,
+        "nonce": 0,
+    }
+    handler_context.shared_state[hmod.PENDING_TASKS] = [orphaned_task]
+    handler_context.shared_state.setdefault(hmod.IN_MEMORY_REQUESTS, {})[
+        orphaned_request_id
+    ] = "orphaned-payload"
+    handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] = {sender: {0}}
+
+    # On-chain mapNonces has advanced past slot 0 (concurrent
+    # on-chain request from the same sender consumed the slot).
+    _install_nonce_stub(monkeypatch, on_chain_nonce=1)
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+    scenario = _make_eoa_scenario(nonce=1)
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    mh._handle_signed_requests(cast(HttpMessage, make_http_msg(body)), http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+
+    # Orphaned nonce 0 evicted; the freshly-accepted nonce 1 remains.
+    assert handler_context.shared_state[hmod.ACCEPTED_NONCES_BY_SENDER] == {sender: {1}}
+
+    # Orphaned pending task removed; only the freshly-accepted one
+    # remains (the new nonce=1 request).
+    pending_ids = [
+        t[hmod.RequestKey.REQUEST_ID_CAMEL.value]
+        for t in handler_context.shared_state[hmod.PENDING_TASKS]
+    ]
+    assert int(orphaned_request_id) not in pending_ids
+
+    # In-memory payload dropped for the orphaned request.
+    assert (
+        orphaned_request_id not in handler_context.shared_state[hmod.IN_MEMORY_REQUESTS]
+    )
+
+    # Rejection payload written so the polling client sees a
+    # definitive result.
+    rejections = handler_context.shared_state[hmod.OFFCHAIN_REQUEST_RESPONSES]
+    assert orphaned_request_id in rejections
+    assert (
+        rejections[orphaned_request_id][hmod.ResponseKey.STATUS.value]
+        == hmod.ResponseStatus.REJECTED.value
+    )
+
+
 def test_settling_pruned_when_on_chain_advances(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -419,6 +419,7 @@ def test_signed_requests_balance_scenarios(
         },
     )
     mh.setup()
+    _install_verify_ok(mh, monkeypatch)
 
     ipfs_hash: str = "0x" + "ab" * 32
     body: Dict[str, str] = {
@@ -427,6 +428,8 @@ def test_signed_requests_balance_scenarios(
         "ipfs_data": '{"foo":"bar"}',
         "delivery_rate": "123",
         "sender": "0x0000000000000000000000000000000000000001",
+        "signature": "0x" + "00" * 65,
+        "nonce": "0",
     }
     http_msg: Any = make_http_msg(body)
     mh._handle_signed_requests(http_msg, http_dialogue)
@@ -616,6 +619,7 @@ def test_fetch_offchain_request_info_returns_insufficient_balance_response(
         },
     )
     mh.setup()
+    _install_verify_ok(mh, monkeypatch)
 
     request_id = "1003"
     ipfs_hash: str = "0x" + "ab" * 32
@@ -626,6 +630,8 @@ def test_fetch_offchain_request_info_returns_insufficient_balance_response(
             "ipfs_data": '{"foo":"bar"}',
             "delivery_rate": "123",
             "sender": "0x0000000000000000000000000000000000000001",
+            "signature": "0x" + "00" * 65,
+            "nonce": "0",
         }
     )
     mh._handle_signed_requests(send_msg, http_dialogue)
@@ -663,6 +669,7 @@ def test_signed_requests_rollback_partial_enqueue(
         },
     )
     mh.setup()
+    _install_verify_ok(mh, monkeypatch)
 
     class FailingDict(dict):
         """Dict that raises on assignment to simulate partial buffer write."""
@@ -681,6 +688,8 @@ def test_signed_requests_rollback_partial_enqueue(
         "ipfs_data": '{"foo":"bar"}',
         "delivery_rate": "123",
         "sender": "0x0000000000000000000000000000000000000001",
+        "signature": "0x" + "00" * 65,
+        "nonce": "0",
     }
     http_msg: Any = make_http_msg(body)
     mh._handle_signed_requests(http_msg, http_dialogue)
@@ -717,6 +726,7 @@ def _patched_handler_for_balance(
         },
     )
     mh.setup()
+    _install_verify_ok(mh, monkeypatch)
     return mh
 
 
@@ -731,6 +741,8 @@ def _send_signed_request(
             "ipfs_data": '{"foo":"bar"}',
             "delivery_rate": "123",
             "sender": "0x0000000000000000000000000000000000000001",
+            "signature": "0x" + "00" * 65,
+            "nonce": "0",
         }
     )
     mh._handle_signed_requests(http_msg, http_dialogue)
@@ -1969,18 +1981,47 @@ def _make_signed_request_body(
     delivery_rate: str = "123",
     request_id: str = "req-hardening",
 ) -> Dict[str, str]:
-    """Build a valid signed-request body used by hardening tests."""
+    """Build a valid signed-request body used by hardening tests.
+
+    ``signature`` and ``nonce`` are populated with syntactically-valid
+    placeholders so the ingress parse succeeds; tests that exercise real
+    accept paths install a stub verifier via ``_install_verify_ok`` and
+    tests that exercise sig-verify itself override these fields.
+    """
     return {
         "ipfs_hash": ipfs_hash,
         "request_id": request_id,
         "ipfs_data": '{"foo":"bar"}',
         "delivery_rate": delivery_rate,
         "sender": "0x0000000000000000000000000000000000000001",
+        "signature": "0x" + "00" * 65,
+        "nonce": "0",
     }
 
 
+def _install_verify_ok(mh: Any, monkeypatch: Any) -> None:
+    """Make _verify_offchain_request_signature accept every request.
+
+    Boundary-level stub for tests that focus on downstream behaviour
+    (balance check, 402 flow, receipt header). The sig-verify method
+    itself is exercised by dedicated tests that feed real signatures
+    through the real code path.
+    """
+    monkeypatch.setattr(
+        mh,
+        "_verify_offchain_request_signature",
+        lambda **_kwargs: True,
+    )
+
+
 def _install_balance_ok(mh: Any, monkeypatch: Any) -> None:
-    """Make _check_offchain_requester_balance return an OK, sufficient response."""
+    """Make _check_offchain_requester_balance return an OK, sufficient response.
+
+    Also installs the passing sig-verify stub so downstream tests that
+    only care about the balance path don't 401 at the new accept-time
+    signature gate.
+    """
+    _install_verify_ok(mh, monkeypatch)
     monkeypatch.setattr(
         mh,
         "_check_offchain_requester_balance",
@@ -2301,6 +2342,7 @@ def test_handler_replies_500_when_402_build_fails(
         },
     )
     mh = _http_handler(handler_context, monkeypatch)
+    _install_verify_ok(mh, monkeypatch)
     http_msg: Any = make_http_msg(
         _make_signed_request_body(delivery_rate="1", request_id="500")
     )
@@ -2308,3 +2350,427 @@ def test_handler_replies_500_when_402_build_fails(
 
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.INTERNAL_SERVER_ERROR_CODE.value
+
+
+# ---------------------------------------------------------------------------
+# Offchain signature verification
+# ---------------------------------------------------------------------------
+
+
+from eth_account import Account as _Account  # noqa: E402
+from eth_utils import to_checksum_address as _to_checksum  # noqa: E402
+
+from packages.valory.skills.task_execution.utils.request_id import (  # noqa: E402
+    compute_request_id as _compute_request_id,
+)
+
+_SIGVERIFY_MARKETPLACE = "0xdEaDbeefdEaDbeefdEadbEefdeADBeEfDeAdBeEf"
+_SIGVERIFY_MECH = "0xCAFECAFECAFECAFECAFECAFECAFECAFECAFECAFE"
+_SIGVERIFY_DOMAIN_SEPARATOR = b"\xab" * 32
+_SIGVERIFY_PAYMENT_TYPE = b"\xcd" * 32
+_SIGVERIFY_PRIVATE_KEY = "0x" + "42" * 32
+
+
+def _seed_verification_constants(
+    mh: MechHttpHandler, params: SimpleNamespace, monkeypatch: Any
+) -> None:
+    """Seed the marketplace / mech addresses and boot-time constants used by verify.
+
+    The constants would normally be fetched from chain in ``setup()``; this
+    helper stamps them directly so the sig-verify path can run end-to-end
+    without an RPC. ``_get_ledger_settings`` is also patched to return a
+    non-error value so the ``EthereumApi`` construction path succeeds; the
+    ``ledger_api`` returned is discarded because the verify path only uses
+    its checksum helper.
+    """
+    params.mech_marketplace_address = _SIGVERIFY_MARKETPLACE
+    params.agent_mech_contract_addresses = [_SIGVERIFY_MECH]
+    mh._domain_separator = _SIGVERIFY_DOMAIN_SEPARATOR
+    mh._payment_type = _SIGVERIFY_PAYMENT_TYPE
+    # Bypass the RPC that _verify_offchain_request_signature would otherwise
+    # try to open. Both the balance and verify paths would call this — the
+    # verify path only needs the address prep to succeed. Returning ``ok``
+    # with an unroutable RPC is fine because the tests never let the code
+    # actually make a network call.
+    monkeypatch.setattr(
+        mh,
+        "_get_ledger_settings",
+        lambda: {
+            hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+            hmod.ResponseKey.RPC_ADDRESS.value: "http://127.0.0.1:1",
+            hmod.ResponseKey.CHAIN_ID.value: 100,
+        },
+    )
+
+
+def _sig_body(
+    request_id: str,
+    delivery_rate: int,
+    nonce: int,
+    sender: str,
+    signature_hex: str,
+    ipfs_hash: str = "0x" + "ab" * 32,
+) -> Dict[str, str]:
+    """Build a signed-request body populated for a sig-verify scenario."""
+    return {
+        "ipfs_hash": ipfs_hash,
+        "request_id": request_id,
+        "ipfs_data": '{"foo":"bar"}',
+        "delivery_rate": str(delivery_rate),
+        "sender": sender,
+        "signature": signature_hex,
+        "nonce": str(nonce),
+    }
+
+
+def _make_eoa_scenario(delivery_rate: int = 123, nonce: int = 7) -> Dict[str, Any]:
+    """Sign a request_id derived from the marketplace formula with a fixed EOA key."""
+    account = _Account.from_key(_SIGVERIFY_PRIVATE_KEY)
+    sender = _to_checksum(account.address)
+    ipfs_hash = "0x" + "ab" * 32
+    request_data = bytes.fromhex(ipfs_hash[2:])
+    request_id_bytes = _compute_request_id(
+        marketplace=_SIGVERIFY_MARKETPLACE,
+        mech=_SIGVERIFY_MECH,
+        requester=sender,
+        request_data=request_data,
+        delivery_rate=delivery_rate,
+        payment_type=_SIGVERIFY_PAYMENT_TYPE,
+        nonce=nonce,
+        domain_separator=_SIGVERIFY_DOMAIN_SEPARATOR,
+    )
+    signature = account.unsafe_sign_hash(request_id_bytes).signature
+    return {
+        "sender": sender,
+        "request_id": str(int.from_bytes(request_id_bytes, "big")),
+        "ipfs_hash": ipfs_hash,
+        "delivery_rate": delivery_rate,
+        "nonce": nonce,
+        "signature_hex": "0x" + signature.hex(),
+    }
+
+
+def test_verify_offchain_signature_eoa_valid_accepts_and_enqueues(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A well-formed EOA-signed request is accepted (200) and enqueued."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    balance_calls: List[Dict[str, Any]] = []
+
+    def fake_balance(sender: str, delivery_rate: int) -> Dict[str, Any]:
+        balance_calls.append({"sender": sender, "delivery_rate": delivery_rate})
+        return {
+            hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+            hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
+            hmod.ResponseKey.AVAILABLE_AMOUNT.value: int(delivery_rate) + 1,
+            hmod.ResponseKey.REASON.value: "ok",
+            hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+            hmod.ResponseKey.PAYMENT_TYPE.value: "0xpaymenttype",
+            hmod.ResponseKey.CHAIN_ID.value: 100,
+        }
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", fake_balance)
+
+    scenario = _make_eoa_scenario()
+    http_msg: Any = make_http_msg(
+        _sig_body(
+            request_id=scenario["request_id"],
+            delivery_rate=scenario["delivery_rate"],
+            nonce=scenario["nonce"],
+            sender=scenario["sender"],
+            signature_hex=scenario["signature_hex"],
+            ipfs_hash=scenario["ipfs_hash"],
+        )
+    )
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert len(balance_calls) == 1, "balance check must run after a valid signature"
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_verify_offchain_signature_eoa_invalid_rejects_401_before_balance_check(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A bad EOA signature is rejected 401 before the balance-check RPC runs."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    balance_calls: List[Dict[str, Any]] = []
+
+    def fake_balance(sender: str, delivery_rate: int) -> Dict[str, Any]:
+        balance_calls.append({"sender": sender, "delivery_rate": delivery_rate})
+        return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", fake_balance)
+
+    scenario = _make_eoa_scenario()
+    # Corrupt the signature by flipping the s component; recovery will
+    # succeed to a different address than the declared sender, and the
+    # EIP-1271 fallback will fail (sender has no code).
+    bad_sig = "0x" + "00" * 32 + scenario["signature_hex"][2 + 64 :]
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=bad_sig,
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    # Make the EIP-1271 fallback return False so the outcome is deterministic
+    # (the real fallback would depend on whether the "sender" address has
+    # code on the fake RPC — it doesn't, but we don't want the test to hang
+    # on a network attempt either).
+    monkeypatch.setattr(
+        hmod,
+        "check_eip1271_signature",
+        lambda **_kw: False,
+    )
+
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert balance_calls == [], "balance check must not run when signature fails"
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_verify_offchain_signature_safe_eip1271_true_accepts(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A Safe sender whose isValidSignature returns the magic value is accepted."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    balance_calls: List[Any] = []
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: balance_calls.append(sender)
+        or {
+            hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value,
+            hmod.ResponseKey.REQUIRED_AMOUNT.value: int(delivery_rate),
+            hmod.ResponseKey.AVAILABLE_AMOUNT.value: int(delivery_rate) + 1,
+            hmod.ResponseKey.REASON.value: "ok",
+            hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
+            hmod.ResponseKey.PAYMENT_TYPE.value: "0xpaymenttype",
+            hmod.ResponseKey.CHAIN_ID.value: 100,
+        },
+    )
+
+    # Sender is a Safe (contract) — sign with an arbitrary key that does not
+    # recover to the sender, so the ecrecover branch misses and the code
+    # falls through to the EIP-1271 wrapper.
+    safe_sender = _to_checksum("0x" + "99" * 20)
+    ipfs_hash = "0x" + "ab" * 32
+    request_data = bytes.fromhex(ipfs_hash[2:])
+    delivery_rate = 42
+    nonce = 3
+    request_id_bytes = _compute_request_id(
+        marketplace=_SIGVERIFY_MARKETPLACE,
+        mech=_SIGVERIFY_MECH,
+        requester=safe_sender,
+        request_data=request_data,
+        delivery_rate=delivery_rate,
+        payment_type=_SIGVERIFY_PAYMENT_TYPE,
+        nonce=nonce,
+        domain_separator=_SIGVERIFY_DOMAIN_SEPARATOR,
+    )
+    # An arbitrary EOA signs the hash; recovery will succeed to that EOA's
+    # address, which is NOT ``safe_sender``, forcing the EIP-1271 fallback.
+    arbitrary_sig = (
+        _Account.from_key("0x" + "77" * 32).unsafe_sign_hash(request_id_bytes).signature
+    )
+
+    monkeypatch.setattr(
+        hmod,
+        "check_eip1271_signature",
+        lambda **_kw: True,
+    )
+
+    body = _sig_body(
+        request_id=str(int.from_bytes(request_id_bytes, "big")),
+        delivery_rate=delivery_rate,
+        nonce=nonce,
+        sender=safe_sender,
+        signature_hex="0x" + arbitrary_sig.hex(),
+        ipfs_hash=ipfs_hash,
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.OK_CODE.value
+    assert balance_calls == [safe_sender]
+    assert len(handler_context.shared_state["pending_tasks"]) == 1
+
+
+def test_verify_offchain_signature_safe_eip1271_false_rejects_before_balance_check(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A Safe whose isValidSignature returns False is rejected 401 before balance check."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    balance_calls: List[Any] = []
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: balance_calls.append(sender)
+        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+    )
+
+    safe_sender = _to_checksum("0x" + "aa" * 20)
+    ipfs_hash = "0x" + "ab" * 32
+    request_data = bytes.fromhex(ipfs_hash[2:])
+    delivery_rate = 42
+    nonce = 3
+    request_id_bytes = _compute_request_id(
+        marketplace=_SIGVERIFY_MARKETPLACE,
+        mech=_SIGVERIFY_MECH,
+        requester=safe_sender,
+        request_data=request_data,
+        delivery_rate=delivery_rate,
+        payment_type=_SIGVERIFY_PAYMENT_TYPE,
+        nonce=nonce,
+        domain_separator=_SIGVERIFY_DOMAIN_SEPARATOR,
+    )
+    arbitrary_sig = (
+        _Account.from_key("0x" + "77" * 32).unsafe_sign_hash(request_id_bytes).signature
+    )
+
+    monkeypatch.setattr(
+        hmod,
+        "check_eip1271_signature",
+        lambda **_kw: False,
+    )
+
+    body = _sig_body(
+        request_id=str(int.from_bytes(request_id_bytes, "big")),
+        delivery_rate=delivery_rate,
+        nonce=nonce,
+        sender=safe_sender,
+        signature_hex="0x" + arbitrary_sig.hex(),
+        ipfs_hash=ipfs_hash,
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert balance_calls == [], "balance check must not run when signature fails"
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["signature", "nonce"],
+)
+def test_verify_offchain_signature_missing_field_returns_400(
+    handler_context: Any,
+    http_dialogue: Any,
+    monkeypatch: Any,
+    missing_field: str,
+) -> None:
+    """Missing signature or nonce field is rejected 400 at ingress parsing."""
+    mh = _http_handler(handler_context, monkeypatch)
+    _install_verify_ok(mh, monkeypatch)
+    balance_calls: List[Any] = []
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: balance_calls.append(sender)
+        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+    )
+
+    body = _make_signed_request_body(request_id="1")
+    body.pop(missing_field)
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.BAD_REQUEST_CODE.value
+    assert balance_calls == []
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_verify_offchain_signature_rejects_when_wire_request_id_mismatches_derivation(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A wire request_id that does not match the local derivation fails verification."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    balance_calls: List[Any] = []
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: balance_calls.append(sender)
+        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+    )
+    monkeypatch.setattr(
+        hmod,
+        "check_eip1271_signature",
+        lambda **_kw: False,
+    )
+
+    scenario = _make_eoa_scenario()
+    # Substitute a numerically-valid but wrong request_id; the signature was
+    # produced over the correct one, so the derivation-mismatch branch fires.
+    wrong_request_id = str((int(scenario["request_id"]) + 1) % (2**256))
+    body = _sig_body(
+        request_id=wrong_request_id,
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert balance_calls == []
+
+
+def test_verify_offchain_signature_rejects_when_constants_unloaded(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """If setup could not load the deployment constants, requests are refused."""
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    # Force the unloaded state that a failed setup would leave behind.
+    mh._domain_separator = None
+    mh._payment_type = None
+
+    balance_calls: List[Any] = []
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: balance_calls.append(sender)
+        or {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value},
+    )
+
+    body = _make_signed_request_body(request_id="1")
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+    assert balance_calls == []

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -1987,6 +1987,11 @@ def _make_signed_request_body(
     placeholders so the ingress parse succeeds; tests that exercise real
     accept paths install a stub verifier via ``_install_verify_ok`` and
     tests that exercise sig-verify itself override these fields.
+
+    :param ipfs_hash: 0x-prefixed hex ipfs hash value for the body.
+    :param delivery_rate: decimal delivery rate string for the body.
+    :param request_id: request_id string for the body.
+    :return: a request-body dict with all required fields populated.
     """
     return {
         "ipfs_hash": ipfs_hash,
@@ -2006,6 +2011,9 @@ def _install_verify_ok(mh: Any, monkeypatch: Any) -> None:
     (balance check, 402 flow, receipt header). The sig-verify method
     itself is exercised by dedicated tests that feed real signatures
     through the real code path.
+
+    :param mh: the ``MechHttpHandler`` instance to patch.
+    :param monkeypatch: the pytest ``monkeypatch`` fixture.
     """
     monkeypatch.setattr(
         mh,
@@ -2020,6 +2028,9 @@ def _install_balance_ok(mh: Any, monkeypatch: Any) -> None:
     Also installs the passing sig-verify stub so downstream tests that
     only care about the balance path don't 401 at the new accept-time
     signature gate.
+
+    :param mh: the ``MechHttpHandler`` instance to patch.
+    :param monkeypatch: the pytest ``monkeypatch`` fixture.
     """
     _install_verify_ok(mh, monkeypatch)
     monkeypatch.setattr(
@@ -2382,6 +2393,10 @@ def _seed_verification_constants(
     non-error value so the ``EthereumApi`` construction path succeeds; the
     ``ledger_api`` returned is discarded because the verify path only uses
     its checksum helper.
+
+    :param mh: the ``MechHttpHandler`` instance to patch.
+    :param params: the params ``SimpleNamespace`` used by the handler.
+    :param monkeypatch: the pytest ``monkeypatch`` fixture.
     """
     params.mech_marketplace_address = _SIGVERIFY_MARKETPLACE
     params.agent_mech_contract_addresses = [_SIGVERIFY_MECH]
@@ -2566,9 +2581,7 @@ def test_verify_offchain_signature_safe_eip1271_true_accepts(
             hmod.ResponseKey.CHAIN_ID.value: 100,
         }
 
-    monkeypatch.setattr(
-        mh, "_check_offchain_requester_balance", _spy_balance_check
-    )
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance_check)
 
     # Sender is a Safe (contract) — sign with an arbitrary key that does not
     # recover to the sender, so the ecrecover branch misses and the code
@@ -2632,9 +2645,7 @@ def test_verify_offchain_signature_safe_eip1271_false_rejects_before_balance_che
         balance_calls.append(sender)
         return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
 
-    monkeypatch.setattr(
-        mh, "_check_offchain_requester_balance", _spy_balance_check
-    )
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance_check)
 
     safe_sender = _to_checksum("0x" + "aa" * 20)
     ipfs_hash = "0x" + "ab" * 32
@@ -2697,9 +2708,7 @@ def test_verify_offchain_signature_missing_field_returns_400(
         balance_calls.append(sender)
         return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
 
-    monkeypatch.setattr(
-        mh, "_check_offchain_requester_balance", _spy_balance_check
-    )
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance_check)
 
     body = _make_signed_request_body(request_id="1")
     body.pop(missing_field)
@@ -2727,9 +2736,7 @@ def test_verify_offchain_signature_rejects_when_wire_request_id_mismatches_deriv
         balance_calls.append(sender)
         return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
 
-    monkeypatch.setattr(
-        mh, "_check_offchain_requester_balance", _spy_balance_check
-    )
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance_check)
     monkeypatch.setattr(
         hmod,
         "check_eip1271_signature",
@@ -2773,9 +2780,7 @@ def test_verify_offchain_signature_rejects_when_constants_unloaded(
         balance_calls.append(sender)
         return {hmod.ResponseKey.STATUS.value: hmod.ResponseStatus.OK.value}
 
-    monkeypatch.setattr(
-        mh, "_check_offchain_requester_balance", _spy_balance_check
-    )
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance_check)
 
     body = _make_signed_request_body(request_id="1")
     http_msg: Any = make_http_msg(body)

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -23,7 +23,7 @@ import json
 import time
 import urllib.parse
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -2055,6 +2055,12 @@ def _install_verify_ok(mh: Any, monkeypatch: Any) -> None:
     the ``bool`` → verdict refactor) so callers can branch on
     ``is_infra`` to distinguish 401 vs 503.
 
+    Also stubs the admission-gate call (``_bind_wire_nonce_to_chain``)
+    and the checksum resolver (``_resolve_sender_checksum``) so
+    downstream tests that only care about the balance / 402 / receipt
+    branches don't need to also stand up a ``MechMarketplaceContract``
+    stub — the admission gate is exercised by its own dedicated tests.
+
     :param mh: the ``MechHttpHandler`` instance to patch.
     :param monkeypatch: the pytest ``monkeypatch`` fixture.
     """
@@ -2062,6 +2068,16 @@ def _install_verify_ok(mh: Any, monkeypatch: Any) -> None:
         mh,
         "_verify_offchain_request_signature",
         lambda **_kwargs: hmod.SignatureVerdict(ok=True, reason="", is_infra=False),
+    )
+    monkeypatch.setattr(
+        mh,
+        "_bind_wire_nonce_to_chain",
+        lambda **_kwargs: hmod.SignatureVerdict(ok=True, reason="", is_infra=False),
+    )
+    monkeypatch.setattr(
+        mh,
+        "_resolve_sender_checksum",
+        lambda sender: str(sender),
     )
 
 
@@ -2420,6 +2436,7 @@ def test_handler_replies_500_when_402_build_fails(
 import requests as _requests_for_sigverify  # noqa: E402
 from eth_account import Account as _Account  # noqa: E402
 from eth_utils import to_checksum_address as _to_checksum  # noqa: E402
+
 from packages.valory.skills.task_execution.utils.request_id import (  # noqa: E402
     compute_request_id as _compute_request_id,
 )
@@ -2527,8 +2544,22 @@ def _sig_body(
     }
 
 
-def _make_eoa_scenario(delivery_rate: int = 123, nonce: int = 7) -> Dict[str, Any]:
-    """Sign a request_id derived from the marketplace formula with a fixed EOA key."""
+def _make_eoa_scenario(delivery_rate: int = 123, nonce: int = 0) -> Dict[str, Any]:
+    """Sign a request_id derived from the marketplace formula with a fixed EOA key.
+
+    ``nonce=0`` matches the default ``get_nonce`` stub installed by
+    ``_seed_verification_constants`` combined with an empty
+    outstanding-nonces set on a fresh handler, so happy-path callers
+    hit the admission gate's ``wire == expected`` accept branch
+    without an extra monkeypatch.
+
+    :param delivery_rate: the requester-signed delivery rate embedded
+        in the derived request id.
+    :param nonce: the wire nonce embedded in the derived request id.
+    :return: dict with the fields the ``_sig_body`` helper needs
+        (sender / request_id / ipfs_hash / delivery_rate / nonce /
+        signature_hex).
+    """
     account = _Account.from_key(_SIGVERIFY_PRIVATE_KEY)
     sender = _to_checksum(account.address)
     # The signature commits to ``keccak(ipfs_hash)``; the CID-binding
@@ -2686,6 +2717,7 @@ def test_verify_offchain_signature_safe_eip1271_true_accepts(
     request_data = bytes.fromhex(ipfs_hash[2:])
     delivery_rate = 42
     nonce = 3
+    _install_nonce_stub(monkeypatch, on_chain_nonce=nonce)
     request_id_bytes = _compute_request_id(
         marketplace=_SIGVERIFY_MARKETPLACE,
         mech=_SIGVERIFY_MECH,
@@ -3039,29 +3071,192 @@ def test_verify_offchain_signature_accepts_when_wire_nonce_matches_on_chain(
     assert len(handler_context.shared_state["pending_tasks"]) == 1
 
 
-def test_verify_offchain_signature_accepts_when_wire_nonce_at_upper_window_edge(
+def test_verify_offchain_signature_rejects_first_request_when_wire_nonce_above_chain(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
-    """Wire nonce at ``on_chain + MAX_OUTSTANDING_NONCE_WINDOW`` accepts.
+    """First request from a sender: wire=on_chain+1 rejects 503, not accept.
 
-    Pins the exact-match upper boundary of the accepted window (15
-    over the on-chain value when the window is 16 — the on-chain
-    value 1 plus the window 15 equals the tested wire value 16).
+    With no outstanding requests from the sender, the admission gate's
+    expected slot is exactly the on-chain ``mapNonces`` value. A wire
+    value one above that skips a slot — settlement would derive a
+    different ``request_id`` for it and revert the whole per-sender
+    batch. Reject 503 so the client can retry once its earlier
+    requests drain (empty in this scenario, so the retry sees the
+    same expected slot and lands on the accept branch).
 
     :param handler_context: pytest fixture, mech HTTP handler test context.
     :param http_dialogue: pytest fixture, HTTP dialogue stub.
     :param monkeypatch: pytest fixture, per-test monkeypatch helper.
     """
-    on_chain = 1
-    wire = on_chain + hmod.MAX_OUTSTANDING_NONCE_WINDOW - 1
-
     mh = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
     mh.setup()
     _seed_verification_constants(mh, handler_context.params, monkeypatch)
 
-    scenario = _make_eoa_scenario(nonce=wire)
-    nonce_calls = _install_nonce_stub(monkeypatch, on_chain_nonce=on_chain)
+    scenario = _make_eoa_scenario(nonce=1)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=0)
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+    _real_send_rejection = mh._send_rejection_response
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.NONCE_ABOVE_EXPECTED
+    assert balance_calls == []
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_verify_offchain_signature_admission_gate_after_two_outstanding_accepts(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Two outstanding at ``k, k+1``: next accept requires ``k+2``.
+
+    Seeds the sender's outstanding-nonce set at ``{0, 1}`` (as if two
+    earlier requests were already accepted) and asserts that a third
+    accept with wire ``nonce=2`` is admitted, while wire ``nonce=3``
+    is rejected 503 (skips a slot) and wire ``nonce=1`` is rejected
+    401 (duplicate of an outstanding slot).
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    _install_nonce_stub(monkeypatch, on_chain_nonce=0)
+    monkeypatch.setattr(
+        mh,
+        "_check_offchain_requester_balance",
+        lambda sender, delivery_rate: _ok_balance_check(delivery_rate),
+    )
+
+    # Preload the sender's outstanding-nonce set with the two nonces
+    # a pair of prior accepts would have recorded. The scenario helper
+    # deterministically returns the same sender across calls, so the
+    # key here matches what ``_bind_wire_nonce_to_chain`` will look up.
+    sender_checksum = _make_eoa_scenario(nonce=0)["sender"]
+    handler_context.shared_state[hmod.OUTSTANDING_NONCES_BY_SENDER] = {
+        sender_checksum: {0, 1},
+    }
+
+    # Third accept at the expected next slot (k+2): admitted.
+    scenario_accept = _make_eoa_scenario(nonce=2)
+    body = _sig_body(
+        request_id=scenario_accept["request_id"],
+        delivery_rate=scenario_accept["delivery_rate"],
+        nonce=scenario_accept["nonce"],
+        sender=scenario_accept["sender"],
+        signature_hex=scenario_accept["signature_hex"],
+        ipfs_hash=scenario_accept["ipfs_hash"],
+    )
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+    accept_resp = handler_context.outbox.sent[-1]
+    assert accept_resp.status_code == HttpCode.OK_CODE.value
+    assert (
+        2
+        in handler_context.shared_state[hmod.OUTSTANDING_NONCES_BY_SENDER][
+            sender_checksum
+        ]
+    )
+
+    # Fourth accept skipping a slot (k+3 when k+2 is now expected): 503.
+    scenario_ahead = _make_eoa_scenario(nonce=4)
+    body_ahead = _sig_body(
+        request_id=scenario_ahead["request_id"],
+        delivery_rate=scenario_ahead["delivery_rate"],
+        nonce=scenario_ahead["nonce"],
+        sender=scenario_ahead["sender"],
+        signature_hex=scenario_ahead["signature_hex"],
+        ipfs_hash=scenario_ahead["ipfs_hash"],
+    )
+    http_msg_ahead: Any = make_http_msg(body_ahead)
+    mh._handle_signed_requests(http_msg_ahead, http_dialogue)
+    ahead_resp = handler_context.outbox.sent[-1]
+    assert ahead_resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+
+    # Fifth accept duplicating an outstanding slot (k+1): 401.
+    scenario_dup = _make_eoa_scenario(nonce=1)
+    body_dup = _sig_body(
+        request_id=scenario_dup["request_id"],
+        delivery_rate=scenario_dup["delivery_rate"],
+        nonce=scenario_dup["nonce"],
+        sender=scenario_dup["sender"],
+        signature_hex=scenario_dup["signature_hex"],
+        ipfs_hash=scenario_dup["ipfs_hash"],
+    )
+    http_msg_dup: Any = make_http_msg(body_dup)
+    mh._handle_signed_requests(http_msg_dup, http_dialogue)
+    dup_resp = handler_context.outbox.sent[-1]
+    assert dup_resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
+
+
+def test_accept_records_sender_nonce_in_outstanding_set(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """A successful accept records the wire nonce under the sender's checksum.
+
+    Pins the accept-side half of the outstanding-nonces lifecycle so a
+    regression that stops populating the set would still admit the
+    first accept but silently regress the ``next expected == on_chain
+    + len(outstanding)`` semantics on the second.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=0)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=0)
     monkeypatch.setattr(
         mh,
         "_check_offchain_requester_balance",
@@ -3081,8 +3276,8 @@ def test_verify_offchain_signature_accepts_when_wire_nonce_at_upper_window_edge(
 
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.OK_CODE.value
-    assert len(nonce_calls) == 1
-    assert len(handler_context.shared_state["pending_tasks"]) == 1
+    outstanding = handler_context.shared_state[hmod.OUTSTANDING_NONCES_BY_SENDER]
+    assert outstanding == {scenario["sender"]: {0}}
 
 
 def test_verify_offchain_signature_rejects_401_when_wire_nonce_below_on_chain(
@@ -3145,17 +3340,30 @@ def test_verify_offchain_signature_rejects_401_when_wire_nonce_below_on_chain(
 
     resp = handler_context.outbox.sent[-1]
     assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
-    assert stored["reason"] == hmod.NONCE_BELOW_CHAIN
+    assert stored["reason"] == hmod.NONCE_BELOW_EXPECTED
     assert balance_calls == [], "balance check must not run when nonce is stale"
     assert handler_context.shared_state["pending_tasks"] == []
 
 
-def test_verify_offchain_signature_rejects_401_when_wire_nonce_above_window(
+def test_verify_offchain_signature_rejects_503_when_wire_nonce_above_expected(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
-    """Wire nonce more than ``MAX_OUTSTANDING_NONCE_WINDOW`` above on-chain rejects 401."""
+    """Wire nonce above the sender's next expected slot rejects 503.
+
+    The sender is racing ahead of its own in-flight queue; mech-client
+    retries 503 in the next round so the earlier requests get a chance
+    to drain and the same body settles when the slot opens. 401 would
+    be wrong — the client would treat the credential as permanently
+    invalid and stop retrying.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
     on_chain = 4
-    wire = on_chain + hmod.MAX_OUTSTANDING_NONCE_WINDOW + 1
+    # No outstanding, so expected next slot equals ``on_chain``. Any
+    # wire above that skips a slot.
+    wire = on_chain + 5
 
     mh = MechHttpHandler(name="http", skill_context=handler_context)
     monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
@@ -3211,8 +3419,8 @@ def test_verify_offchain_signature_rejects_401_when_wire_nonce_above_window(
     mh._handle_signed_requests(http_msg, http_dialogue)
 
     resp = handler_context.outbox.sent[-1]
-    assert resp.status_code == HttpCode.UNAUTHORIZED_CODE.value
-    assert stored["reason"] == hmod.NONCE_ABOVE_WINDOW
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.NONCE_ABOVE_EXPECTED
     assert balance_calls == []
 
 
@@ -3296,17 +3504,20 @@ def test_verify_offchain_signature_returns_503_when_mapnonces_read_fails(
     assert handler_context.shared_state["pending_tasks"] == []
 
 
-def test_verify_offchain_signature_rejects_401_on_eip1271_timeout(
+def test_verify_offchain_signature_rejects_503_on_eip1271_timeout(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
-    """A transport timeout on the EIP-1271 call surfaces as 401 with the timeout reason.
+    """A transport timeout on the EIP-1271 call surfaces as 503 with the timeout reason.
 
-    Well-behaved Safes reply to ``isValidSignature`` in milliseconds; a
-    view that exceeds the provider-level HTTP timeout is more likely
-    hostile than transient, so returning 401 (instead of 503) prevents
-    infinite operator-paid retries. The nonce read after the sig
-    branch must NOT run in this case — the verdict has already
-    rejected, so no on-chain read is issued.
+    Provider-side slowness is an infrastructure signal, not a
+    credential rejection: the ``gas`` cap bounds a hostile
+    ``isValidSignature`` view to sub-millisecond CPU on the RPC side
+    (that path surfaces as ``ContractLogicError`` and flattens to
+    ``False`` on the other branch), so a timeout at this depth
+    mirrors ``NONCE_READ_FAILED`` — an ``is_infra=True`` verdict that
+    routes to 503 so a well-behaved client backs off and retries. The
+    nonce read after the sig branch must NOT run when sig-verify
+    rejects, so no on-chain ``mapNonces`` call is issued.
 
     :param handler_context: pytest fixture, mech HTTP handler test context.
     :param http_dialogue: pytest fixture, HTTP dialogue stub.
@@ -3376,6 +3587,199 @@ def test_verify_offchain_signature_rejects_401_on_eip1271_timeout(
     assert balance_calls == []
     assert nonce_calls == [], "nonce read must not run when sig verify rejects"
     assert handler_context.shared_state["pending_tasks"] == []
+
+
+def test_verify_offchain_signature_wall_clock_deadline_bounds_eip1271_call(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The wall-clock deadline caps the EIP-1271 call independently of provider timeout.
+
+    Replaces ``check_eip1271_signature`` with a stub that sleeps well
+    past the wall-clock deadline. The stub would otherwise pin the
+    handler thread for its full sleep — long enough for the
+    http_server to time out the client at its own 5s reply budget,
+    and long enough to stall ABCI processing on the AEA main loop.
+    Assert the handler returns a 503 within a small epsilon of the
+    deadline (not after the sleep), with the ``EIP1271_CALL_TIMEOUT``
+    reason so operators can attribute the outcome.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    import time as _time
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_safe_eip1271_scenario(nonce=3)
+    _install_nonce_stub(monkeypatch, on_chain_nonce=3)
+
+    # Reduce the deadline to keep the test fast while still exercising
+    # the deadline branch. The sleep length is 5x the deadline so the
+    # test would visibly hang if the deadline were not enforced.
+    test_deadline = 0.2
+    monkeypatch.setattr(hmod, "_RPC_WALL_CLOCK_DEADLINE_SECONDS", test_deadline)
+
+    def _slow_eip1271(**_kw: Any) -> bool:
+        _time.sleep(test_deadline * 5)
+        return True
+
+    monkeypatch.setattr(hmod, "check_eip1271_signature", _slow_eip1271)
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+    _real_send_rejection = mh._send_rejection_response
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    started_at = _time.monotonic()
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+    elapsed = _time.monotonic() - started_at
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.EIP1271_CALL_TIMEOUT
+    # Deadline enforcement — the handler must return within deadline +
+    # a small epsilon for scheduling / test overhead, NOT after the
+    # 5x-deadline sleep the stub would otherwise impose.
+    assert elapsed < test_deadline + 2.0, (
+        f"handler returned in {elapsed:.3f}s but wall-clock deadline is "
+        f"{test_deadline}s; regression would let a slow isValidSignature "
+        f"pin the AEA main loop past the http_server reply budget"
+    )
+    assert balance_calls == []
+
+
+def test_bind_wire_nonce_to_chain_wall_clock_deadline_bounds_mapnonces_read(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """The wall-clock deadline caps the ``mapNonces`` read the same way.
+
+    Same shape as the EIP-1271 test above but on the nonce-bind path.
+    Asserts the admission gate returns 503 with ``NONCE_READ_FAILED``
+    within the deadline when the underlying read hangs.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    import time as _time
+
+    mh = MechHttpHandler(name="http", skill_context=handler_context)
+    monkeypatch.setattr(mh, "start_prometheus_server", MagicMock())
+    mh.setup()
+    _seed_verification_constants(mh, handler_context.params, monkeypatch)
+
+    scenario = _make_eoa_scenario(nonce=0)
+    test_deadline = 0.2
+    monkeypatch.setattr(hmod, "_RPC_WALL_CLOCK_DEADLINE_SECONDS", test_deadline)
+
+    def _slow_get_nonce(
+        cls: Any, ledger_api: Any, contract_address: Any, sender_address: Any
+    ) -> Dict[str, int]:
+        _time.sleep(test_deadline * 5)
+        return {"data": 0}
+
+    monkeypatch.setattr(
+        hmod.MechMarketplaceContract, "get_nonce", classmethod(_slow_get_nonce)
+    )
+
+    balance_calls: List[Any] = []
+
+    def _spy_balance(sender: Any, delivery_rate: Any) -> Dict[str, Any]:
+        balance_calls.append(sender)
+        return _ok_balance_check(delivery_rate)
+
+    monkeypatch.setattr(mh, "_check_offchain_requester_balance", _spy_balance)
+
+    stored: Dict[str, Any] = {}
+    _real_send_rejection = mh._send_rejection_response
+
+    def _capture_rejection(
+        _http_msg: Any,
+        _http_dialogue: Any,
+        request_id: str,
+        reason: str,
+        status_code: int,
+        status_text: str,
+        **_kwargs: Any,
+    ) -> None:
+        stored["reason"] = reason
+        stored["status_code"] = status_code
+        _real_send_rejection(
+            _http_msg,
+            _http_dialogue,
+            request_id,
+            reason=reason,
+            status_code=status_code,
+            status_text=status_text,
+            **_kwargs,
+        )
+
+    monkeypatch.setattr(mh, "_send_rejection_response", _capture_rejection)
+
+    body = _sig_body(
+        request_id=scenario["request_id"],
+        delivery_rate=scenario["delivery_rate"],
+        nonce=scenario["nonce"],
+        sender=scenario["sender"],
+        signature_hex=scenario["signature_hex"],
+        ipfs_hash=scenario["ipfs_hash"],
+    )
+    started_at = _time.monotonic()
+    http_msg: Any = make_http_msg(body)
+    mh._handle_signed_requests(http_msg, http_dialogue)
+    elapsed = _time.monotonic() - started_at
+
+    resp = handler_context.outbox.sent[-1]
+    assert resp.status_code == HttpCode.SERVICE_UNAVAILABLE_CODE.value
+    assert stored["reason"] == hmod.NONCE_READ_FAILED
+    assert elapsed < test_deadline + 2.0, (
+        f"handler returned in {elapsed:.3f}s but wall-clock deadline is "
+        f"{test_deadline}s; regression would let a slow mapNonces read "
+        f"pin the AEA main loop past the http_server reply budget"
+    )
+    assert balance_calls == []
 
 
 def test_get_ledger_api_caches_instance_per_rpc_and_chain_and_timeout(
@@ -3773,6 +4177,58 @@ def test_signed_requests_distinct_ids_both_enqueue(
     assert len(handler_context.shared_state["pending_tasks"]) == 2
 
 
+def test_signed_requests_retry_after_delivery_returns_200_even_when_nonce_stale(
+    handler_context: Any, http_dialogue: Any, monkeypatch: Any
+) -> None:
+    """Dedup runs BEFORE the nonce-bind admission gate.
+
+    A client re-posting an already-delivered request has by then
+    watched the on-chain ``mapNonces`` counter advance past the value
+    it originally signed. If the admission gate ran before dedup, the
+    retry would 401 (``NONCE_BELOW_EXPECTED``) instead of the
+    idempotent 200 (``REQUEST_ALREADY_ACCEPTED``) mech-client's own
+    retry loop depends on. Seed the response cache as if a delivery
+    settled, install a nonce stub that would refuse the request as
+    stale, and assert the retry still returns 200 with the
+    ``REQUEST_ALREADY_ACCEPTED`` reason.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param http_dialogue: pytest fixture, HTTP dialogue stub.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    mh: MechHttpHandler = _patched_handler_for_balance(
+        handler_context, monkeypatch, available_offset=10
+    )
+
+    # Force the admission gate to reject if it runs: on_chain far past
+    # the wire nonce (``0`` from ``_send_signed_request``) would land
+    # the request on ``NONCE_BELOW_EXPECTED`` (401). Dedup running
+    # first is the only way the response is a 200.
+    #
+    # ``_install_verify_ok`` inside ``_patched_handler_for_balance``
+    # has already installed a passing admission stub; override it here
+    # so the gate would 401 IF the ordering regressed.
+    def _reject_nonce(**_kw: Any) -> hmod.SignatureVerdict:
+        return hmod.SignatureVerdict(
+            ok=False,
+            reason=hmod.NONCE_BELOW_EXPECTED,
+            is_infra=False,
+        )
+
+    monkeypatch.setattr(mh, "_bind_wire_nonce_to_chain", _reject_nonce)
+    handler_context.shared_state["offchain_request_responses"]["7085"] = {
+        "status": "ok",
+        "request_id": "7085",
+    }
+
+    resp = _send_signed_request(mh, http_dialogue, request_id="7085")
+
+    assert resp.status_code == HttpCode.OK_CODE.value
+    payload = json.loads(resp.body.decode("utf-8"))
+    assert payload["reason"] == hmod.REQUEST_ALREADY_ACCEPTED
+    assert handler_context.shared_state["pending_tasks"] == []
+
+
 def test_signed_requests_dedup_covers_delivered_state(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
@@ -4136,16 +4592,18 @@ def test_cid_binding_bare_digest_starting_with_1220_accepted() -> None:
     class _MinimalHandler:
         context = _FakeContext()
 
-        _verify_ipfs_hash_binding = MechHttpHandler._verify_ipfs_hash_binding
-
     dummy = _MinimalHandler()
     ipfs_data = '{"payload":"whatever"}'
     # Force ``to_multihash(compute_cidv1(...))`` to return the same
     # bare-digest hex the caller posted. The prefix-strip must NOT
     # touch the 64-char form; if it does, only 60 hex chars survive
     # for the compare and this test fails.
+    # Call the unbound method with an explicit ``cast`` to satisfy the
+    # ``self`` type; the method only touches ``self.context.logger`` and
+    # arithmetic on the arguments, so a duck-typed stub passes at runtime.
     with patch.object(_h, "to_multihash", return_value=bare_digest):
-        ok, reason = dummy._verify_ipfs_hash_binding(
+        ok, reason = MechHttpHandler._verify_ipfs_hash_binding(
+            cast(MechHttpHandler, dummy),
             request_id="rid",
             ipfs_hash="0x" + bare_digest,
             ipfs_data=ipfs_data,
@@ -4170,11 +4628,13 @@ def test_cid_binding_multihash_prefix_stripped_only_from_68_char_form() -> None:
     class _MinimalHandler:
         context = _FakeContext()
 
-        _verify_ipfs_hash_binding = MechHttpHandler._verify_ipfs_hash_binding
-
     dummy = _MinimalHandler()
+    # Call the unbound method with an explicit ``cast`` to satisfy the
+    # ``self`` type; see the sibling ``_bare_digest`` test above for the
+    # duck-typed-stub rationale.
     with patch.object(_h, "to_multihash", return_value=bare_digest):
-        ok, reason = dummy._verify_ipfs_hash_binding(
+        ok, reason = MechHttpHandler._verify_ipfs_hash_binding(
+            cast(MechHttpHandler, dummy),
             request_id="rid",
             ipfs_hash="0x" + multihash_form,
             ipfs_data='{"any":"data"}',

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -120,17 +120,37 @@ def test_check_eip1271_signature_returns_declined_on_non_magic_value(
     assert result is Eip1271Verdict.DECLINED
 
 
-def test_check_eip1271_signature_returns_declined_on_revert() -> None:
-    """A revert maps to DECLINED (the contract said no).
+@pytest.mark.parametrize(
+    "raised",
+    [
+        pytest.param(
+            ContractLogicError("execution reverted"), id="contract_logic_error"
+        ),
+        pytest.param(
+            BadFunctionCallOutput(
+                "Could not transact with/call contract function, "
+                "is contract deployed correctly and chain synced?"
+            ),
+            id="bad_function_call_output_missing_code",
+        ),
+    ],
+)
+def test_check_eip1271_signature_returns_declined_on_credential_side_failure(
+    raised: BaseException,
+) -> None:
+    """A revert or codeless target maps to DECLINED (the contract said no).
 
     ``ContractLogicError`` fires on an explicit ``revert`` (including
-    the out-of-gas revert triggered by the gas cap). The caller
-    routes ``DECLINED`` to 401 so the client learns its signature
-    was not accepted.
+    the out-of-gas revert triggered by the gas cap).
+    ``BadFunctionCallOutput`` with the missing-code message shape
+    fires when the ``eth_call`` target has no code at all — a plain
+    EOA whose ``ecrecover`` did not match on the primary path. Both
+    are credential-side outcomes; the caller routes ``DECLINED`` to
+    401 so the client learns its signature was not accepted.
+
+    :param raised: the boundary exception injected by the parametrise.
     """
-    ledger_api = _make_ledger_api(
-        "isValidSignature", ContractLogicError("execution reverted")
-    )
+    ledger_api = _make_ledger_api("isValidSignature", raised)
 
     result = check_eip1271_signature(
         ledger_api=ledger_api,
@@ -155,8 +175,11 @@ def test_check_eip1271_signature_returns_declined_on_revert() -> None:
         ),
         pytest.param(ValueError("abi decode failure"), id="value_error"),
         pytest.param(
-            BadFunctionCallOutput("Could not decode contract function call"),
-            id="bad_function_call_output_from_pruned_node",
+            BadFunctionCallOutput(
+                "Could not decode contract function call to isValidSignature "
+                "with return data: b'', output_types: ['bytes4']"
+            ),
+            id="bad_function_call_output_decode_failure_from_pruned_node",
         ),
         pytest.param(
             requests.exceptions.ConnectionError("boom"), id="connection_error"

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -31,13 +31,17 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from web3.exceptions import ContractLogicError
+import requests
+from web3.exceptions import (
+    BadFunctionCallOutput,
+    ContractLogicError,
+    Web3RPCError,
+)
 
 from packages.valory.skills.task_execution.utils.eip1271 import (
     EIP1271_MAGIC_VALUE,
     check_eip1271_signature,
     get_marketplace_domain_separator,
-    get_mech_payment_type,
 )
 
 _CONTRACT_ADDRESS = "0x1111111111111111111111111111111111111111"
@@ -109,16 +113,31 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
         pytest.param(
             ContractLogicError("execution reverted"), id="contract_logic_error"
         ),
+        pytest.param(
+            BadFunctionCallOutput("decode failure"), id="bad_function_call_output"
+        ),
+        pytest.param(Web3RPCError("rpc error"), id="web3_rpc_error"),
         pytest.param(ValueError("abi decode failure"), id="value_error"),
+        pytest.param(
+            requests.exceptions.ConnectionError("boom"), id="connection_error"
+        ),
+        pytest.param(requests.exceptions.ReadTimeout("slow"), id="read_timeout"),
+        pytest.param(requests.exceptions.HTTPError("bad status"), id="http_error"),
     ],
 )
-def test_check_eip1271_signature_returns_false_on_revert(
+def test_check_eip1271_signature_returns_false_on_boundary_exception(
     raised: BaseException,
 ) -> None:
-    """A revert or ABI-decode failure at the ledger boundary maps to False.
+    """Any recognised failure at the ledger boundary maps to False.
 
-    Any exception at the call boundary means the sender either reverted or
-    does not implement EIP-1271; both mean the signature is not accepted.
+    Web3 raises ``BadFunctionCallOutput`` when ``eth_call`` targets a
+    codeless address (the common case for a Safe pointed at the wrong
+    proxy) and ``Web3RPCError`` on JSON-RPC failures; ``requests``
+    transport failures (connection error, read timeout, HTTP error)
+    surface as siblings under ``RequestException``. All must map to
+    False so the accept path's fallback treats the outcome as a
+    signature rejection instead of crashing the framework's default
+    ``propagate`` handler and stopping the agent.
 
     :param raised: the boundary exception injected by the parametrise.
     """
@@ -159,27 +178,7 @@ def test_get_marketplace_domain_separator_rejects_wrong_length() -> None:
         )
 
 
-# --- get_mech_payment_type ---------------------------------------------------
-
-
-def test_get_mech_payment_type_returns_bytes32() -> None:
-    """Return the 32-byte mech payment type."""
-    expected = b"\xcd" * 32
-    ledger_api = _make_ledger_api("paymentType", expected)
-
-    result = get_mech_payment_type(
-        ledger_api=ledger_api,
-        mech_address=_CONTRACT_ADDRESS,
-    )
-    assert result == expected
-
-
-def test_get_mech_payment_type_rejects_wrong_length() -> None:
-    """A ``paymentType`` return that is not 32 bytes raises."""
-    ledger_api = _make_ledger_api("paymentType", b"\x00" * 30)
-
-    with pytest.raises(ValueError, match="payment_type length"):
-        get_mech_payment_type(
-            ledger_api=ledger_api,
-            mech_address=_CONTRACT_ADDRESS,
-        )
+# ``get_mech_payment_type`` was removed in favour of the packaged
+# ``OlasMechContract.get_mech_type`` wrapper; both call the same
+# ``paymentType()`` selector and the wrapper carries its own tests
+# alongside the contract package.

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -42,6 +42,7 @@ from web3.exceptions import (
 
 from packages.valory.skills.task_execution.utils.eip1271 import (
     EIP1271_MAGIC_VALUE,
+    Eip1271Verdict,
     check_eip1271_signature,
     get_marketplace_domain_separator,
 )
@@ -81,8 +82,8 @@ def _make_ledger_api(fn_name: str, call_return: Any) -> SimpleNamespace:
 # --- check_eip1271_signature -------------------------------------------------
 
 
-def test_check_eip1271_signature_returns_true_on_magic_value() -> None:
-    """Return True when the contract returns the EIP-1271 magic value."""
+def test_check_eip1271_signature_returns_valid_on_magic_value() -> None:
+    """Return VALID when the contract returns the EIP-1271 magic value."""
     ledger_api = _make_ledger_api("isValidSignature", EIP1271_MAGIC_VALUE)
 
     result = check_eip1271_signature(
@@ -92,7 +93,7 @@ def test_check_eip1271_signature_returns_true_on_magic_value() -> None:
         signature=_SIGNATURE,
         gas=_TEST_GAS_CAP,
     )
-    assert result is True
+    assert result is Eip1271Verdict.VALID
 
 
 @pytest.mark.parametrize(
@@ -103,10 +104,10 @@ def test_check_eip1271_signature_returns_true_on_magic_value() -> None:
         pytest.param(b"\xde\xad\xbe\xef", id="unrelated_bytes4"),
     ],
 )
-def test_check_eip1271_signature_returns_false_on_non_magic_value(
+def test_check_eip1271_signature_returns_declined_on_non_magic_value(
     returned: bytes,
 ) -> None:
-    """Return False when the contract returns any bytes4 other than the magic value."""
+    """Return DECLINED when the contract returns any bytes4 other than the magic value."""
     ledger_api = _make_ledger_api("isValidSignature", returned)
 
     result = check_eip1271_signature(
@@ -116,7 +117,7 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
         signature=_SIGNATURE,
         gas=_TEST_GAS_CAP,
     )
-    assert result is False
+    assert result is Eip1271Verdict.DECLINED
 
 
 @pytest.mark.parametrize(
@@ -128,6 +129,38 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
         pytest.param(
             BadFunctionCallOutput("decode failure"), id="bad_function_call_output"
         ),
+    ],
+)
+def test_check_eip1271_signature_returns_declined_on_credential_side_failure(
+    raised: BaseException,
+) -> None:
+    """A revert or codeless target maps to DECLINED (the contract said no).
+
+    Both branches are semantically "the sender's contract does not
+    accept this signature": ``ContractLogicError`` fires on an explicit
+    ``revert`` (including the out-of-gas revert triggered by the gas
+    cap) and ``BadFunctionCallOutput`` fires on a codeless target
+    (the common case for a Safe pointed at the wrong proxy). The
+    caller routes ``DECLINED`` to 401 so the client learns its
+    signature was not accepted.
+
+    :param raised: the boundary exception injected by the parametrise.
+    """
+    ledger_api = _make_ledger_api("isValidSignature", raised)
+
+    result = check_eip1271_signature(
+        ledger_api=ledger_api,
+        contract_address=_CONTRACT_ADDRESS,
+        message_hash=_MESSAGE_HASH,
+        signature=_SIGNATURE,
+        gas=_TEST_GAS_CAP,
+    )
+    assert result is Eip1271Verdict.DECLINED
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
         pytest.param(Web3RPCError("rpc error"), id="web3_rpc_error"),
         pytest.param(
             BadResponseFormat("non-conforming json-rpc envelope"),
@@ -143,26 +176,20 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
         pytest.param(requests.exceptions.HTTPError("bad status"), id="http_error"),
     ],
 )
-def test_check_eip1271_signature_returns_false_on_boundary_exception(
+def test_check_eip1271_signature_returns_call_failed_on_infra_error(
     raised: BaseException,
 ) -> None:
-    """Any recognised non-timeout failure at the ledger boundary maps to False.
+    """Infra-side failures at the ledger boundary map to CALL_FAILED.
 
-    Web3 raises ``BadFunctionCallOutput`` when ``eth_call`` targets a
-    codeless address (the common case for a Safe pointed at the wrong
-    proxy) and ``Web3RPCError`` on JSON-RPC failures; ``requests``
-    transport failures other than a timeout (connection error, HTTP
-    error) surface as siblings under ``RequestException``.
-    ``BadResponseFormat`` and ``Web3ValidationError`` are the two
-    ``Web3Exception`` siblings raised outside the
-    ``RotatingHTTPProvider.make_request`` boundary (in
-    ``web3.manager.formatted_response``), so a narrower ``except``
+    Distinguishing CALL_FAILED from DECLINED is what stops an RPC
+    outage from surfacing to a legitimate Safe requester as 401
+    "unauthorized" — the caller routes CALL_FAILED to 503 (retry)
+    while DECLINED stays 401 (bad signature). ``BadResponseFormat``
+    and ``Web3ValidationError`` are the two ``Web3Exception`` siblings
+    raised outside the ``RotatingHTTPProvider.make_request`` boundary
+    (in ``web3.manager.formatted_response``), so a narrower ``except``
     tuple would let them propagate out through the accept path and
-    crash the framework's default ``propagate`` handler. All must map
-    to False so the accept path's fallback treats the outcome as a
-    signature rejection instead of stopping the agent. Timeouts are
-    covered separately below because the caller distinguishes them
-    from a plain signature rejection.
+    crash the framework's default ``propagate`` handler.
 
     :param raised: the boundary exception injected by the parametrise.
     """
@@ -175,7 +202,45 @@ def test_check_eip1271_signature_returns_false_on_boundary_exception(
         signature=_SIGNATURE,
         gas=_TEST_GAS_CAP,
     )
-    assert result is False
+    assert result is Eip1271Verdict.CALL_FAILED
+
+
+def test_check_eip1271_signature_logger_records_branch_for_operator_triage() -> None:
+    """The optional ``logger`` records the exception type on CALL_FAILED.
+
+    Pins that a caller supplying its own logger sees the exception type
+    in the log line so operator triage on a 503 has the underlying
+    fault visible. Without this, every infra-side branch produced the
+    same "signature verification failed" line and operators had no
+    way to distinguish which of the six causes fired.
+    """
+    import logging
+
+    ledger_api = _make_ledger_api("isValidSignature", Web3RPCError("rpc down"))
+    logger = logging.getLogger("test_check_eip1271_signature_logger_records_branch")
+    captured: list[str] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    handler = _Handler(level=logging.WARNING)
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        result = check_eip1271_signature(
+            ledger_api=ledger_api,
+            contract_address=_CONTRACT_ADDRESS,
+            message_hash=_MESSAGE_HASH,
+            signature=_SIGNATURE,
+            gas=_TEST_GAS_CAP,
+            logger=logger,
+        )
+    finally:
+        logger.removeHandler(handler)
+    assert result is Eip1271Verdict.CALL_FAILED
+    assert any("CALL_FAILED" in msg for msg in captured), captured
+    assert any("Web3RPCError" in msg for msg in captured), captured
 
 
 @pytest.mark.parametrize(

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -119,6 +119,8 @@ def test_check_eip1271_signature_returns_false_on_revert(
 
     Any exception at the call boundary means the sender either reverted or
     does not implement EIP-1271; both mean the signature is not accepted.
+
+    :param raised: the boundary exception injected by the parametrise.
     """
     ledger_api = _make_ledger_api("isValidSignature", raised)
 

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -120,33 +120,17 @@ def test_check_eip1271_signature_returns_declined_on_non_magic_value(
     assert result is Eip1271Verdict.DECLINED
 
 
-@pytest.mark.parametrize(
-    "raised",
-    [
-        pytest.param(
-            ContractLogicError("execution reverted"), id="contract_logic_error"
-        ),
-        pytest.param(
-            BadFunctionCallOutput("decode failure"), id="bad_function_call_output"
-        ),
-    ],
-)
-def test_check_eip1271_signature_returns_declined_on_credential_side_failure(
-    raised: BaseException,
-) -> None:
-    """A revert or codeless target maps to DECLINED (the contract said no).
+def test_check_eip1271_signature_returns_declined_on_revert() -> None:
+    """A revert maps to DECLINED (the contract said no).
 
-    Both branches are semantically "the sender's contract does not
-    accept this signature": ``ContractLogicError`` fires on an explicit
-    ``revert`` (including the out-of-gas revert triggered by the gas
-    cap) and ``BadFunctionCallOutput`` fires on a codeless target
-    (the common case for a Safe pointed at the wrong proxy). The
-    caller routes ``DECLINED`` to 401 so the client learns its
-    signature was not accepted.
-
-    :param raised: the boundary exception injected by the parametrise.
+    ``ContractLogicError`` fires on an explicit ``revert`` (including
+    the out-of-gas revert triggered by the gas cap). The caller
+    routes ``DECLINED`` to 401 so the client learns its signature
+    was not accepted.
     """
-    ledger_api = _make_ledger_api("isValidSignature", raised)
+    ledger_api = _make_ledger_api(
+        "isValidSignature", ContractLogicError("execution reverted")
+    )
 
     result = check_eip1271_signature(
         ledger_api=ledger_api,
@@ -170,6 +154,10 @@ def test_check_eip1271_signature_returns_declined_on_credential_side_failure(
             Web3ValidationError("schema mismatch"), id="web3_validation_error"
         ),
         pytest.param(ValueError("abi decode failure"), id="value_error"),
+        pytest.param(
+            BadFunctionCallOutput("Could not decode contract function call"),
+            id="bad_function_call_output_from_pruned_node",
+        ),
         pytest.param(
             requests.exceptions.ConnectionError("boom"), id="connection_error"
         ),

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the EIP-1271 signature check and marketplace/mech read helpers.
+
+Mocks the ledger boundary — the wrapper's contract is purely about mapping a
+view return to a Python value, so an in-process mock at the eth_contract
+level is the right cut.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from web3.exceptions import ContractLogicError
+
+from packages.valory.skills.task_execution.utils.eip1271 import (
+    EIP1271_MAGIC_VALUE,
+    check_eip1271_signature,
+    get_marketplace_domain_separator,
+    get_mech_payment_type,
+)
+
+_CONTRACT_ADDRESS = "0x1111111111111111111111111111111111111111"
+_MESSAGE_HASH = b"\x22" * 32
+_SIGNATURE = b"\x33" * 65
+
+
+def _make_ledger_api(fn_name: str, call_return: Any) -> SimpleNamespace:
+    """Fake EthereumApi whose named function's ``call`` returns / raises as configured."""
+    call_mock = MagicMock()
+    if isinstance(call_return, BaseException):
+        call_mock.side_effect = call_return
+    else:
+        call_mock.return_value = call_return
+
+    def _fn(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(call=call_mock)
+
+    functions_ns = SimpleNamespace(**{fn_name: _fn})
+    contract_ns = SimpleNamespace(functions=functions_ns)
+
+    inner_eth = SimpleNamespace(contract=MagicMock(return_value=contract_ns))
+    api_ns = SimpleNamespace(eth=inner_eth, to_checksum_address=lambda a: a)
+    return SimpleNamespace(api=api_ns)
+
+
+# --- check_eip1271_signature -------------------------------------------------
+
+
+def test_check_eip1271_signature_returns_true_on_magic_value() -> None:
+    """Return True when the contract returns the EIP-1271 magic value."""
+    ledger_api = _make_ledger_api("isValidSignature", EIP1271_MAGIC_VALUE)
+
+    result = check_eip1271_signature(
+        ledger_api=ledger_api,
+        contract_address=_CONTRACT_ADDRESS,
+        message_hash=_MESSAGE_HASH,
+        signature=_SIGNATURE,
+    )
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "returned",
+    [
+        pytest.param(b"\x00\x00\x00\x00", id="zero_bytes4"),
+        pytest.param(b"\xff\xff\xff\xff", id="all_ones_bytes4"),
+        pytest.param(b"\xde\xad\xbe\xef", id="unrelated_bytes4"),
+    ],
+)
+def test_check_eip1271_signature_returns_false_on_non_magic_value(
+    returned: bytes,
+) -> None:
+    """Return False when the contract returns any bytes4 other than the magic value."""
+    ledger_api = _make_ledger_api("isValidSignature", returned)
+
+    result = check_eip1271_signature(
+        ledger_api=ledger_api,
+        contract_address=_CONTRACT_ADDRESS,
+        message_hash=_MESSAGE_HASH,
+        signature=_SIGNATURE,
+    )
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        pytest.param(
+            ContractLogicError("execution reverted"), id="contract_logic_error"
+        ),
+        pytest.param(ValueError("abi decode failure"), id="value_error"),
+    ],
+)
+def test_check_eip1271_signature_returns_false_on_revert(
+    raised: BaseException,
+) -> None:
+    """A revert or ABI-decode failure at the ledger boundary maps to False.
+
+    Any exception at the call boundary means the sender either reverted or
+    does not implement EIP-1271; both mean the signature is not accepted.
+    """
+    ledger_api = _make_ledger_api("isValidSignature", raised)
+
+    result = check_eip1271_signature(
+        ledger_api=ledger_api,
+        contract_address=_CONTRACT_ADDRESS,
+        message_hash=_MESSAGE_HASH,
+        signature=_SIGNATURE,
+    )
+    assert result is False
+
+
+# --- get_marketplace_domain_separator ---------------------------------------
+
+
+def test_get_marketplace_domain_separator_returns_bytes32() -> None:
+    """Return the 32-byte marketplace domain separator."""
+    expected = b"\xab" * 32
+    ledger_api = _make_ledger_api("getDomainSeparator", expected)
+
+    result = get_marketplace_domain_separator(
+        ledger_api=ledger_api,
+        marketplace_address=_CONTRACT_ADDRESS,
+    )
+    assert result == expected
+
+
+def test_get_marketplace_domain_separator_rejects_wrong_length() -> None:
+    """A ``getDomainSeparator`` return that is not 32 bytes raises."""
+    ledger_api = _make_ledger_api("getDomainSeparator", b"\x00" * 31)
+
+    with pytest.raises(ValueError, match="domain_separator length"):
+        get_marketplace_domain_separator(
+            ledger_api=ledger_api,
+            marketplace_address=_CONTRACT_ADDRESS,
+        )
+
+
+# --- get_mech_payment_type ---------------------------------------------------
+
+
+def test_get_mech_payment_type_returns_bytes32() -> None:
+    """Return the 32-byte mech payment type."""
+    expected = b"\xcd" * 32
+    ledger_api = _make_ledger_api("paymentType", expected)
+
+    result = get_mech_payment_type(
+        ledger_api=ledger_api,
+        mech_address=_CONTRACT_ADDRESS,
+    )
+    assert result == expected
+
+
+def test_get_mech_payment_type_rejects_wrong_length() -> None:
+    """A ``paymentType`` return that is not 32 bytes raises."""
+    ledger_api = _make_ledger_api("paymentType", b"\x00" * 30)
+
+    with pytest.raises(ValueError, match="payment_type length"):
+        get_mech_payment_type(
+            ledger_api=ledger_api,
+            mech_address=_CONTRACT_ADDRESS,
+        )

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -34,8 +34,10 @@ import pytest
 import requests
 from web3.exceptions import (
     BadFunctionCallOutput,
+    BadResponseFormat,
     ContractLogicError,
     Web3RPCError,
+    Web3ValidationError,
 )
 
 from packages.valory.skills.task_execution.utils.eip1271 import (
@@ -127,6 +129,13 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
             BadFunctionCallOutput("decode failure"), id="bad_function_call_output"
         ),
         pytest.param(Web3RPCError("rpc error"), id="web3_rpc_error"),
+        pytest.param(
+            BadResponseFormat("non-conforming json-rpc envelope"),
+            id="bad_response_format",
+        ),
+        pytest.param(
+            Web3ValidationError("schema mismatch"), id="web3_validation_error"
+        ),
         pytest.param(ValueError("abi decode failure"), id="value_error"),
         pytest.param(
             requests.exceptions.ConnectionError("boom"), id="connection_error"
@@ -143,10 +152,15 @@ def test_check_eip1271_signature_returns_false_on_boundary_exception(
     codeless address (the common case for a Safe pointed at the wrong
     proxy) and ``Web3RPCError`` on JSON-RPC failures; ``requests``
     transport failures other than a timeout (connection error, HTTP
-    error) surface as siblings under ``RequestException``. All must
-    map to False so the accept path's fallback treats the outcome as a
-    signature rejection instead of crashing the framework's default
-    ``propagate`` handler and stopping the agent. Timeouts are
+    error) surface as siblings under ``RequestException``.
+    ``BadResponseFormat`` and ``Web3ValidationError`` are the two
+    ``Web3Exception`` siblings raised outside the
+    ``RotatingHTTPProvider.make_request`` boundary (in
+    ``web3.manager.formatted_response``), so a narrower ``except``
+    tuple would let them propagate out through the accept path and
+    crash the framework's default ``propagate`` handler. All must map
+    to False so the accept path's fallback treats the outcome as a
+    signature rejection instead of stopping the agent. Timeouts are
     covered separately below because the caller distinguishes them
     from a plain signature rejection.
 

--- a/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_eip1271.py
@@ -47,10 +47,14 @@ from packages.valory.skills.task_execution.utils.eip1271 import (
 _CONTRACT_ADDRESS = "0x1111111111111111111111111111111111111111"
 _MESSAGE_HASH = b"\x22" * 32
 _SIGNATURE = b"\x33" * 65
+_TEST_GAS_CAP = 500_000
 
 
 def _make_ledger_api(fn_name: str, call_return: Any) -> SimpleNamespace:
-    """Fake EthereumApi whose named function's ``call`` returns / raises as configured."""
+    """Fake EthereumApi whose named function's ``call`` returns / raises as configured."""  # noqa: E501
+    # The returned ``call`` is a real ``MagicMock`` so tests that need
+    # to assert on the transaction kwargs (``gas`` cap) can inspect
+    # ``call_args`` after the exchange.
     call_mock = MagicMock()
     if isinstance(call_return, BaseException):
         call_mock.side_effect = call_return
@@ -65,7 +69,11 @@ def _make_ledger_api(fn_name: str, call_return: Any) -> SimpleNamespace:
 
     inner_eth = SimpleNamespace(contract=MagicMock(return_value=contract_ns))
     api_ns = SimpleNamespace(eth=inner_eth, to_checksum_address=lambda a: a)
-    return SimpleNamespace(api=api_ns)
+    ledger_api = SimpleNamespace(api=api_ns)
+    # Expose the call mock so tests can assert on the kwargs the caller
+    # actually threaded through to ``.call(...)``.
+    ledger_api.call_mock = call_mock  # type: ignore[attr-defined]
+    return ledger_api
 
 
 # --- check_eip1271_signature -------------------------------------------------
@@ -80,6 +88,7 @@ def test_check_eip1271_signature_returns_true_on_magic_value() -> None:
         contract_address=_CONTRACT_ADDRESS,
         message_hash=_MESSAGE_HASH,
         signature=_SIGNATURE,
+        gas=_TEST_GAS_CAP,
     )
     assert result is True
 
@@ -103,6 +112,7 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
         contract_address=_CONTRACT_ADDRESS,
         message_hash=_MESSAGE_HASH,
         signature=_SIGNATURE,
+        gas=_TEST_GAS_CAP,
     )
     assert result is False
 
@@ -121,23 +131,24 @@ def test_check_eip1271_signature_returns_false_on_non_magic_value(
         pytest.param(
             requests.exceptions.ConnectionError("boom"), id="connection_error"
         ),
-        pytest.param(requests.exceptions.ReadTimeout("slow"), id="read_timeout"),
         pytest.param(requests.exceptions.HTTPError("bad status"), id="http_error"),
     ],
 )
 def test_check_eip1271_signature_returns_false_on_boundary_exception(
     raised: BaseException,
 ) -> None:
-    """Any recognised failure at the ledger boundary maps to False.
+    """Any recognised non-timeout failure at the ledger boundary maps to False.
 
     Web3 raises ``BadFunctionCallOutput`` when ``eth_call`` targets a
     codeless address (the common case for a Safe pointed at the wrong
     proxy) and ``Web3RPCError`` on JSON-RPC failures; ``requests``
-    transport failures (connection error, read timeout, HTTP error)
-    surface as siblings under ``RequestException``. All must map to
-    False so the accept path's fallback treats the outcome as a
+    transport failures other than a timeout (connection error, HTTP
+    error) surface as siblings under ``RequestException``. All must
+    map to False so the accept path's fallback treats the outcome as a
     signature rejection instead of crashing the framework's default
-    ``propagate`` handler and stopping the agent.
+    ``propagate`` handler and stopping the agent. Timeouts are
+    covered separately below because the caller distinguishes them
+    from a plain signature rejection.
 
     :param raised: the boundary exception injected by the parametrise.
     """
@@ -148,8 +159,62 @@ def test_check_eip1271_signature_returns_false_on_boundary_exception(
         contract_address=_CONTRACT_ADDRESS,
         message_hash=_MESSAGE_HASH,
         signature=_SIGNATURE,
+        gas=_TEST_GAS_CAP,
     )
     assert result is False
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        pytest.param(requests.exceptions.ReadTimeout("slow"), id="read_timeout"),
+        pytest.param(
+            requests.exceptions.ConnectTimeout("no route"), id="connect_timeout"
+        ),
+    ],
+)
+def test_check_eip1271_signature_raises_timeout_error_on_transport_timeout(
+    raised: BaseException,
+) -> None:
+    """A read/connect timeout propagates as ``TimeoutError`` instead of False.
+
+    The caller distinguishes a slow / hostile ``isValidSignature`` view
+    from a plain signature rejection so operators can surface the
+    former as a dedicated rejection reason.
+
+    :param raised: the timeout exception injected by the parametrise.
+    """
+    ledger_api = _make_ledger_api("isValidSignature", raised)
+
+    with pytest.raises(TimeoutError):
+        check_eip1271_signature(
+            ledger_api=ledger_api,
+            contract_address=_CONTRACT_ADDRESS,
+            message_hash=_MESSAGE_HASH,
+            signature=_SIGNATURE,
+            gas=_TEST_GAS_CAP,
+        )
+
+
+def test_check_eip1271_signature_passes_gas_cap_to_eth_call() -> None:
+    """The provided ``gas`` cap is threaded to the underlying ``.call(...)``.
+
+    Assert on the exact transaction kwargs the wrapper forwards to the
+    web3 contract call so a future refactor that drops or mistypes the
+    kwarg surfaces in the test rather than silently letting a caller's
+    ``isValidSignature`` run to the block gas limit.
+    """
+    ledger_api = _make_ledger_api("isValidSignature", EIP1271_MAGIC_VALUE)
+
+    check_eip1271_signature(
+        ledger_api=ledger_api,
+        contract_address=_CONTRACT_ADDRESS,
+        message_hash=_MESSAGE_HASH,
+        signature=_SIGNATURE,
+        gas=123_456,
+    )
+
+    ledger_api.call_mock.assert_called_once_with({"gas": 123_456})
 
 
 # --- get_marketplace_domain_separator ---------------------------------------

--- a/packages/valory/skills/task_execution/tests/utils/test_request_id.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_request_id.py
@@ -49,6 +49,16 @@ def _reference_request_id(
 
     Written from the marketplace's ``getRequestId`` Solidity source, not
     by copying the helper. If the two diverge the test fails.
+
+    :param marketplace: mech marketplace address.
+    :param mech: mech contract address.
+    :param requester: requester address.
+    :param request_data: raw request data bytes.
+    :param delivery_rate: uint256 delivery rate.
+    :param payment_type: bytes32 payment type identifier.
+    :param nonce: uint256 requester nonce.
+    :param domain_separator: 32-byte EIP-712 domain separator.
+    :return: 32-byte reference request_id.
     """
     inner = abi_encode(
         [

--- a/packages/valory/skills/task_execution/tests/utils/test_request_id.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_request_id.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the marketplace request-id derivation and EOA recovery helpers."""
+
+from __future__ import annotations
+
+import pytest
+from eth_abi import encode as abi_encode
+from eth_account import Account
+from eth_utils import keccak
+
+from packages.valory.skills.task_execution.utils.request_id import (
+    SECP256K1_HALF_ORDER,
+    compute_request_id,
+    recover_eoa_signer,
+)
+
+# --- request-id derivation ---------------------------------------------------
+
+
+def _reference_request_id(
+    marketplace: str,
+    mech: str,
+    requester: str,
+    request_data: bytes,
+    delivery_rate: int,
+    payment_type: bytes,
+    nonce: int,
+    domain_separator: bytes,
+) -> bytes:
+    """Independent reference implementation using ``eth_abi.encode``.
+
+    Written from the marketplace's ``getRequestId`` Solidity source, not
+    by copying the helper. If the two diverge the test fails.
+    """
+    inner = abi_encode(
+        [
+            "address",
+            "address",
+            "address",
+            "bytes32",
+            "uint256",
+            "bytes32",
+            "uint256",
+        ],
+        [
+            marketplace,
+            mech,
+            requester,
+            keccak(request_data),
+            delivery_rate,
+            payment_type,
+            nonce,
+        ],
+    )
+    inner_hash = keccak(inner)
+    outer = b"\x19\x01" + domain_separator + inner_hash
+    return keccak(outer)
+
+
+@pytest.mark.parametrize(
+    "request_data,delivery_rate,payment_type,nonce",
+    [
+        pytest.param(b"", 0, b"\x00" * 32, 0, id="all_zero_edges"),
+        pytest.param(b"foo", 100, b"\xff" * 32, 5, id="small_bytes"),
+        pytest.param(
+            bytes(range(32)),
+            2**200,
+            (42).to_bytes(32, "big"),
+            2**64,
+            id="mid_range_values",
+        ),
+        pytest.param(
+            bytes(range(64)),
+            2**256 - 1,
+            b"\xaa" * 32,
+            2**256 - 1,
+            id="uint256_upper_bound",
+        ),
+    ],
+)
+def test_compute_request_id_matches_abi_reference(
+    request_data: bytes,
+    delivery_rate: int,
+    payment_type: bytes,
+    nonce: int,
+) -> None:
+    """The helper produces the same bytes32 as the independent reference."""
+    marketplace = "0x" + "11" * 20
+    mech = "0x" + "22" * 20
+    requester = "0x" + "33" * 20
+    domain_separator = b"\xab" * 32
+
+    actual = compute_request_id(
+        marketplace=marketplace,
+        mech=mech,
+        requester=requester,
+        request_data=request_data,
+        delivery_rate=delivery_rate,
+        payment_type=payment_type,
+        nonce=nonce,
+        domain_separator=domain_separator,
+    )
+    expected = _reference_request_id(
+        marketplace=marketplace,
+        mech=mech,
+        requester=requester,
+        request_data=request_data,
+        delivery_rate=delivery_rate,
+        payment_type=payment_type,
+        nonce=nonce,
+        domain_separator=domain_separator,
+    )
+    assert actual == expected
+
+
+def test_compute_request_id_rejects_wrong_domain_separator_length() -> None:
+    """A domain separator not exactly 32 bytes is a caller bug and raises."""
+    with pytest.raises(ValueError, match="domain_separator"):
+        compute_request_id(
+            marketplace="0x" + "11" * 20,
+            mech="0x" + "22" * 20,
+            requester="0x" + "33" * 20,
+            request_data=b"foo",
+            delivery_rate=1,
+            payment_type=b"\x00" * 32,
+            nonce=0,
+            domain_separator=b"\x00" * 31,
+        )
+
+
+def test_compute_request_id_rejects_oversized_payment_type() -> None:
+    """A payment type longer than 32 bytes is a caller bug and raises."""
+    with pytest.raises(ValueError, match="payment_type"):
+        compute_request_id(
+            marketplace="0x" + "11" * 20,
+            mech="0x" + "22" * 20,
+            requester="0x" + "33" * 20,
+            request_data=b"foo",
+            delivery_rate=1,
+            payment_type=b"\x00" * 33,
+            nonce=0,
+            domain_separator=b"\x00" * 32,
+        )
+
+
+def test_compute_request_id_rejects_out_of_range_uint256() -> None:
+    """A uint256 field above ``2**256 - 1`` is caller bug and raises."""
+    with pytest.raises(ValueError, match="uint256"):
+        compute_request_id(
+            marketplace="0x" + "11" * 20,
+            mech="0x" + "22" * 20,
+            requester="0x" + "33" * 20,
+            request_data=b"foo",
+            delivery_rate=2**256,
+            payment_type=b"\x00" * 32,
+            nonce=0,
+            domain_separator=b"\x00" * 32,
+        )
+
+
+def test_compute_request_id_short_payment_type_is_right_padded() -> None:
+    """A short payment_type is right-padded to 32 bytes (Solidity bytes32 layout)."""
+    short = b"\xde\xad"
+    padded = short + b"\x00" * 30
+    marketplace = "0x" + "11" * 20
+    mech = "0x" + "22" * 20
+    requester = "0x" + "33" * 20
+    domain_separator = b"\xab" * 32
+    a = compute_request_id(
+        marketplace=marketplace,
+        mech=mech,
+        requester=requester,
+        request_data=b"foo",
+        delivery_rate=1,
+        payment_type=short,
+        nonce=0,
+        domain_separator=domain_separator,
+    )
+    b = compute_request_id(
+        marketplace=marketplace,
+        mech=mech,
+        requester=requester,
+        request_data=b"foo",
+        delivery_rate=1,
+        payment_type=padded,
+        nonce=0,
+        domain_separator=domain_separator,
+    )
+    assert a == b
+
+
+# --- EOA signer recovery -----------------------------------------------------
+
+
+PRIVATE_KEY = "0x" + "01" * 32
+
+
+def _sign_hash(request_id: bytes) -> bytes:
+    """Sign a raw 32-byte hash with the fixed test key. Returns 65 bytes."""
+    account = Account.from_key(PRIVATE_KEY)
+    return account.unsafe_sign_hash(request_id).signature
+
+
+def _test_signer_address() -> str:
+    """Return the checksummed address of the fixed test key."""
+    return Account.from_key(PRIVATE_KEY).address
+
+
+def test_recover_eoa_signer_valid_signature_recovers_signer() -> None:
+    """A signature produced by the private key recovers to its address."""
+    request_id = keccak(b"some request id preimage")
+    signature = _sign_hash(request_id)
+
+    recovered = recover_eoa_signer(request_id, signature)
+    assert recovered == _test_signer_address()
+
+
+def test_recover_eoa_signer_ledger_style_v_is_normalised() -> None:
+    """A v byte of 0 / 1 (Ledger convention) is normalised to 27 / 28."""
+    request_id = keccak(b"ledger style request")
+    signature = _sign_hash(request_id)
+    # Downshift v from 27/28 to 0/1 so the helper's normalise branch fires.
+    v_byte = signature[64]
+    assert v_byte in (27, 28)
+    ledger_sig = signature[:64] + bytes([v_byte - 27])
+
+    recovered = recover_eoa_signer(request_id, ledger_sig)
+    assert recovered == _test_signer_address()
+
+
+def test_recover_eoa_signer_rejects_high_s_malleable_signature() -> None:
+    """A signature with s above secp256k1n/2 is rejected as malleable."""
+    request_id = keccak(b"malleability check")
+    signature = _sign_hash(request_id)
+    # Force s into the upper half of the curve order.
+    high_s = SECP256K1_HALF_ORDER + 1
+    malleable = signature[:32] + high_s.to_bytes(32, "big") + signature[64:]
+
+    assert recover_eoa_signer(request_id, malleable) is None
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        pytest.param(b"", id="empty"),
+        pytest.param(b"\x00" * 64, id="one_byte_short"),
+        pytest.param(b"\x00" * 66, id="one_byte_long"),
+    ],
+)
+def test_recover_eoa_signer_rejects_wrong_signature_length(
+    signature: bytes,
+) -> None:
+    """A signature that is not exactly 65 bytes recovers to ``None``."""
+    request_id = keccak(b"length check")
+    assert recover_eoa_signer(request_id, signature) is None
+
+
+def test_recover_eoa_signer_rejects_wrong_hash_length() -> None:
+    """A hash that is not exactly 32 bytes recovers to ``None``."""
+    signature = _sign_hash(keccak(b"anything"))
+    short_hash = b"\x00" * 31
+    assert recover_eoa_signer(short_hash, signature) is None
+
+
+def test_recover_eoa_signer_rejects_out_of_range_v() -> None:
+    """A v byte outside {0,1,27,28} (after normalisation) recovers to ``None``."""
+    request_id = keccak(b"v range check")
+    signature = _sign_hash(request_id)
+    # v = 29 is not the ledger convention (< 4) and not the canonical (27/28).
+    bad_v = signature[:64] + bytes([29])
+    assert recover_eoa_signer(request_id, bad_v) is None
+
+
+def test_recover_eoa_signer_wrong_signature_recovers_different_address() -> None:
+    """A signature for a different hash recovers to a different address."""
+    signed_hash = keccak(b"actually-signed")
+    signature = _sign_hash(signed_hash)
+    other_hash = keccak(b"different-hash")
+
+    recovered = recover_eoa_signer(other_hash, signature)
+    # Recovery may succeed with a spurious address or fail entirely; either
+    # way it must NOT return the true signer's address.
+    assert recovered != _test_signer_address()

--- a/packages/valory/skills/task_execution/tests/utils/test_request_id.py
+++ b/packages/valory/skills/task_execution/tests/utils/test_request_id.py
@@ -17,7 +17,18 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Tests for the marketplace request-id derivation and EOA recovery helpers."""
+"""Tests for the marketplace request-id derivation and EOA recovery helpers.
+
+``eth_abi.encode`` here is the *independent* reference implementation
+that pins the production ``compute_request_id`` byte-for-byte against
+the marketplace's Solidity ``getRequestId`` layout. Production never
+imports ``eth_abi``, only this test does. ``check-dependencies`` still
+forces the declaration in the skill's ``dependencies:`` because the
+scanner walks the test tree too, so the version pin lives in
+``skill.yaml`` (currently ``eth-abi==6.0.0b1``, the pre-release that
+resolves transitively via the ``web3<8,>=7.15.0`` pin — track upstream
+and switch to ``==6.0.0`` once the stable release ships).
+"""
 
 from __future__ import annotations
 

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -39,7 +39,7 @@ from typing import Any, Dict
 
 from aea_ledger_ethereum import EthereumApi
 from requests.exceptions import RequestException, Timeout
-from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
+from web3.exceptions import Web3Exception
 
 # bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
 # sender must return exactly this value from its ``isValidSignature`` view
@@ -146,22 +146,27 @@ def check_eip1271_signature(
         # signature-rejected outcome that a revert or bad output would
         # produce.
         raise TimeoutError(str(exc)) from exc
-    except (
-        ContractLogicError,
-        BadFunctionCallOutput,
-        Web3RPCError,
-        ValueError,
-        RequestException,
-    ):
-        # Web3 raises ``BadFunctionCallOutput`` when the target address
-        # holds no code and ``Web3RPCError`` when the node returns a
-        # JSON-RPC error; ``requests`` transport failures other than a
-        # timeout (connection error, HTTP error) surface as
-        # ``RequestException``. Any of them means the contract did not
-        # unambiguously return the magic value, so the signature is
-        # not accepted. An out-of-gas revert triggered by the ``gas``
-        # cap above lands here as ``ContractLogicError`` and returns
-        # ``False`` the same way any other revert does.
+    except (Web3Exception, RequestException, ValueError):
+        # Broad web3 + requests + ValueError capture: every
+        # ``Web3Exception`` subclass reaches this branch, not just the
+        # obvious ones (``ContractLogicError`` on revert,
+        # ``BadFunctionCallOutput`` on a codeless target,
+        # ``Web3RPCError`` on a JSON-RPC error). The two subclasses
+        # that a narrower tuple used to miss —
+        # ``BadResponseFormat`` and ``Web3ValidationError`` — are
+        # raised OUTSIDE the ``RotatingHTTPProvider.make_request``
+        # boundary (in ``web3.manager.formatted_response``), so the
+        # rotation layer's own ``except Exception`` never sees them
+        # and they would otherwise propagate out through
+        # ``check_eip1271_signature``, out of the accept path, and
+        # crash the AEA framework's default ``propagate`` handler.
+        # ``RequestException`` covers connection / HTTP / non-timeout
+        # transport failures; ``ValueError`` covers ABI decode
+        # failures the web3 layer surfaces without a
+        # ``BadFunctionCallOutput`` wrap. An out-of-gas revert
+        # triggered by the ``gas`` cap above lands here as
+        # ``ContractLogicError`` (a ``Web3Exception`` subclass) and
+        # returns ``False`` the same way any other revert does.
         return False
     return bytes(returned) == EIP1271_MAGIC_VALUE
 

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -74,6 +74,30 @@ _PAYMENT_TYPE_ABI: Dict[str, Any] = {
 }
 
 
+# Marketplace ``getRequestId`` view. Colocated with the rest of the
+# boot-time verification helpers because the packaged ``MechMarketplace``
+# contract wrapper does not expose it today and this repo carries that
+# wrapper as a third-party package (git-ignored, upstream hash pinned).
+# Extending the wrapper would drift the local file off its upstream hash
+# and fail ``check-third-party-hashes`` on every CI run; keeping the ABI
+# fragment here in the skill's utils module colocates it with the sig
+# verifier that consumes it and keeps the third-party package untouched.
+_GET_REQUEST_ID_ABI: Dict[str, Any] = {
+    "inputs": [
+        {"internalType": "address", "name": "mech", "type": "address"},
+        {"internalType": "address", "name": "requester", "type": "address"},
+        {"internalType": "bytes", "name": "data", "type": "bytes"},
+        {"internalType": "uint256", "name": "deliveryRate", "type": "uint256"},
+        {"internalType": "bytes32", "name": "paymentType", "type": "bytes32"},
+        {"internalType": "uint256", "name": "nonce", "type": "uint256"},
+    ],
+    "name": "getRequestId",
+    "outputs": [{"internalType": "bytes32", "name": "requestId", "type": "bytes32"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+
 def check_eip1271_signature(
     ledger_api: EthereumApi,
     contract_address: str,
@@ -143,4 +167,52 @@ def get_mech_payment_type(ledger_api: EthereumApi, mech_address: str) -> bytes:
     result = bytes(payment_type)
     if len(result) != 32:
         raise ValueError(f"payment_type length is {len(result)}, expected 32")
+    return result
+
+
+def get_marketplace_request_id_view(
+    ledger_api: EthereumApi,
+    marketplace_address: str,
+    mech: str,
+    requester: str,
+    data: bytes,
+    delivery_rate: int,
+    payment_type: bytes,
+    nonce: int,
+) -> bytes:
+    """Call the marketplace ``getRequestId`` view and return its bytes32 output.
+
+    Used at handler boot to cross-check the locally-reimplemented
+    ``compute_request_id`` against the marketplace contract. Any
+    mismatch means the marketplace was upgraded to a layout the local
+    formula does not mirror; the caller flips the boot-cached
+    constants off so subsequent offchain requests are refused rather
+    than being accepted under a mis-derived request id.
+
+    :param ledger_api: the ledger API object.
+    :param marketplace_address: the marketplace contract address.
+    :param mech: the mech contract address.
+    :param requester: the requester address (EOA or Safe).
+    :param data: the raw request-data blob.
+    :param delivery_rate: the delivery rate uint256.
+    :param payment_type: the mech's ``paymentType`` bytes32.
+    :param nonce: the requester nonce uint256.
+    :return: the 32-byte request id returned by the view.
+    :raises ValueError: on ABI decode error or if the return is not 32 bytes.
+    """
+    contract_instance = ledger_api.api.eth.contract(
+        address=ledger_api.api.to_checksum_address(marketplace_address),
+        abi=[_GET_REQUEST_ID_ABI],
+    )
+    request_id = contract_instance.functions.getRequestId(
+        ledger_api.api.to_checksum_address(mech),
+        ledger_api.api.to_checksum_address(requester),
+        data,
+        delivery_rate,
+        payment_type,
+        nonce,
+    ).call()
+    result = bytes(request_id)
+    if len(result) != 32:
+        raise ValueError(f"request_id length is {len(result)}, expected 32")
     return result

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -35,16 +35,43 @@ file; the mech ``paymentType`` is read through the packaged
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import logging
+from enum import Enum
+from typing import Any, Dict, Optional
 
 from aea_ledger_ethereum import EthereumApi
 from requests.exceptions import RequestException, Timeout
-from web3.exceptions import Web3Exception
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
 
 # bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
 # sender must return exactly this value from its ``isValidSignature`` view
 # for the presented signature to be accepted per EIP-1271.
 EIP1271_MAGIC_VALUE: bytes = b"\x16\x26\xba\x7e"
+
+
+class Eip1271Verdict(str, Enum):
+    """Tri-state outcome of an ``isValidSignature`` view call.
+
+    * ``VALID`` — the contract returned the EIP-1271 magic value; the
+      presented signature verifies. Accept.
+    * ``DECLINED`` — the contract returned a different bytes4 value,
+      reverted with :class:`ContractLogicError`, or the target address
+      has no code (``BadFunctionCallOutput``). Semantically "the
+      signature does not verify". The caller should reject with 401.
+    * ``CALL_FAILED`` — infra-side failure: ``Web3RPCError``,
+      ``BadResponseFormat``, ``Web3ValidationError``, ``RequestException``,
+      ``ValueError``, or the wall-clock deadline expired. The caller
+      should reject with 503; the sender's credentials are not at
+      fault, an RPC or transport error is.
+
+    A single ``bool`` return flattened all three of the ``CALL_FAILED``
+    reasons into the same outcome as a genuine ``DECLINED``, so a
+    Safe requester saw 401 "unauthorized" during an RPC outage.
+    """
+
+    VALID = "valid"
+    DECLINED = "declined"
+    CALL_FAILED = "call_failed"
 
 
 _IS_VALID_SIGNATURE_ABI: Dict[str, Any] = {
@@ -98,23 +125,27 @@ def check_eip1271_signature(
     message_hash: bytes,
     signature: bytes,
     gas: int,
-) -> bool:
-    """Return True iff the contract at ``contract_address`` accepts the signature.
+    logger: Optional[logging.Logger] = None,
+) -> Eip1271Verdict:
+    """Verify the contract's ``isValidSignature`` view and return a tri-state.
 
-    Calls the sender contract's ``isValidSignature(bytes32,bytes)`` view; any
-    return value other than the EIP-1271 magic value — including a revert or
-    an ABI-decode failure — is flattened to False so the caller can treat the
-    outcome as a simple boolean.
+    Calls the sender contract's ``isValidSignature(bytes32,bytes)``
+    view. The outcome is one of the three :class:`Eip1271Verdict`
+    values so the caller can route "the RPC failed" separately from
+    "the signature does not verify" — flattening those two to the same
+    boolean surfaced RPC outages as 401 "unauthorized" to well-
+    behaved Safe callers.
 
-    The call carries an explicit ``gas`` cap in the ``eth_call`` transaction
-    payload so a sender contract whose ``isValidSignature`` view loops
-    to the block gas limit is capped at a bounded amount of node work per
-    request; an out-of-gas revert then surfaces as ``ContractLogicError``
-    and flattens to ``False`` like any other revert.
+    The call carries an explicit ``gas`` cap in the ``eth_call``
+    transaction payload so a sender contract whose ``isValidSignature``
+    view loops to the block gas limit is capped at a bounded amount
+    of node work per request; an out-of-gas revert then surfaces as
+    :class:`ContractLogicError` and returns ``DECLINED`` like any
+    other revert.
 
-    Transport-level read timeouts propagate as ``TimeoutError`` so the caller
-    can distinguish a slow / hostile ``isValidSignature`` from a plain
-    signature rejection.
+    Transport-level read timeouts propagate as :class:`TimeoutError`
+    so the caller can distinguish a slow / hostile ``isValidSignature``
+    from either a plain rejection or an RPC infra failure.
 
     :param ledger_api: the ledger API object.
     :param contract_address: the contract sender to query.
@@ -123,8 +154,16 @@ def check_eip1271_signature(
     :param gas: the ``gas`` cap applied to the ``eth_call``. Bounds the
         amount of work a sender's ``isValidSignature`` view can force
         the RPC node to do per request.
-    :return: True on magic-value match; False otherwise (including on
-        revert or out-of-gas).
+    :param logger: optional logger used to record which of the three
+        branches fired (including the exception type on ``DECLINED`` /
+        ``CALL_FAILED``). Kept optional so callers with no logger in
+        scope can still call the helper; recommended for the accept
+        path so operator triage on 503s has the exception type
+        visible.
+    :return: an :class:`Eip1271Verdict`. ``VALID`` on magic-value
+        match; ``DECLINED`` on a non-magic return value, revert, or
+        codeless target; ``CALL_FAILED`` on an infra-side failure
+        (RPC error, transport error, ABI-decode failure).
     :raises TimeoutError: when the underlying HTTP read times out (the
         provider-level ``timeout`` on the ``EthereumApi`` fires). The
         caller distinguishes this from a signature rejection.
@@ -142,33 +181,52 @@ def check_eip1271_signature(
         # ``isValidSignature`` view is slow enough that the provider's
         # transport timeout fires. Re-raise as the built-in
         # ``TimeoutError`` so the caller can return a distinct verdict
-        # (401 with the timeout reason) instead of the generic
+        # (503 with the timeout reason) instead of the generic
         # signature-rejected outcome that a revert or bad output would
         # produce.
         raise TimeoutError(str(exc)) from exc
-    except (Web3Exception, RequestException, ValueError):
-        # Broad web3 + requests + ValueError capture: every
-        # ``Web3Exception`` subclass reaches this branch, not just the
-        # obvious ones (``ContractLogicError`` on revert,
-        # ``BadFunctionCallOutput`` on a codeless target,
-        # ``Web3RPCError`` on a JSON-RPC error). The two subclasses
-        # that a narrower tuple used to miss —
-        # ``BadResponseFormat`` and ``Web3ValidationError`` — are
-        # raised OUTSIDE the ``RotatingHTTPProvider.make_request``
-        # boundary (in ``web3.manager.formatted_response``), so the
-        # rotation layer's own ``except Exception`` never sees them
-        # and they would otherwise propagate out through
-        # ``check_eip1271_signature``, out of the accept path, and
-        # crash the AEA framework's default ``propagate`` handler.
-        # ``RequestException`` covers connection / HTTP / non-timeout
-        # transport failures; ``ValueError`` covers ABI decode
-        # failures the web3 layer surfaces without a
-        # ``BadFunctionCallOutput`` wrap. An out-of-gas revert
-        # triggered by the ``gas`` cap above lands here as
-        # ``ContractLogicError`` (a ``Web3Exception`` subclass) and
-        # returns ``False`` the same way any other revert does.
-        return False
-    return bytes(returned) == EIP1271_MAGIC_VALUE
+    except (ContractLogicError, BadFunctionCallOutput) as exc:
+        # ``ContractLogicError`` on revert (including the out-of-gas
+        # revert triggered by the ``gas`` cap above), and
+        # ``BadFunctionCallOutput`` on a codeless target. Both are
+        # semantically "the contract did not accept this signature";
+        # 401 at the caller.
+        if logger is not None:
+            logger.debug(
+                "check_eip1271_signature DECLINED for %s: %s",
+                contract_address,
+                exc,
+            )
+        return Eip1271Verdict.DECLINED
+    except (Web3Exception, RequestException, ValueError) as exc:
+        # Broader web3 + requests + ValueError capture for the
+        # infra-side failure classes: ``Web3RPCError`` on a JSON-RPC
+        # error, ``BadResponseFormat`` / ``Web3ValidationError`` raised
+        # outside the ``RotatingHTTPProvider.make_request`` boundary
+        # (in ``web3.manager.formatted_response``, invisible to the
+        # rotation layer's own ``except Exception``), ``RequestException``
+        # for connection / HTTP / non-timeout transport failures, and
+        # ``ValueError`` for ABI decode failures the web3 layer
+        # surfaces without a ``BadFunctionCallOutput`` wrap. These
+        # are ALL infra-side — the sender's credentials are not at
+        # fault, so returning ``DECLINED`` would surface an RPC
+        # outage as 401 "unauthorized" to a legitimate caller.
+        if logger is not None:
+            logger.warning(
+                "check_eip1271_signature CALL_FAILED for %s: %r",
+                contract_address,
+                exc,
+            )
+        return Eip1271Verdict.CALL_FAILED
+    if bytes(returned) == EIP1271_MAGIC_VALUE:
+        return Eip1271Verdict.VALID
+    if logger is not None:
+        logger.debug(
+            "check_eip1271_signature DECLINED for %s: non-magic return %r",
+            contract_address,
+            bytes(returned).hex() if returned is not None else None,
+        )
+    return Eip1271Verdict.DECLINED
 
 
 def get_marketplace_domain_separator(

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -41,7 +41,19 @@ from typing import Any, Dict, Optional
 
 from aea_ledger_ethereum import EthereumApi
 from requests.exceptions import RequestException, Timeout
-from web3.exceptions import ContractLogicError, Web3Exception
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
+
+# Prefix web3 uses on ``BadFunctionCallOutput`` when the decode failure
+# comes from calling into an address that has no code (i.e. the sender
+# is a plain EOA rather than a contract with an ``isValidSignature``
+# view). See ``web3.contract.utils.call_contract_function``'s
+# ``is_missing_code_error`` branch — it substitutes this message when
+# both the return data and the contract's code are empty. The other
+# ``BadFunctionCallOutput`` shape ("Could not decode contract function
+# call to ... with return data: ...") fires when the target contract
+# has code but the ``eth_call`` response cannot be decoded, which is
+# what a pruned or lagging node returns.
+_MISSING_CODE_MESSAGE_PREFIX = "Could not transact with/call contract function"
 
 # bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
 # sender must return exactly this value from its ``isValidSignature`` view
@@ -54,14 +66,17 @@ class Eip1271Verdict(str, Enum):
 
     * ``VALID`` — the contract returned the EIP-1271 magic value; the
       presented signature verifies. Accept.
-    * ``DECLINED`` — the contract returned a different bytes4 value
-      or reverted with :class:`ContractLogicError`. Semantically "the
-      signature does not verify". The caller should reject with 401.
+    * ``DECLINED`` — the contract returned a different bytes4 value,
+      reverted with :class:`ContractLogicError`, or the target address
+      has no code (``BadFunctionCallOutput`` with the missing-code
+      message shape). Semantically "the signature does not verify".
+      The caller should reject with 401.
     * ``CALL_FAILED`` — infra-side failure: ``Web3RPCError``,
       ``BadResponseFormat``, ``Web3ValidationError``, ``RequestException``,
-      ``BadFunctionCallOutput`` (empty / undecodable ``eth_call``
-      return, e.g. from a pruned or lagging node), ``ValueError``, or
-      the wall-clock deadline expired. The caller should reject with
+      ``BadFunctionCallOutput`` with the decode-failure shape (empty
+      or malformed ``eth_call`` return from a pruned or lagging node
+      against a target that DOES have code), ``ValueError``, or the
+      wall-clock deadline expired. The caller should reject with
       503; the sender's credentials are not at fault, an RPC or
       transport error is.
 
@@ -198,6 +213,33 @@ def check_eip1271_signature(
                 exc,
             )
         return Eip1271Verdict.DECLINED
+    except BadFunctionCallOutput as exc:
+        # Two distinct producers, disambiguated by the message shape
+        # web3 sets on the raise: the ``eth_call`` target has no code
+        # (the sender is a plain EOA whose ``ecrecover`` did not match
+        # the request id) versus the target has code but the return
+        # data does not decode (a pruned or lagging node responded
+        # with empty or malformed data for a genuine contract call).
+        # The first is a credential-side outcome and belongs in 401;
+        # the second is infra-side and belongs in 503.
+        message = str(exc)
+        if message.startswith(_MISSING_CODE_MESSAGE_PREFIX):
+            if logger is not None:
+                logger.debug(
+                    "check_eip1271_signature DECLINED for %s: no code at "
+                    "target (%s)",
+                    contract_address,
+                    exc,
+                )
+            return Eip1271Verdict.DECLINED
+        if logger is not None:
+            logger.warning(
+                "check_eip1271_signature CALL_FAILED for %s: undecodable "
+                "return data (%s)",
+                contract_address,
+                exc,
+            )
+        return Eip1271Verdict.CALL_FAILED
     except (Web3Exception, RequestException, ValueError) as exc:
         # Infra-side failure classes at the JSON-RPC / transport
         # boundary: ``Web3RPCError`` on a JSON-RPC error,
@@ -205,13 +247,12 @@ def check_eip1271_signature(
         # ``web3.manager.formatted_response`` layer (outside the
         # ``RotatingHTTPProvider.make_request`` boundary),
         # ``RequestException`` for connection / HTTP / non-timeout
-        # transport failures, ``BadFunctionCallOutput`` (a
-        # ``Web3Exception`` subclass) for ``eth_call`` returning
-        # empty / undecodable data from a pruned or lagging node,
-        # and ``ValueError`` for ABI decode failures the web3 layer
-        # surfaces without a ``BadFunctionCallOutput`` wrap. All
-        # belong in the retry-later bucket — the sender's credentials
-        # are not at fault.
+        # transport failures, and ``ValueError`` for ABI decode
+        # failures the web3 layer surfaces without a
+        # ``BadFunctionCallOutput`` wrap. All belong in the
+        # retry-later bucket — the sender's credentials are not at
+        # fault. ``BadFunctionCallOutput`` is handled above so the
+        # codeless-target shape can route to ``DECLINED``.
         if logger is not None:
             logger.warning(
                 "check_eip1271_signature CALL_FAILED for %s: %r",

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from aea_ledger_ethereum import EthereumApi
-from requests.exceptions import RequestException
+from requests.exceptions import RequestException, Timeout
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
 
 # bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
@@ -97,6 +97,7 @@ def check_eip1271_signature(
     contract_address: str,
     message_hash: bytes,
     signature: bytes,
+    gas: int,
 ) -> bool:
     """Return True iff the contract at ``contract_address`` accepts the signature.
 
@@ -105,11 +106,28 @@ def check_eip1271_signature(
     an ABI-decode failure — is flattened to False so the caller can treat the
     outcome as a simple boolean.
 
+    The call carries an explicit ``gas`` cap in the ``eth_call`` transaction
+    payload so a sender contract whose ``isValidSignature`` view loops
+    to the block gas limit is capped at a bounded amount of node work per
+    request; an out-of-gas revert then surfaces as ``ContractLogicError``
+    and flattens to ``False`` like any other revert.
+
+    Transport-level read timeouts propagate as ``TimeoutError`` so the caller
+    can distinguish a slow / hostile ``isValidSignature`` from a plain
+    signature rejection.
+
     :param ledger_api: the ledger API object.
     :param contract_address: the contract sender to query.
     :param message_hash: the 32-byte message hash the caller signed.
     :param signature: the packed signature bytes.
-    :return: True on magic-value match; False otherwise (including on revert).
+    :param gas: the ``gas`` cap applied to the ``eth_call``. Bounds the
+        amount of work a sender's ``isValidSignature`` view can force
+        the RPC node to do per request.
+    :return: True on magic-value match; False otherwise (including on
+        revert or out-of-gas).
+    :raises TimeoutError: when the underlying HTTP read times out (the
+        provider-level ``timeout`` on the ``EthereumApi`` fires). The
+        caller distinguishes this from a signature rejection.
     """
     contract_instance = ledger_api.api.eth.contract(
         address=ledger_api.api.to_checksum_address(contract_address),
@@ -118,7 +136,16 @@ def check_eip1271_signature(
     try:
         returned = contract_instance.functions.isValidSignature(
             bytes(message_hash), bytes(signature)
-        ).call()
+        ).call({"gas": gas})
+    except Timeout as exc:
+        # Read/connect timeouts surface here when the sender's
+        # ``isValidSignature`` view is slow enough that the provider's
+        # transport timeout fires. Re-raise as the built-in
+        # ``TimeoutError`` so the caller can return a distinct verdict
+        # (401 with the timeout reason) instead of the generic
+        # signature-rejected outcome that a revert or bad output would
+        # produce.
+        raise TimeoutError(str(exc)) from exc
     except (
         ContractLogicError,
         BadFunctionCallOutput,
@@ -128,11 +155,13 @@ def check_eip1271_signature(
     ):
         # Web3 raises ``BadFunctionCallOutput`` when the target address
         # holds no code and ``Web3RPCError`` when the node returns a
-        # JSON-RPC error; ``requests`` transport failures (connection
-        # error, read timeout — HTTPError is one subclass) surface as
+        # JSON-RPC error; ``requests`` transport failures other than a
+        # timeout (connection error, HTTP error) surface as
         # ``RequestException``. Any of them means the contract did not
         # unambiguously return the magic value, so the signature is
-        # not accepted.
+        # not accepted. An out-of-gas revert triggered by the ``gas``
+        # cap above lands here as ``ContractLogicError`` and returns
+        # ``False`` the same way any other revert does.
         return False
     return bytes(returned) == EIP1271_MAGIC_VALUE
 

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -41,7 +41,7 @@ from typing import Any, Dict, Optional
 
 from aea_ledger_ethereum import EthereumApi
 from requests.exceptions import RequestException, Timeout
-from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
+from web3.exceptions import ContractLogicError, Web3Exception
 
 # bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
 # sender must return exactly this value from its ``isValidSignature`` view
@@ -54,15 +54,16 @@ class Eip1271Verdict(str, Enum):
 
     * ``VALID`` — the contract returned the EIP-1271 magic value; the
       presented signature verifies. Accept.
-    * ``DECLINED`` — the contract returned a different bytes4 value,
-      reverted with :class:`ContractLogicError`, or the target address
-      has no code (``BadFunctionCallOutput``). Semantically "the
+    * ``DECLINED`` — the contract returned a different bytes4 value
+      or reverted with :class:`ContractLogicError`. Semantically "the
       signature does not verify". The caller should reject with 401.
     * ``CALL_FAILED`` — infra-side failure: ``Web3RPCError``,
       ``BadResponseFormat``, ``Web3ValidationError``, ``RequestException``,
-      ``ValueError``, or the wall-clock deadline expired. The caller
-      should reject with 503; the sender's credentials are not at
-      fault, an RPC or transport error is.
+      ``BadFunctionCallOutput`` (empty / undecodable ``eth_call``
+      return, e.g. from a pruned or lagging node), ``ValueError``, or
+      the wall-clock deadline expired. The caller should reject with
+      503; the sender's credentials are not at fault, an RPC or
+      transport error is.
 
     A single ``bool`` return flattened all three of the ``CALL_FAILED``
     reasons into the same outcome as a genuine ``DECLINED``, so a
@@ -161,9 +162,10 @@ def check_eip1271_signature(
         path so operator triage on 503s has the exception type
         visible.
     :return: an :class:`Eip1271Verdict`. ``VALID`` on magic-value
-        match; ``DECLINED`` on a non-magic return value, revert, or
-        codeless target; ``CALL_FAILED`` on an infra-side failure
-        (RPC error, transport error, ABI-decode failure).
+        match; ``DECLINED`` on a non-magic return value or a revert;
+        ``CALL_FAILED`` on an infra-side failure (RPC error, transport
+        error, ABI-decode failure, empty/undecodable ``eth_call``
+        return from a pruned or lagging node).
     :raises TimeoutError: when the underlying HTTP read times out (the
         provider-level ``timeout`` on the ``EthereumApi`` fires). The
         caller distinguishes this from a signature rejection.
@@ -185,12 +187,10 @@ def check_eip1271_signature(
         # signature-rejected outcome that a revert or bad output would
         # produce.
         raise TimeoutError(str(exc)) from exc
-    except (ContractLogicError, BadFunctionCallOutput) as exc:
-        # ``ContractLogicError`` on revert (including the out-of-gas
-        # revert triggered by the ``gas`` cap above), and
-        # ``BadFunctionCallOutput`` on a codeless target. Both are
-        # semantically "the contract did not accept this signature";
-        # 401 at the caller.
+    except ContractLogicError as exc:
+        # Revert (including the out-of-gas revert triggered by the
+        # ``gas`` cap above). Semantically "the contract did not accept
+        # this signature"; 401 at the caller.
         if logger is not None:
             logger.debug(
                 "check_eip1271_signature DECLINED for %s: %s",
@@ -199,18 +199,19 @@ def check_eip1271_signature(
             )
         return Eip1271Verdict.DECLINED
     except (Web3Exception, RequestException, ValueError) as exc:
-        # Broader web3 + requests + ValueError capture for the
-        # infra-side failure classes: ``Web3RPCError`` on a JSON-RPC
-        # error, ``BadResponseFormat`` / ``Web3ValidationError`` raised
-        # outside the ``RotatingHTTPProvider.make_request`` boundary
-        # (in ``web3.manager.formatted_response``, invisible to the
-        # rotation layer's own ``except Exception``), ``RequestException``
-        # for connection / HTTP / non-timeout transport failures, and
-        # ``ValueError`` for ABI decode failures the web3 layer
-        # surfaces without a ``BadFunctionCallOutput`` wrap. These
-        # are ALL infra-side — the sender's credentials are not at
-        # fault, so returning ``DECLINED`` would surface an RPC
-        # outage as 401 "unauthorized" to a legitimate caller.
+        # Infra-side failure classes at the JSON-RPC / transport
+        # boundary: ``Web3RPCError`` on a JSON-RPC error,
+        # ``BadResponseFormat`` / ``Web3ValidationError`` from the
+        # ``web3.manager.formatted_response`` layer (outside the
+        # ``RotatingHTTPProvider.make_request`` boundary),
+        # ``RequestException`` for connection / HTTP / non-timeout
+        # transport failures, ``BadFunctionCallOutput`` (a
+        # ``Web3Exception`` subclass) for ``eth_call`` returning
+        # empty / undecodable data from a pruned or lagging node,
+        # and ``ValueError`` for ABI decode failures the web3 layer
+        # surfaces without a ``BadFunctionCallOutput`` wrap. All
+        # belong in the retry-later bucket — the sender's credentials
+        # are not at fault.
         if logger is not None:
             logger.warning(
                 "check_eip1271_signature CALL_FAILED for %s: %r",

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""EIP-1271 signature check against a contract sender.
+
+Wraps a single web3 view call. Kept in the task_execution skill (rather than
+against the third-party ``GnosisSafeContract`` wrapper) so the minimal ABI
+fragment lives alongside the caller: the check is a one-selector view that
+does not warrant its own contract-package build tree.
+
+Also fetches the marketplace ``domainSeparator`` and mech ``paymentType`` at
+boot time — both are ``bytes32`` view getters that the request-id derivation
+needs but that the packaged wrappers do not expose today. Colocated here so
+the ABI fragments and the call sites live in one file.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from aea_ledger_ethereum import EthereumApi
+from requests import HTTPError
+from web3.exceptions import ContractLogicError
+
+# bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
+# sender must return exactly this value from its ``isValidSignature`` view
+# for the presented signature to be accepted per EIP-1271.
+EIP1271_MAGIC_VALUE: bytes = b"\x16\x26\xba\x7e"
+
+
+_IS_VALID_SIGNATURE_ABI: Dict[str, Any] = {
+    "inputs": [
+        {"internalType": "bytes32", "name": "_dataHash", "type": "bytes32"},
+        {"internalType": "bytes", "name": "_signature", "type": "bytes"},
+    ],
+    "name": "isValidSignature",
+    "outputs": [{"internalType": "bytes4", "name": "", "type": "bytes4"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+
+_DOMAIN_SEPARATOR_ABI: Dict[str, Any] = {
+    "inputs": [],
+    "name": "getDomainSeparator",
+    "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+
+_PAYMENT_TYPE_ABI: Dict[str, Any] = {
+    "inputs": [],
+    "name": "paymentType",
+    "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+    "stateMutability": "view",
+    "type": "function",
+}
+
+
+def check_eip1271_signature(
+    ledger_api: EthereumApi,
+    contract_address: str,
+    message_hash: bytes,
+    signature: bytes,
+) -> bool:
+    """Return True iff the contract at ``contract_address`` accepts the signature.
+
+    Calls the sender contract's ``isValidSignature(bytes32,bytes)`` view; any
+    return value other than the EIP-1271 magic value — including a revert or
+    an ABI-decode failure — is flattened to False so the caller can treat the
+    outcome as a simple boolean.
+
+    :param ledger_api: the ledger API object.
+    :param contract_address: the contract sender to query.
+    :param message_hash: the 32-byte message hash the caller signed.
+    :param signature: the packed signature bytes.
+    :return: True on magic-value match; False otherwise (including on revert).
+    """
+    contract_instance = ledger_api.api.eth.contract(
+        address=ledger_api.api.to_checksum_address(contract_address),
+        abi=[_IS_VALID_SIGNATURE_ABI],
+    )
+    try:
+        returned = contract_instance.functions.isValidSignature(
+            bytes(message_hash), bytes(signature)
+        ).call()
+    except (ContractLogicError, ValueError, HTTPError):
+        return False
+    return bytes(returned) == EIP1271_MAGIC_VALUE
+
+
+def get_marketplace_domain_separator(
+    ledger_api: EthereumApi, marketplace_address: str
+) -> bytes:
+    """Return the marketplace EIP-712 domain separator as raw bytes32.
+
+    :param ledger_api: the ledger API object.
+    :param marketplace_address: the mech marketplace contract address.
+    :return: the 32-byte domain separator.
+    :raises ValueError: on ABI decode error or if the return is not 32 bytes.
+    """
+    contract_instance = ledger_api.api.eth.contract(
+        address=ledger_api.api.to_checksum_address(marketplace_address),
+        abi=[_DOMAIN_SEPARATOR_ABI],
+    )
+    domain_separator = contract_instance.functions.getDomainSeparator().call()
+    result = bytes(domain_separator)
+    if len(result) != 32:
+        raise ValueError(f"domain_separator length is {len(result)}, expected 32")
+    return result
+
+
+def get_mech_payment_type(ledger_api: EthereumApi, mech_address: str) -> bytes:
+    """Return the mech's ``paymentType`` bytes32.
+
+    :param ledger_api: the ledger API object.
+    :param mech_address: the mech contract address.
+    :return: the 32-byte payment type identifier.
+    :raises ValueError: on ABI decode error or if the return is not 32 bytes.
+    """
+    contract_instance = ledger_api.api.eth.contract(
+        address=ledger_api.api.to_checksum_address(mech_address),
+        abi=[_PAYMENT_TYPE_ABI],
+    )
+    payment_type = contract_instance.functions.paymentType().call()
+    result = bytes(payment_type)
+    if len(result) != 32:
+        raise ValueError(f"payment_type length is {len(result)}, expected 32")
+    return result

--- a/packages/valory/skills/task_execution/utils/eip1271.py
+++ b/packages/valory/skills/task_execution/utils/eip1271.py
@@ -24,10 +24,13 @@ against the third-party ``GnosisSafeContract`` wrapper) so the minimal ABI
 fragment lives alongside the caller: the check is a one-selector view that
 does not warrant its own contract-package build tree.
 
-Also fetches the marketplace ``domainSeparator`` and mech ``paymentType`` at
-boot time — both are ``bytes32`` view getters that the request-id derivation
-needs but that the packaged wrappers do not expose today. Colocated here so
-the ABI fragments and the call sites live in one file.
+Also fetches the marketplace ``getDomainSeparator`` view at boot time — a
+``bytes32`` getter that the request-id derivation needs but that the
+packaged ``MechMarketplace`` wrapper does not expose today. Colocated with
+the sig-verify boot path so the ABI fragment and call site live in one
+file; the mech ``paymentType`` is read through the packaged
+``OlasMechContract.get_mech_type`` wrapper (both call the same on-chain
+``paymentType()`` selector).
 """
 
 from __future__ import annotations
@@ -35,8 +38,8 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from aea_ledger_ethereum import EthereumApi
-from requests import HTTPError
-from web3.exceptions import ContractLogicError
+from requests.exceptions import RequestException
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
 
 # bytes4 of ``keccak256("isValidSignature(bytes32,bytes)")``. A contract
 # sender must return exactly this value from its ``isValidSignature`` view
@@ -59,15 +62,6 @@ _IS_VALID_SIGNATURE_ABI: Dict[str, Any] = {
 _DOMAIN_SEPARATOR_ABI: Dict[str, Any] = {
     "inputs": [],
     "name": "getDomainSeparator",
-    "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
-    "stateMutability": "view",
-    "type": "function",
-}
-
-
-_PAYMENT_TYPE_ABI: Dict[str, Any] = {
-    "inputs": [],
-    "name": "paymentType",
     "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
     "stateMutability": "view",
     "type": "function",
@@ -125,7 +119,20 @@ def check_eip1271_signature(
         returned = contract_instance.functions.isValidSignature(
             bytes(message_hash), bytes(signature)
         ).call()
-    except (ContractLogicError, ValueError, HTTPError):
+    except (
+        ContractLogicError,
+        BadFunctionCallOutput,
+        Web3RPCError,
+        ValueError,
+        RequestException,
+    ):
+        # Web3 raises ``BadFunctionCallOutput`` when the target address
+        # holds no code and ``Web3RPCError`` when the node returns a
+        # JSON-RPC error; ``requests`` transport failures (connection
+        # error, read timeout — HTTPError is one subclass) surface as
+        # ``RequestException``. Any of them means the contract did not
+        # unambiguously return the magic value, so the signature is
+        # not accepted.
         return False
     return bytes(returned) == EIP1271_MAGIC_VALUE
 
@@ -135,10 +142,19 @@ def get_marketplace_domain_separator(
 ) -> bytes:
     """Return the marketplace EIP-712 domain separator as raw bytes32.
 
+    Calls ``getDomainSeparator()`` (not the storage getter
+    ``domainSeparator``): the view returns
+    ``block.chainid == chainId ? domainSeparator : _computeDomainSeparator()``,
+    so the value stays correct after a chain fork where the raw
+    storage getter would return the pre-fork value.
+
     :param ledger_api: the ledger API object.
     :param marketplace_address: the mech marketplace contract address.
     :return: the 32-byte domain separator.
-    :raises ValueError: on ABI decode error or if the return is not 32 bytes.
+    :raises ValueError: only from the explicit 32-byte length guard.
+        Web3 raises ``BadFunctionCallOutput`` when ``eth_call`` returns
+        undecodable output, and ``ContractLogicError`` on a revert;
+        both propagate to the caller.
     """
     contract_instance = ledger_api.api.eth.contract(
         address=ledger_api.api.to_checksum_address(marketplace_address),
@@ -148,25 +164,6 @@ def get_marketplace_domain_separator(
     result = bytes(domain_separator)
     if len(result) != 32:
         raise ValueError(f"domain_separator length is {len(result)}, expected 32")
-    return result
-
-
-def get_mech_payment_type(ledger_api: EthereumApi, mech_address: str) -> bytes:
-    """Return the mech's ``paymentType`` bytes32.
-
-    :param ledger_api: the ledger API object.
-    :param mech_address: the mech contract address.
-    :return: the 32-byte payment type identifier.
-    :raises ValueError: on ABI decode error or if the return is not 32 bytes.
-    """
-    contract_instance = ledger_api.api.eth.contract(
-        address=ledger_api.api.to_checksum_address(mech_address),
-        abi=[_PAYMENT_TYPE_ABI],
-    )
-    payment_type = contract_instance.functions.paymentType().call()
-    result = bytes(payment_type)
-    if len(result) != 32:
-        raise ValueError(f"payment_type length is {len(result)}, expected 32")
     return result
 
 
@@ -198,7 +195,10 @@ def get_marketplace_request_id_view(
     :param payment_type: the mech's ``paymentType`` bytes32.
     :param nonce: the requester nonce uint256.
     :return: the 32-byte request id returned by the view.
-    :raises ValueError: on ABI decode error or if the return is not 32 bytes.
+    :raises ValueError: only from the explicit 32-byte length guard.
+        Web3 raises ``BadFunctionCallOutput`` when ``eth_call`` returns
+        undecodable output, and ``ContractLogicError`` on a revert;
+        both propagate to the caller.
     """
     contract_instance = ledger_api.api.eth.contract(
         address=ledger_api.api.to_checksum_address(marketplace_address),

--- a/packages/valory/skills/task_execution/utils/request_id.py
+++ b/packages/valory/skills/task_execution/utils/request_id.py
@@ -30,12 +30,8 @@ from __future__ import annotations
 from typing import Optional
 
 from eth_account import Account
+from eth_keys.exceptions import BadSignature
 from eth_utils import keccak, to_checksum_address
-
-# EIP-1271 magic value returned by a contract's isValidSignature when it
-# accepts the presented (message_hash, signature) pair. bytes4 of
-# keccak256("isValidSignature(bytes32,bytes)").
-EIP1271_MAGIC_VALUE: bytes = b"\x16\x26\xba\x7e"
 
 # Length of a canonical secp256k1 signature: r (32) + s (32) + v (1).
 SIGNATURE_BYTES_LENGTH: int = 65
@@ -104,7 +100,9 @@ def compute_request_id(
     :param nonce: uint256 requester nonce as tracked by
         ``MechMarketplace.mapNonces[requester]`` at the time of signing.
     :param domain_separator: 32-byte EIP-712 domain separator, as returned
-        by ``MechMarketplace.domainSeparator()``.
+        by ``MechMarketplace.getDomainSeparator()`` (chain-fork-safe view
+        that returns ``block.chainid == chainId ? domainSeparator :
+        _computeDomainSeparator()``).
     :return: 32-byte request_id.
     """
     if len(domain_separator) != 32:
@@ -163,11 +161,22 @@ def recover_eoa_signer(message_hash: bytes, signature: bytes) -> Optional[str]:
 
     normalised = signature[:64] + bytes([v])
 
+    # ``Account._recover_hash`` is a private helper on ``eth-account``
+    # (pinned to ``0.13.7`` in ``skill.yaml``). It is used because the
+    # public ``Account.recover_message`` would prepend the EIP-191
+    # ``\x19Ethereum Signed Message:\n32`` header, which is not what
+    # the marketplace signs — the marketplace signs the raw request-id
+    # bytes32 directly. If a routine ``eth-account`` bump removes the
+    # underscore-prefixed API, the exception surfaces here (as
+    # ``AttributeError``) and every EOA request falls through to the
+    # EIP-1271 branch: ``skill.yaml`` pin plus this comment are the
+    # coupling the caller has to notice.
     try:
         recovered = Account._recover_hash(message_hash, signature=normalised)
-    except Exception:  # pylint: disable=broad-exception-caught
-        # Any recovery failure — bad r/s, curve point at infinity, decode
-        # error — is treated as a failed recovery so the caller can fall
-        # through to the EIP-1271 path.
+    except (BadSignature, ValueError, AttributeError):
+        # Recovery failures ``eth-keys`` surfaces as ``BadSignature`` and
+        # ``eth-account`` surfaces as ``ValueError`` on malformed inputs
+        # (bad ``r``/``s``, curve point at infinity, decode error). The
+        # caller falls through to the EIP-1271 branch on ``None``.
         return None
     return to_checksum_address(recovered)

--- a/packages/valory/skills/task_execution/utils/request_id.py
+++ b/packages/valory/skills/task_execution/utils/request_id.py
@@ -79,13 +79,13 @@ def compute_request_id(
     nonce: int,
     domain_separator: bytes,
 ) -> bytes:
-    """Compute the marketplace request_id from its constituent fields.
+    r"""Compute the marketplace request_id from its constituent fields.
 
     Mirrors ``MechMarketplace.getRequestId`` byte-for-byte::
 
         requestId = keccak256(
             abi.encodePacked(
-                "\\x19\\x01",
+                "\x19\x01",
                 domainSeparator,
                 keccak256(abi.encode(
                     marketplace, mech, requester,
@@ -132,10 +132,10 @@ def compute_request_id(
 
 
 def recover_eoa_signer(message_hash: bytes, signature: bytes) -> Optional[str]:
-    """Recover the signer address from a raw-hash EOA signature.
+    r"""Recover the signer address from a raw-hash EOA signature.
 
     The marketplace signs the raw ``request_id`` bytes32 directly (no
-    ``\\x19Ethereum Signed Message:\\n32`` prefix) because the request_id
+    ``\x19Ethereum Signed Message:\n32`` prefix) because the request_id
     is itself an EIP-712 signable digest. This helper mirrors the
     marketplace's ``ecrecover`` path: normalise a Ledger-style
     ``v ∈ {0, 1}`` to ``{27, 28}`` and reject an upper-half ``s``

--- a/packages/valory/skills/task_execution/utils/request_id.py
+++ b/packages/valory/skills/task_execution/utils/request_id.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Marketplace request-id derivation and EOA signature recovery helpers.
+
+Pure functions. No I/O, no ledger calls. Mirrors the on-chain
+``MechMarketplace.getRequestId`` formula so an offchain request-id and its
+requester signature can be validated locally against the same bytes32 the
+marketplace would produce.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from eth_account import Account
+from eth_utils import keccak, to_checksum_address
+
+# EIP-1271 magic value returned by a contract's isValidSignature when it
+# accepts the presented (message_hash, signature) pair. bytes4 of
+# keccak256("isValidSignature(bytes32,bytes)").
+EIP1271_MAGIC_VALUE: bytes = b"\x16\x26\xba\x7e"
+
+# Length of a canonical secp256k1 signature: r (32) + s (32) + v (1).
+SIGNATURE_BYTES_LENGTH: int = 65
+
+# Upper bound on the low-s half of the secp256k1 order. A signature whose
+# s value is above this bound is malleable and must be rejected before
+# recovery — mirrors the EIP-2 / marketplace ``_verifySignedHash`` guard.
+SECP256K1_HALF_ORDER: int = int(
+    "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0",
+    16,
+)
+
+
+def _encode_address(address: str) -> bytes:
+    """Return the 32-byte left-padded encoding of an Ethereum address."""
+    address_bytes = bytes.fromhex(to_checksum_address(address)[2:])
+    return b"\x00" * 12 + address_bytes
+
+
+def _encode_uint256(value: int) -> bytes:
+    """Return the 32-byte big-endian encoding of a uint256."""
+    if value < 0 or value >= 2**256:
+        raise ValueError(f"value {value} out of uint256 range")
+    return value.to_bytes(32, "big")
+
+
+def _encode_bytes32(value: bytes) -> bytes:
+    """Return the 32-byte value, right-padded with zeros if shorter."""
+    if len(value) > 32:
+        raise ValueError(f"bytes32 value longer than 32: len={len(value)}")
+    return value + b"\x00" * (32 - len(value))
+
+
+def compute_request_id(
+    marketplace: str,
+    mech: str,
+    requester: str,
+    request_data: bytes,
+    delivery_rate: int,
+    payment_type: bytes,
+    nonce: int,
+    domain_separator: bytes,
+) -> bytes:
+    """Compute the marketplace request_id from its constituent fields.
+
+    Mirrors ``MechMarketplace.getRequestId`` byte-for-byte::
+
+        requestId = keccak256(
+            abi.encodePacked(
+                "\\x19\\x01",
+                domainSeparator,
+                keccak256(abi.encode(
+                    marketplace, mech, requester,
+                    keccak256(requestData),
+                    deliveryRate, paymentType, nonce
+                ))
+            )
+        )
+
+    :param marketplace: mech marketplace contract address (0x-prefixed).
+    :param mech: mech contract address (0x-prefixed).
+    :param requester: requester address, EOA or Safe (0x-prefixed).
+    :param request_data: raw request data blob signed on-chain.
+    :param delivery_rate: uint256 delivery rate.
+    :param payment_type: bytes32 payment type identifier.
+    :param nonce: uint256 requester nonce as tracked by
+        ``MechMarketplace.mapNonces[requester]`` at the time of signing.
+    :param domain_separator: 32-byte EIP-712 domain separator, as returned
+        by ``MechMarketplace.domainSeparator()``.
+    :return: 32-byte request_id.
+    """
+    if len(domain_separator) != 32:
+        raise ValueError(
+            f"domain_separator must be 32 bytes, got {len(domain_separator)}"
+        )
+    if len(payment_type) > 32:
+        raise ValueError(
+            f"payment_type must be at most 32 bytes, got {len(payment_type)}"
+        )
+
+    inner = (
+        _encode_address(marketplace)
+        + _encode_address(mech)
+        + _encode_address(requester)
+        + keccak(request_data)
+        + _encode_uint256(delivery_rate)
+        + _encode_bytes32(payment_type)
+        + _encode_uint256(nonce)
+    )
+    inner_hash = keccak(inner)
+
+    outer = b"\x19\x01" + domain_separator + inner_hash
+    return keccak(outer)
+
+
+def recover_eoa_signer(message_hash: bytes, signature: bytes) -> Optional[str]:
+    """Recover the signer address from a raw-hash EOA signature.
+
+    The marketplace signs the raw ``request_id`` bytes32 directly (no
+    ``\\x19Ethereum Signed Message:\\n32`` prefix) because the request_id
+    is itself an EIP-712 signable digest. This helper mirrors the
+    marketplace's ``ecrecover`` path: normalise a Ledger-style
+    ``v ∈ {0, 1}`` to ``{27, 28}`` and reject an upper-half ``s``
+    (malleability).
+
+    :param message_hash: the 32-byte request_id being signed.
+    :param signature: the 65-byte ``r || s || v`` signature.
+    :return: the checksummed signer address, or ``None`` if the signature
+        is malformed, malleable, or otherwise unrecoverable.
+    """
+    if len(message_hash) != 32:
+        return None
+    if len(signature) != SIGNATURE_BYTES_LENGTH:
+        return None
+
+    v = signature[64]
+    if v < 4:
+        v += 27
+    if v not in (27, 28):
+        return None
+
+    s = int.from_bytes(signature[32:64], "big")
+    if s > SECP256K1_HALF_ORDER:
+        return None
+
+    normalised = signature[:64] + bytes([v])
+
+    try:
+        recovered = Account._recover_hash(message_hash, signature=normalised)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Any recovery failure — bad r/s, curve point at infinity, decode
+        # error — is treated as a failed recovery so the caller can fall
+        # through to the EIP-1271 path.
+        return None
+    return to_checksum_address(recovered)

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -31,23 +31,23 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
-- valory/mech_marketplace:0.1.0:bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu
-- valory/complementary_service_metadata:0.1.0:bafybeihukaditdbnvhkxnt2bfqtclfnniw6l2dwks4dx3hhzlvt46ilduq
-- valory/gnosis_safe:0.1.0:bafybeiek7zs3r5c4wspwwuvnhunc2ddvccbsuy3xccedbjffju5eywp3ju
-- valory/multisend:0.1.0:bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi
-- valory/service_registry:0.1.0:bafybeicbfffywnaaehptzasxsdoyguuurpleirsnor5xf7rqk57isjkury
-- valory/hash_checkpoint:0.1.0:bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m
 - valory/balance_tracker:0.1.0:bafybeiayyxl643qfpw57vopytxgyd6flxxmwassswuxen7myekqaxdxxvi
+- valory/complementary_service_metadata:0.1.0:bafybeihukaditdbnvhkxnt2bfqtclfnniw6l2dwks4dx3hhzlvt46ilduq
 - valory/erc20:0.1.0:bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq
+- valory/gnosis_safe:0.1.0:bafybeiek7zs3r5c4wspwwuvnhunc2ddvccbsuy3xccedbjffju5eywp3ju
+- valory/hash_checkpoint:0.1.0:bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m
+- valory/mech_marketplace:0.1.0:bafybeigrcnjaycggulxyx2tsjub4ssjij66d7nfzsavo6gd54hm7beliiu
+- valory/multisend:0.1.0:bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi
+- valory/olas_mech:0.1.0:bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm
+- valory/service_registry:0.1.0:bafybeicbfffywnaaehptzasxsdoyguuurpleirsnor5xf7rqk57isjkury
 protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu
+- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
+- valory/task_execution:0.1.0:bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq
+- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
 behaviours:
   main:
     args: {}
@@ -99,9 +99,10 @@ models:
     class_name: LedgerApiDialogues
   params:
     args:
-      mech_to_config: {}
-      mech_to_max_delivery_rate: {}
+      agent_funding_amount: 200000000000000000
       cleanup_history_depth_current: null
+      complementary_service_metadata_address: '0x0000000000000000000000000000000000000000'
+      default_chain_id: gnosis
       drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
       finalize_timeout: 60.0
       genesis_config:
@@ -121,17 +122,28 @@ models:
           version: {}
         genesis_time: '2022-05-20T16:00:21.735122717Z'
         voting_power: '10'
+      hash_checkpoint_address: '0x0000000000000000000000000000000000000000'
       history_check_timeout: 1205
       ipfs_domain_name: null
-      complementary_service_metadata_address: '0x0000000000000000000000000000000000000000'
-      metadata_hash: '00000000000000000000000000000000000000000000000000'
       ipfs_fetch_timeout: 15.0
       keeper_allowed_retries: 3
       keeper_timeout: 30.0
+      light_slash_unit_amount: 5000000000000000
       max_attempts: 10
       max_healthcheck: 120
-      hash_checkpoint_address: '0x0000000000000000000000000000000000000000'
+      mech_events_chain_id: 0
+      mech_events_sweep_max_age_seconds: 3600.0
+      mech_events_sweep_pending_enabled: false
+      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
+      mech_staking_instance_address: '0x0000000000000000000000000000000000000000'
+      mech_to_config: {}
+      mech_to_max_delivery_rate: {}
+      metadata_hash: '00000000000000000000000000000000000000000000000000'
+      minimum_agent_balance: 100000000000000000
       on_chain_service_id: null
+      predict_api_events_timeout_seconds: 5.0
+      predict_api_events_url: https://mpp.autonolas.tech/mech/events
+      profit_split_balance: 1000
       request_retry_delay: 1.0
       request_timeout: 10.0
       reset_pause_duration: 10
@@ -139,7 +151,10 @@ models:
       retry_attempts: 400
       retry_timeout: 3
       round_timeout_seconds: 30.0
+      serious_slash_unit_amount: 8000000000000000
+      service_endpoint_base: https://dummy_service.autonolas.tech/
       service_id: task_execution
+      service_owner_share: 1000
       service_registry_address: null
       setup:
         all_participants:
@@ -147,6 +162,8 @@ models:
         consensus_threshold: null
         safe_contract_address: '0x0000000000000000000000000000000000000000'
       share_tm_config_on_startup: false
+      slash_cooldown_hours: 3
+      slash_threshold_amount: 10000000000000000
       sleep_time: 1
       task_wait_timeout: 15
       tendermint_check_sleep_delay: 3
@@ -154,28 +171,11 @@ models:
       tendermint_max_retries: 5
       tendermint_p2p_url: localhost:26656
       tendermint_url: http://localhost:26657
-      mech_staking_instance_address: '0x0000000000000000000000000000000000000000'
-      mech_marketplace_address: '0x0000000000000000000000000000000000000000'
       tx_timeout: 10.0
+      use_offchain: false
+      use_slashing: false
       use_termination: false
       validate_timeout: 1205
-      use_slashing: false
-      service_owner_share: 1000
-      profit_split_balance: 1000
-      slash_cooldown_hours: 3
-      agent_funding_amount: 200000000000000000
-      minimum_agent_balance: 100000000000000000
-      slash_threshold_amount: 10000000000000000
-      light_slash_unit_amount: 5000000000000000
-      serious_slash_unit_amount: 8000000000000000
-      service_endpoint_base: https://dummy_service.autonolas.tech/
-      default_chain_id: gnosis
-      use_offchain: false
-      predict_api_events_url: https://mpp.autonolas.tech/mech/events
-      predict_api_events_timeout_seconds: 5.0
-      mech_events_sweep_pending_enabled: false
-      mech_events_sweep_max_age_seconds: 3600.0
-      mech_events_chain_id: 0
     class_name: Params
   requests:
     args: {}
@@ -197,3 +197,4 @@ dependencies:
   prometheus_client:
     version: ==0.23.1
 is_abstract: true
+customs: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq
+- valory/task_execution:0.1.0:bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
+- valory/task_execution:0.1.0:bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly
+- valory/task_execution:0.1.0:bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm
+- valory/task_execution:0.1.0:bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
-- valory/task_execution:0.1.0:bafybeigbciefghh32opfl5te7cbwm5p2oie52r2y64n6h6zkzuvffbu7lq
+- valory/task_execution:0.1.0:bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi
 - valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeia5aolr6j3by3cgjv7d6b2zh6w56xkcsbelmfgqpzvmyvjwlhc33m
+- valory/task_execution:0.1.0:bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeict52dva76yt5h4oragymiczokwptr44kgyey7imred345vicrtwi
+- valory/task_execution:0.1.0:bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai
+- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeifegstxhsdbla2mumyp3rgck5vum6murhaqlerbb7pno3nafpctwq
+- valory/task_execution:0.1.0:bafybeicfodcmqhysoegomvrajrzxc2cwxn7wardbp5xyrvgoeijl3gpivm
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -45,9 +45,9 @@ protocols:
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeidvxzo27p5fkthf6xj5n4e6vwthldcuwx3wvjx4fzpwi6cc7yhn3m
-- valory/task_execution:0.1.0:bafybeiexvgxjymcd43a4fgwey6hwlr5iir5wnenbfub2yvd5l4zd3chvsi
-- valory/transaction_settlement_abci:0.1.0:bafybeibmkegs4e63zldrhsa24h7s7cpgqdf3mmkktopwywtyjjxtnsuv2m
+- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
+- valory/task_execution:0.1.0:bafybeierqzfkkvyah6g2g7ra3ztkggzvlg5pplx6iqxduhy7qhzpmlmxly
+- valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiabfi54wc566g5diapegfxhryaa5dzdchgvo3fqxajypwtfkxlise
+- valory/task_execution:0.1.0:bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeicwi7f36gvoth6ejhzoj3priys4ebafexwm3hrvjmasesns766dqu
+- valory/task_execution:0.1.0:bafybeihpeekvw2q7xhhikul4fdohlcsinn642b32vhjufvd4vhqpo4shaq
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -47,7 +47,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/task_execution:0.1.0:bafybeigzm6w2y3icz6gsbtxc5f5hcmsqvvp3e7yber4nxertqf6gpmtmfm
+- valory/task_execution:0.1.0:bafybeidrdvzykow7biibnvdgaici5b7ssdn5qhbg4dge75wetvs5ijpyiu
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeidy6ecu3bphjgpbclzxkktrrm24qufzdfrqirnbmgrpoevwk47ipy
+- valory/task_execution:0.1.0:bafybeiblrcetmnn56l3seeyuqbugwbmmb66onqqphd4j2egyxe6m22pyai
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/websocket_client/skill.yaml
+++ b/packages/valory/skills/websocket_client/skill.yaml
@@ -27,13 +27,14 @@ handlers:
     args: {}
     class_name: WebSocketHandler
 models:
+  params:
+    args:
+      subscription_id: websocket-subscription
+      websocket_provider: ws://localhost:8001
+    class_name: Params
   websocket_client_dialogues:
     args: {}
     class_name: WebsocketClientDialogues
-  params:
-    args:
-      websocket_provider: ws://localhost:8001
-      subscription_id: websocket-subscription
-    class_name: Params
 dependencies: {}
 is_abstract: true
+customs: []

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@
 ; pyproject / package YAMLs / this section. Drop entries once the
 ; corresponding skill YAMLs adopt the range form.
 extra_deps =
+    eth-account==0.13.7
     eth-utils==6.0.0
     protobuf<7,>=5
     openapi-core<0.23,>=0.22
@@ -16,6 +17,7 @@ extra_deps =
     pebble<6,>=5.1
     peewee<4,>=3.17
     prometheus_client<0.24,>=0.23.1
+    requests>=2.32.5
     web3<8,>=7.15.0
     aiohttp<4.0.0,>=3.8.5
     asn1crypto<1.5.0,>=1.4.0
@@ -76,3 +78,13 @@ ignore_errors = True
 
 [mypy-packages.valory.skills.registration_abci.*]
 ignore_errors = True
+
+; Third-party ethereum utility packages that ship no PEP 561 stubs.
+[mypy-eth_account.*]
+ignore_missing_imports = True
+
+[mypy-eth_utils.*]
+ignore_missing_imports = True
+
+[mypy-eth_abi.*]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -89,3 +89,12 @@ ignore_missing_imports = True
 
 [mypy-eth_abi.*]
 ignore_missing_imports = True
+
+[mypy-eth_keys.*]
+ignore_missing_imports = True
+
+; ``requests.exceptions`` needs an explicit override even though tomte's
+; base config already covers bare ``requests``: ``requests.exceptions``
+; is imported as a distinct submodule in the sig-verify path.
+[mypy-requests.exceptions]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@
 ; pyproject / package YAMLs / this section. Drop entries once the
 ; corresponding skill YAMLs adopt the range form.
 extra_deps =
+    eth-abi==6.0.0b1
     eth-account==0.13.7
     eth-utils==6.0.0
     protobuf<7,>=5

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@
 extra_deps =
     eth-abi==6.0.0b1
     eth-account==0.13.7
+    eth-keys==0.8.0b1
     eth-utils==6.0.0
     protobuf<7,>=5
     openapi-core<0.23,>=0.22


### PR DESCRIPTION
## Summary

Adds signature verification to the `/send_signed_requests` handler in `task_execution`. The handler now runs the verification step before the balance-check RPC, in a strict sequence: parse, verify, balance, enqueue. A signature that does not verify returns `401 Unauthorized` and no balance RPC or task enqueue happens.

Verification recomputes the marketplace `request_id` locally from the posted fields using the same formula as `MechMarketplace.getRequestId`, wraps it appropriately for the sender type, and recovers the signer. For an EOA sender, the signer must equal the sender address. For a contract sender, the signer must be accepted by the sender's own `isValidSignature` view (EIP-1271 magic value). Local `ecrecover` is tried first, so EOA callers add zero RPC on the verification step. Only contract-sender callers pay one additional RPC to the sender's `isValidSignature`.

The two deployment-scoped values the derivation needs (the marketplace's `domainSeparator` and the mech's own `paymentType`) are read once at handler `setup()` when `use_offchain=true` and held on the handler. If those reads fail at boot, subsequent offchain accepts return 401 — a loud operational signal rather than silent mis-derivation.

## Files

New:
- `packages/valory/skills/task_execution/utils/request_id.py` — pure derivation matching `getRequestId`, plus raw-hash EOA signer recovery with s-value malleability guard and Ledger-style v normalisation.
- `packages/valory/skills/task_execution/utils/eip1271.py` — three thin web3 view wrappers (`isValidSignature`, `domainSeparator`, `paymentType`). Minimal ABI fragments and the EIP-1271 magic value live at module scope.

Modified:
- `packages/valory/skills/task_execution/handlers.py` — new `_verify_offchain_request_signature` method (sequential local ecrecover → EIP-1271 fallback), `_initialise_offchain_verification_constants` in `setup()`, sig-verify step inserted before the balance check, added `RequestKey.SIGNATURE`, `RequestKey.NONCE`, `HttpCode.UNAUTHORIZED_CODE = 401`.
- `packages/valory/skills/task_execution/tests/test_handlers.py` — added `_install_verify_ok` boundary stub and 10 new sig-verify handler tests.

Fingerprint refresh in `packages.json` and dependent `*.yaml` from `autonomy packages lock`.

## Test plan

- [x] `pytest packages/valory/skills/task_execution/tests/` → **401 passed** (366 baseline + 35 new)
- [x] Byte-for-byte match of local derivation against an independent `eth_abi` reference implementation
- [x] EIP-1271 branches covered: magic-value True, non-magic False, ContractLogicError revert False
- [x] Handler paths assert the balance RPC is NOT called when the signature fails
- [x] s-value malleability rejection, wire-vs-derivation mismatch, missing signature / missing nonce, constants unloaded, Ledger-style v
- [x] `autonomy packages lock --check` will pass on CI (fingerprints refreshed)

## Notes

- The `is_valid_signature` and `domainSeparator` view helpers live in `task_execution/utils/eip1271.py` rather than as new methods on the third-party `gnosis_safe` / `mech_marketplace` contract wrappers because those wrapper packages are outside the tracked source tree in this repo; keeping the helpers in the caller's skill puts the ABI fragments and the call sites in one file that CI can lock.
- Wire request_id is validated against the locally-derived value before signature recovery, so a caller cannot ride through by signing a different id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)