### PR TITLE
fix(offchain): 402 challenge reads asset from balance tracker's token()

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeicaohpjhxmliqepo7zxysz2odhek2imvpmsdgp76sl6tltexui4ly",
-        "skill/valory/task_execution/0.1.0": "bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeia65wzj3vjrtdqkq55lsgvmju7hq4rz4jhau3b65wmg7tnj6fr6oy",
+        "skill/valory/mech_abci/0.1.0": "bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4",
+        "skill/valory/task_execution/0.1.0": "bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeig4kfzh7cfdta245ayb3hc62tstu5d2y3rtpxhvibhzkhmj3vbk6y",
-        "service/valory/mech/0.1.0": "bafybeifnswe2nfcpvnelrgfbnfpokhb2f7eeu5v4dcnskj32uuvmafvycq"
+        "agent/valory/mech/0.1.0": "bafybeibt7dq5ux6h4j55jp25r7fuy7tbx4c3z6mwcjxqdjbiegijtzpyey",
+        "service/valory/mech/0.1.0": "bafybeick5dfyj3irgdbkovikudfg3aedoetlmnh3g6pnzz4riffxbeswra"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm",
-        "skill/valory/task_execution/0.1.0": "bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve",
+        "skill/valory/mech_abci/0.1.0": "bafybeicaohpjhxmliqepo7zxysz2odhek2imvpmsdgp76sl6tltexui4ly",
+        "skill/valory/task_execution/0.1.0": "bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeia65wzj3vjrtdqkq55lsgvmju7hq4rz4jhau3b65wmg7tnj6fr6oy",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihvzdx6mlaib4ucfygp7ujg3a37opexdz3vefunedkpqaithaq5py",
-        "service/valory/mech/0.1.0": "bafybeigs2myih7nasouv5z7dikcystgykz4i2njeu57wvczlbmxi2canhy"
+        "agent/valory/mech/0.1.0": "bafybeig4kfzh7cfdta245ayb3hc62tstu5d2y3rtpxhvibhzkhmj3vbk6y",
+        "service/valory/mech/0.1.0": "bafybeifnswe2nfcpvnelrgfbnfpokhb2f7eeu5v4dcnskj32uuvmafvycq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeicaohpjhxmliqepo7zxysz2odhek2imvpmsdgp76sl6tltexui4ly
+- valory/mech_abci:0.1.0:bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli
-- valory/task_submission_abci:0.1.0:bafybeia65wzj3vjrtdqkq55lsgvmju7hq4rz4jhau3b65wmg7tnj6fr6oy
+- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
+- valory/task_submission_abci:0.1.0:bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm
+- valory/mech_abci:0.1.0:bafybeicaohpjhxmliqepo7zxysz2odhek2imvpmsdgp76sl6tltexui4ly
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
-- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
+- valory/task_execution:0.1.0:bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli
+- valory/task_submission_abci:0.1.0:bafybeia65wzj3vjrtdqkq55lsgvmju7hq4rz4jhau3b65wmg7tnj6fr6oy
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihvzdx6mlaib4ucfygp7ujg3a37opexdz3vefunedkpqaithaq5py
+agent: valory/mech:0.1.0:bafybeig4kfzh7cfdta245ayb3hc62tstu5d2y3rtpxhvibhzkhmj3vbk6y
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeig4kfzh7cfdta245ayb3hc62tstu5d2y3rtpxhvibhzkhmj3vbk6y
+agent: valory/mech:0.1.0:bafybeibt7dq5ux6h4j55jp25r7fuy7tbx4c3z6mwcjxqdjbiegijtzpyey
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
-- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
+- valory/task_execution:0.1.0:bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli
+- valory/task_submission_abci:0.1.0:bafybeia65wzj3vjrtdqkq55lsgvmju7hq4rz4jhau3b65wmg7tnj6fr6oy
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli
-- valory/task_submission_abci:0.1.0:bafybeia65wzj3vjrtdqkq55lsgvmju7hq4rz4jhau3b65wmg7tnj6fr6oy
+- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
+- valory/task_submission_abci:0.1.0:bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -448,6 +448,7 @@ class ResponseKey(str, Enum):
     CHAIN_ID = "chain_id"
     BALANCE_TRACKER_ADDRESS = "balance_tracker_address"
     PAYMENT_TYPE = "payment_type"
+    ASSET_ADDRESS = "asset_address"
 
 
 # 402 challenge constants — surfaced so clients can branch on a stable label.
@@ -1227,6 +1228,7 @@ class MechHttpHandler(AbstractResponseHandler):
         # for the balance-check reads without either overwriting the
         # other's provider timeout.
         self._ledger_api_cache: Dict[Tuple[str, int, float], EthereumApi] = {}
+        self._balance_tracker_asset_cache: Dict[str, str] = {}
         # Executor for on-path RPCs whose wall-clock duration must be
         # capped independently of the per-HTTP-request provider timeout.
         # See ``_RPC_WALL_CLOCK_DEADLINE_SECONDS`` for the multiplication
@@ -2528,8 +2530,6 @@ class MechHttpHandler(AbstractResponseHandler):
         :return: the structured 402 challenge as a dict ready for JSON encoding.
         :raises ValueError: if ``balance_check`` lacks the balance-tracker address.
         """
-        # Native-asset payment models surface the zero address for ``asset``;
-        # clients that see it must skip the ERC20 approve step.
         if ResponseKey.BALANCE_TRACKER_ADDRESS.value not in balance_check:
             raise ValueError(
                 "cannot build a 402 challenge from a balance check without a "
@@ -2539,13 +2539,9 @@ class MechHttpHandler(AbstractResponseHandler):
         balance_tracker_address = cast(
             str, balance_check[ResponseKey.BALANCE_TRACKER_ADDRESS.value]
         )
-        # Normalize the lookup key — `or ""` guards a present-but-None
-        # payment_type (a bare cast would be a runtime no-op and .lower() would
-        # then AttributeError); the map keys are lower-cased at load time
-        # (models.Params) so a checksummed payment_type still resolves.
-        payment_type = (balance_check.get(ResponseKey.PAYMENT_TYPE.value) or "").lower()
-        asset_address = self.params.payment_type_to_asset_address.get(
-            payment_type, ZERO_ADDRESS
+        asset_address = cast(
+            str,
+            balance_check.get(ResponseKey.ASSET_ADDRESS.value) or ZERO_ADDRESS,
         )
         return {
             "scheme": PAYMENT_SCHEME,
@@ -2887,6 +2883,10 @@ class MechHttpHandler(AbstractResponseHandler):
                 balance_tracker_address=balance_tracker_address,
                 requester=requester,
             )
+            asset_address = self._resolve_balance_tracker_asset(
+                ledger_api=ledger_api,
+                balance_tracker_address=balance_tracker_address,
+            )
             decision = (
                 BALANCE_LOG_DECISION_ACCEPTED
                 if available_amount >= required_amount
@@ -2903,6 +2903,7 @@ class MechHttpHandler(AbstractResponseHandler):
                 ResponseKey.REASON.value: "balance check completed",
                 ResponseKey.BALANCE_TRACKER_ADDRESS.value: balance_tracker_address,
                 ResponseKey.PAYMENT_TYPE.value: payment_type,
+                ResponseKey.ASSET_ADDRESS.value: asset_address,
                 ResponseKey.CHAIN_ID.value: chain_id,
             }
         except Exception as e:
@@ -2982,6 +2983,47 @@ class MechHttpHandler(AbstractResponseHandler):
             label="balance_tracker_getRequesterBalance",
         )
         return cast(int, requester_balance_res.get(BodyKey.REQUESTER_BALANCE.value, 0))
+
+    def _resolve_balance_tracker_asset(
+        self, ledger_api: EthereumApi, balance_tracker_address: str
+    ) -> str:
+        """Return the asset the balance tracker accepts for deposits.
+
+        Cached per ``balance_tracker_address`` for the process lifetime;
+        ``BalanceTrackerFixedPriceToken.token`` is ``immutable`` in
+        Solidity. Native trackers revert on ``token()``; that revert
+        is their identity and returns ``ZERO_ADDRESS``.
+
+        :param ledger_api: the ledger API object.
+        :param balance_tracker_address: the balance tracker address.
+        :return: the ERC-20 asset address, or ``ZERO_ADDRESS`` for
+            native-payment trackers.
+        """
+        cached = self._balance_tracker_asset_cache.get(balance_tracker_address)
+        if cached is not None:
+            return cached
+        try:
+            token_res = self._run_with_wall_clock_deadline(
+                lambda: BalanceTrackerContract.get_token_address(
+                    ledger_api=ledger_api,
+                    contract_address=balance_tracker_address,
+                ),
+                deadline_seconds=_BALANCE_RPC_DEADLINE_SECONDS,
+                label="balance_tracker_token",
+            )
+            asset = cast(str, token_res.get("token_address") or ZERO_ADDRESS)
+        except ContractLogicError:
+            asset = ZERO_ADDRESS
+        except Exception:  # pylint: disable=broad-exception-caught
+            self.context.logger.warning(
+                "Failed to resolve balance tracker asset for %s; "
+                "falling back to native.",
+                balance_tracker_address,
+                exc_info=True,
+            )
+            asset = ZERO_ADDRESS
+        self._balance_tracker_asset_cache[balance_tracker_address] = asset
+        return asset
 
     def _verify_offchain_request_signature(
         self,

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -2989,10 +2989,20 @@ class MechHttpHandler(AbstractResponseHandler):
     ) -> str:
         """Return the asset the balance tracker accepts for deposits.
 
-        Cached per ``balance_tracker_address`` for the process lifetime;
+        Deterministic outcomes cache per ``balance_tracker_address``
+        for the process lifetime;
         ``BalanceTrackerFixedPriceToken.token`` is ``immutable`` in
-        Solidity. Native trackers revert on ``token()``; that revert
-        is their identity and returns ``ZERO_ADDRESS``.
+        Solidity, so a successful read never goes stale. Native
+        trackers do not implement ``token()`` and the call surfaces
+        as either :class:`ContractLogicError` (provider returned an
+        error object) or :class:`BadFunctionCallOutput` (provider
+        returned bare ``0x``); both are the native-tracker identity
+        and cache as ``ZERO_ADDRESS``.
+
+        Transient failures (timeout, queue saturation, transport)
+        return ``ZERO_ADDRESS`` for this reply but do NOT cache so
+        the next request retries the read rather than latching an
+        infra-side blip into a wrong-asset verdict.
 
         :param ledger_api: the ledger API object.
         :param balance_tracker_address: the balance tracker address.
@@ -3012,16 +3022,16 @@ class MechHttpHandler(AbstractResponseHandler):
                 label="balance_tracker_token",
             )
             asset = cast(str, token_res.get("token_address") or ZERO_ADDRESS)
-        except ContractLogicError:
+        except (ContractLogicError, BadFunctionCallOutput):
             asset = ZERO_ADDRESS
         except Exception:  # pylint: disable=broad-exception-caught
             self.context.logger.warning(
                 "Failed to resolve balance tracker asset for %s; "
-                "falling back to native.",
+                "falling back to native for this reply without caching.",
                 balance_tracker_address,
                 exc_info=True,
             )
-            asset = ZERO_ADDRESS
+            return ZERO_ADDRESS
         self._balance_tracker_asset_cache[balance_tracker_address] = asset
         return asset
 

--- a/packages/valory/skills/task_execution/models.py
+++ b/packages/valory/skills/task_execution/models.py
@@ -128,14 +128,6 @@ class Params(Model):
         self.polygon_ledger_rpc: str = kwargs.get("polygon_ledger_rpc", "")
         self.base_ledger_rpc: str = kwargs.get("base_ledger_rpc", "")
         self.optimism_ledger_rpc: str = kwargs.get("optimism_ledger_rpc", "")
-        # Lower-case the payment_type keys at load so a checksummed-vs-lowercase
-        # hex mismatch at lookup time can't silently fall back to the zero
-        # address (which would signal a native-asset deposit for what is really
-        # an ERC-20 payment model).
-        self.payment_type_to_asset_address: Dict[str, str] = {
-            key.lower(): value
-            for key, value in kwargs.get("payment_type_to_asset_address", {}).items()
-        }
         # Dual-purpose gate: controls BOTH offchain-request ingress AND
         # egress to the predict-api events endpoint (settlement writes for
         # both offchain-settled AND on-chain-settled requests). A mech is

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeigatm6ewxxop733etomyxei7pmfocjlbye3gk7c2jra5w5u5inira
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeifmuestaen2ejfgpohkt5rhy6b5jlwtegcdd5by6wg34hdjxsalti
+  handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
   tests/test_behaviours.py: bafybeigbaekfxjzhzynskbxbxyxy6p2ue6hcxcctadv44cmvag3ufs6mla
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeie5fmi3wo67jki5hlkwrqofqxbdvm6h3c6peaaih4kbgrvua4ooem
+  tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,13 +9,13 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeigatm6ewxxop733etomyxei7pmfocjlbye3gk7c2jra5w5u5inira
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeid26cgoukem5zknnuvsuktiuqram4de4ry4qyyq32vkfkyqncniya
-  models.py: bafybeiatzqnv75vhmqa4srdfewyfzittjjearnn6noz3qfzr6ydcjhkdhy
+  handlers.py: bafybeifmuestaen2ejfgpohkt5rhy6b5jlwtegcdd5by6wg34hdjxsalti
+  models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
-  tests/conftest.py: bafybeicwykoemg55dnpaye5g7o7mib2c34o2k6bh5izw4wzwych5kr4pbq
+  tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
   tests/test_behaviours.py: bafybeigbaekfxjzhzynskbxbxyxy6p2ue6hcxcctadv44cmvag3ufs6mla
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
-  tests/test_handlers.py: bafybeific6kzxga3xtefrguaps2zvv4mjlowqzbsfq6hytzevfxermariu
+  tests/test_handlers.py: bafybeie5fmi3wo67jki5hlkwrqofqxbdvm6h3c6peaaih4kbgrvua4ooem
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq
   tests/test_preimage_buffer.py: bafybeidc6w52c6r27ntwmg4ow3rrvmgwq22fkcvxrvv3y7o5isvktkzuqy
   tests/utils/__init__.py: bafybeihhmu24bkh47szarsroa5esxjbidkbikmijzydele6jaj7uti2sby
@@ -109,7 +109,6 @@ models:
       mech_to_max_delivery_rate: {}
       num_agents: 4
       optimism_ledger_rpc: http://localhost:8545
-      payment_type_to_asset_address: {}
       polling_interval: 30.0
       polygon_ledger_rpc: http://localhost:8545
       serious_slash_unit_amount: 8000000000000000

--- a/packages/valory/skills/task_execution/tests/conftest.py
+++ b/packages/valory/skills/task_execution/tests/conftest.py
@@ -187,7 +187,6 @@ def params_stub() -> SimpleNamespace:
         },
         use_mech_marketplace=True,
         mech_marketplace_address="0xMarketplace",
-        payment_type_to_asset_address={},
         # Offchain path enabled for the tests that exercise it; the
         # default-off gate is covered by a dedicated test.
         use_offchain=True,

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -1797,6 +1797,9 @@ def test_check_offchain_requester_balance_success(
         lambda **kw: "0x" + "1" * 40,  # non-zero
     )
     monkeypatch.setattr(mh, "_get_requester_balance", lambda **kw: 500)
+    monkeypatch.setattr(
+        mh, "_resolve_balance_tracker_asset", lambda **kw: "0xUSDCToken"
+    )
 
     fake_api = MagicMock()
     fake_api.api.to_checksum_address = lambda x: x
@@ -1809,6 +1812,10 @@ def test_check_offchain_requester_balance_success(
     assert result["status"] == "ok"
     assert result["available_amount"] == 500
     assert result["required_amount"] == 100
+    # The 402 challenge builder reads asset from this key; if the wiring
+    # regresses, the challenge would fall back to ZERO_ADDRESS and the
+    # trader's asset-match guard would reject every deposit.
+    assert result[hmod.ResponseKey.ASSET_ADDRESS.value] == "0xUSDCToken"
 
 
 def test_check_offchain_requester_balance_exception(
@@ -2396,19 +2403,42 @@ def test_resolve_balance_tracker_asset_caches_per_address(
     assert calls == ["0xTracker1", "0xTracker2"]
 
 
+@pytest.mark.parametrize(
+    "raised",
+    [
+        pytest.param(
+            hmod.ContractLogicError("execution reverted"), id="contract_logic_error"
+        ),
+        pytest.param(
+            hmod.BadFunctionCallOutput("bare 0x return"),
+            id="bad_function_call_output",
+        ),
+    ],
+)
 def test_resolve_balance_tracker_asset_native_tracker_returns_zero_address(
-    handler_context: Any, monkeypatch: Any
+    handler_context: Any, monkeypatch: Any, raised: BaseException
 ) -> None:
-    """A native tracker reverts on ``token()`` and resolves to ``ZERO_ADDRESS``."""
+    """A native tracker surfaces as ``ContractLogicError`` or ``BadFunctionCallOutput``.
+
+    Both are deterministic identities of a native tracker (the
+    provider chooses between them based on whether it returns an
+    error object or a bare ``0x`` for the missing selector). Both
+    resolve to ``ZERO_ADDRESS`` and cache so the next 402 for the
+    same tracker does not re-RPC.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    :param raised: the deterministic native-tracker exception under test.
+    """
     mh = _http_handler(handler_context, monkeypatch)
 
     def _revert(**_kwargs: Any) -> None:
-        raise hmod.ContractLogicError("execution reverted")
+        raise raised
 
     monkeypatch.setattr(hmod.BalanceTrackerContract, "get_token_address", _revert)
     asset = mh._resolve_balance_tracker_asset(MagicMock(), "0xNativeTracker")
     assert asset == hmod.ZERO_ADDRESS
-    # Same address a second time — no re-attempt of the reverting call.
+    # Same address a second time — no re-attempt of the deterministic call.
     calls: List[Any] = []
 
     def _would_replace(**kwargs: Any) -> Dict[str, str]:
@@ -2421,6 +2451,49 @@ def test_resolve_balance_tracker_asset_native_tracker_returns_zero_address(
     asset2 = mh._resolve_balance_tracker_asset(MagicMock(), "0xNativeTracker")
     assert asset2 == hmod.ZERO_ADDRESS
     assert calls == []
+
+
+def test_resolve_balance_tracker_asset_transient_failure_is_not_cached(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """Timeout / queue-saturation returns ZERO_ADDRESS but does not poison the cache.
+
+    ``_run_with_wall_clock_deadline`` raises
+    ``concurrent.futures.TimeoutError`` on deadline expiry and
+    ``RuntimeError(RPC_QUEUE_SATURATED)`` under executor queue
+    pressure. Caching the ZERO_ADDRESS fallback on those paths would
+    latch a wrong-asset verdict for the process lifetime — exactly
+    the config-drift class this PR replaces with an on-chain read.
+    The transient branch must NOT write the cache so the next
+    request retries and eventually reads the real token address.
+
+    :param handler_context: pytest fixture, mech HTTP handler test context.
+    :param monkeypatch: pytest fixture, per-test monkeypatch helper.
+    """
+    import concurrent.futures as _cf
+
+    mh = _http_handler(handler_context, monkeypatch)
+    calls: List[Any] = []
+
+    def _timeout_once_then_ok(**kwargs: Any) -> Dict[str, str]:
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise _cf.TimeoutError("balance_tracker_token deadline")
+        return {"token_address": "0xUSDCToken"}
+
+    monkeypatch.setattr(
+        hmod.BalanceTrackerContract, "get_token_address", _timeout_once_then_ok
+    )
+    ledger_api = MagicMock()
+
+    first = mh._resolve_balance_tracker_asset(ledger_api, "0xUSDCTracker")
+    assert first == hmod.ZERO_ADDRESS
+    assert "0xUSDCTracker" not in mh._balance_tracker_asset_cache
+
+    second = mh._resolve_balance_tracker_asset(ledger_api, "0xUSDCTracker")
+    assert second == "0xUSDCToken"
+    assert mh._balance_tracker_asset_cache["0xUSDCTracker"] == "0xUSDCToken"
+    assert len(calls) == 2
 
 
 def test_send_ok_response_rejects_non_newline_extra_headers(

--- a/packages/valory/skills/task_execution/tests/test_handlers.py
+++ b/packages/valory/skills/task_execution/tests/test_handlers.py
@@ -737,6 +737,7 @@ def _patched_handler_for_balance(
     available_offset: int,
     payment_type: str = "0xpaymenttype",
     balance_tracker_address: str = "0xBalanceTracker",
+    asset_address: str = "0x0000000000000000000000000000000000000000",
     chain_id: int = 100,
 ) -> MechHttpHandler:
     """Build a MechHttpHandler with the balance check patched to a fixed result."""
@@ -752,6 +753,7 @@ def _patched_handler_for_balance(
             "reason": "balance check completed",
             "balance_tracker_address": balance_tracker_address,
             "payment_type": payment_type,
+            "asset_address": asset_address,
             "chain_id": chain_id,
         },
     )
@@ -783,11 +785,11 @@ def test_402_body_includes_structured_challenge(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
     """402 body carries the structured challenge fields alongside the legacy keys."""
-    handler_context.params.payment_type_to_asset_address = {
-        "0xpaymenttype": "0xUSDCToken",
-    }
     mh = _patched_handler_for_balance(
-        handler_context, monkeypatch, available_offset=-50
+        handler_context,
+        monkeypatch,
+        available_offset=-50,
+        asset_address="0xUSDCToken",
     )
 
     resp = _send_signed_request(mh, http_dialogue, request_id="402")
@@ -829,13 +831,10 @@ def test_402_emits_www_authenticate_header(
     )
 
 
-def test_402_native_asset_when_payment_type_unmapped(
+def test_402_native_asset_when_balance_tracker_is_native(
     handler_context: Any, http_dialogue: Any, monkeypatch: Any
 ) -> None:
-    """Unmapped payment types surface the zero address as the asset."""
-    # Clients seeing the zero address must skip the ERC20 approve step and
-    # treat the payment as a native-asset deposit.
-    handler_context.params.payment_type_to_asset_address = {}
+    """Native-payment balance trackers surface the zero address as the asset."""
     mh = _patched_handler_for_balance(handler_context, monkeypatch, available_offset=-1)
     resp = _send_signed_request(mh, http_dialogue, request_id="4022")
 
@@ -2343,35 +2342,85 @@ def test_build_402_challenge_raises_without_balance_tracker_address(
         )
 
 
-def test_build_402_challenge_payment_type_case_insensitive(
+def test_build_402_challenge_forwards_asset_address_from_balance_check(
     handler_context: Any, monkeypatch: Any
 ) -> None:
-    """A checksummed payment_type resolves against the lower-cased asset map."""
-    handler_context.params.payment_type_to_asset_address = {"0xabc": "0xAssetAddr"}
+    """The 402 challenge's ``asset`` field comes from ``balance_check.asset_address``."""
     mh = _http_handler(handler_context, monkeypatch)
     challenge = mh._build_402_challenge(
         {
             hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
-            hmod.ResponseKey.PAYMENT_TYPE.value: "0xABC",
+            hmod.ResponseKey.ASSET_ADDRESS.value: "0xUSDCToken",
         },
         error_msg="insufficient balance",
     )
-    assert challenge["asset"] == "0xAssetAddr"
+    assert challenge["asset"] == "0xUSDCToken"
 
 
-def test_build_402_challenge_none_payment_type_is_safe(
+def test_build_402_challenge_missing_asset_address_falls_back_to_native(
     handler_context: Any, monkeypatch: Any
 ) -> None:
-    """A present-but-None payment_type must not AttributeError on .lower()."""
+    """A missing or None ``asset_address`` falls back to ``ZERO_ADDRESS`` (native)."""
     mh = _http_handler(handler_context, monkeypatch)
     challenge = mh._build_402_challenge(
         {
             hmod.ResponseKey.BALANCE_TRACKER_ADDRESS.value: "0xBalanceTracker",
-            hmod.ResponseKey.PAYMENT_TYPE.value: None,
+            hmod.ResponseKey.ASSET_ADDRESS.value: None,
         },
         error_msg="insufficient balance",
     )
     assert challenge["asset"] == hmod.ZERO_ADDRESS
+
+
+def test_resolve_balance_tracker_asset_caches_per_address(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """The token() lookup runs once per tracker address and is cached."""
+    mh = _http_handler(handler_context, monkeypatch)
+    calls: List[str] = []
+
+    def _stub(**kwargs: Any) -> Dict[str, str]:
+        calls.append(kwargs["contract_address"])
+        return {"token_address": "0xUSDCToken"}
+
+    monkeypatch.setattr(hmod.BalanceTrackerContract, "get_token_address", _stub)
+    ledger_api = MagicMock()
+
+    a1 = mh._resolve_balance_tracker_asset(ledger_api, "0xTracker1")
+    a2 = mh._resolve_balance_tracker_asset(ledger_api, "0xTracker1")
+    a3 = mh._resolve_balance_tracker_asset(ledger_api, "0xTracker2")
+
+    assert a1 == "0xUSDCToken"
+    assert a2 == "0xUSDCToken"
+    assert a3 == "0xUSDCToken"
+    assert calls == ["0xTracker1", "0xTracker2"]
+
+
+def test_resolve_balance_tracker_asset_native_tracker_returns_zero_address(
+    handler_context: Any, monkeypatch: Any
+) -> None:
+    """A native tracker reverts on ``token()`` and resolves to ``ZERO_ADDRESS``."""
+    mh = _http_handler(handler_context, monkeypatch)
+
+    def _revert(**_kwargs: Any) -> None:
+        raise hmod.ContractLogicError("execution reverted")
+
+    monkeypatch.setattr(hmod.BalanceTrackerContract, "get_token_address", _revert)
+    asset = mh._resolve_balance_tracker_asset(MagicMock(), "0xNativeTracker")
+    assert asset == hmod.ZERO_ADDRESS
+    # Same address a second time — no re-attempt of the reverting call.
+    calls: List[Any] = []
+
+    def _would_replace(**kwargs: Any) -> Dict[str, str]:
+        calls.append(kwargs)
+        return {"token_address": "0xShouldNotSee"}
+
+    monkeypatch.setattr(
+        hmod.BalanceTrackerContract, "get_token_address", _would_replace
+    )
+    asset2 = mh._resolve_balance_tracker_asset(MagicMock(), "0xNativeTracker")
+    assert asset2 == hmod.ZERO_ADDRESS
+    assert calls == []
 
 
 def test_send_ok_response_rejects_non_newline_extra_headers(

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
+- valory/task_execution:0.1.0:bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeifgai2d7qkysxjnein3meyjdsklgt57rfjei3v5p2acxfqxuhavli
+- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:


### PR DESCRIPTION
## Summary

- The 402 challenge's `asset` field is now read from the balance tracker's on-chain `token()` getter, cached per tracker address for the process lifetime.
- Removes the `payment_type_to_asset_address` map primitive that duplicated the same information as an operator-managed env config.

## Background

While bench-testing Pearl 1.9.2-rc4 with Polystrat on Polygon, mech-interact repeatedly failed offchain requests with:

```
Offchain 402 asset mismatch: mech reported '0x0000000000000000000000000000000000000000'
but BalanceTracker 0x5c50ebc17d002a4484585c8fbf62f51953493c0b accepts
'0x3c499c542cef5e3811e1192ce70d8cc03d5c3359'. Refusing to deposit and failing over.
```

The trader's asset-match guard (from mech-interact PR #95) fired correctly and prevented a wrong-asset deposit. Root cause: the mech's 402 builder looked up `paymentType → asset_address` in `Params.payment_type_to_asset_address`, a map that:

1. Had no env-override wiring in the mech agent / service yaml or in any consumer repo (mech-predict, mech-agents-fun). `PAYMENT_TYPE_TO_ASSET_ADDRESS='...'` in a `.env` was a no-op.
2. Fell back to `ZERO_ADDRESS` (native) when the paymentType was missing, which is only correct for native trackers.
3. Would have required 6 yaml edits across 3 repos + per-chain `.env` entries per mech to make usable.

## The fix

`_check_offchain_requester_balance` now calls `_resolve_balance_tracker_asset(ledger_api, tracker_addr)` and adds the result to the response dict under `ResponseKey.ASSET_ADDRESS`. The resolver:

- Reads `BalanceTrackerContract.get_token_address()` (the `token()` view).
- Caches in `_balance_tracker_asset_cache: Dict[str, str]` keyed by tracker address.
- Returns `ZERO_ADDRESS` on `ContractLogicError` (native trackers revert on `token()` — that's their identity).
- Returns `ZERO_ADDRESS` with a WARNING log on any other error so the 402 still emits and mech-interact's asset-match guard catches the mismatch downstream.

`_build_402_challenge` reads `asset` from `balance_check[ASSET_ADDRESS]`, no more Params lookup.

The `payment_type_to_asset_address` field is deleted from `models.Params`, from `skill.yaml`'s default block, and from the test `params_stub` fixture.

## Why auto-derive over env config

`BalanceTrackerFixedPriceToken.token` is declared `immutable` in Solidity — the value baked into runtime bytecode never changes. A re-registered tracker (rare) has a different address, which is a fresh cache key. So one RPC per unique balance tracker per process lifetime, on a code path that already makes three sequential balance-check RPCs. Effectively free. Removes an entire config-drift class of bug.

## Test plan

- [x] `pytest packages/valory/skills/task_execution/tests packages/valory/skills/mech_abci/tests` — 563 pass (+3 new tests: `test_resolve_balance_tracker_asset_caches_per_address`, `test_resolve_balance_tracker_asset_native_tracker_returns_zero_address`, `test_build_402_challenge_forwards_asset_address_from_balance_check`; renamed one)
- [x] `tomte tox -e black-check -e isort-check -e flake8 -e mypy -e darglint -e check-hash -e check-packages -e check-dependencies -e check-abciapp-specs` — all green
- [x] Third-party package hashes unchanged
- [ ] Re-test Polystrat offchain flow on Polygon post-merge (requires trader with insufficient prepaid balance so the 402 branch fires end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)