### PR TITLE
fix(task_execution): populate in_memory_requests on the on-chain path

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeidfne2ibdn52tsjkn3spg3is3ladlbswqqfrgw5vl44ehyj26qifa",
-        "skill/valory/task_execution/0.1.0": "bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeieitcdvu4nvop6lmbwgqpluxlg42yludxl2t5ps747dy37rb5ew3y",
+        "skill/valory/mech_abci/0.1.0": "bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay",
+        "skill/valory/task_execution/0.1.0": "bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeigoua7bvwpd5ns5nlkl57taljbmksqd3jdnpto2c2ijtidrp5e4au",
-        "service/valory/mech/0.1.0": "bafybeic5vbinhkylboxmjkrxpx3eckqqo4yw75pr2toma7zndzx2sochoe"
+        "agent/valory/mech/0.1.0": "bafybeid7ihrotxlbbqtplxoohqmdurrc7gczw5cixafjkgaytjxztwx7im",
+        "service/valory/mech/0.1.0": "bafybeib7gux2jya6qchl2kus3zpz5vgzop5hdlccvrpirdx4lhougctuwq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4",
-        "skill/valory/task_execution/0.1.0": "bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a",
+        "skill/valory/mech_abci/0.1.0": "bafybeidfne2ibdn52tsjkn3spg3is3ladlbswqqfrgw5vl44ehyj26qifa",
+        "skill/valory/task_execution/0.1.0": "bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeieitcdvu4nvop6lmbwgqpluxlg42yludxl2t5ps747dy37rb5ew3y",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeibt7dq5ux6h4j55jp25r7fuy7tbx4c3z6mwcjxqdjbiegijtzpyey",
-        "service/valory/mech/0.1.0": "bafybeick5dfyj3irgdbkovikudfg3aedoetlmnh3g6pnzz4riffxbeswra"
+        "agent/valory/mech/0.1.0": "bafybeigoua7bvwpd5ns5nlkl57taljbmksqd3jdnpto2c2ijtidrp5e4au",
+        "service/valory/mech/0.1.0": "bafybeic5vbinhkylboxmjkrxpx3eckqqo4yw75pr2toma7zndzx2sochoe"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4
+- valory/mech_abci:0.1.0:bafybeidfne2ibdn52tsjkn3spg3is3ladlbswqqfrgw5vl44ehyj26qifa
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
-- valory/task_submission_abci:0.1.0:bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a
+- valory/task_execution:0.1.0:bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424
+- valory/task_submission_abci:0.1.0:bafybeieitcdvu4nvop6lmbwgqpluxlg42yludxl2t5ps747dy37rb5ew3y
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeidfne2ibdn52tsjkn3spg3is3ladlbswqqfrgw5vl44ehyj26qifa
+- valory/mech_abci:0.1.0:bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424
-- valory/task_submission_abci:0.1.0:bafybeieitcdvu4nvop6lmbwgqpluxlg42yludxl2t5ps747dy37rb5ew3y
+- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
+- valory/task_submission_abci:0.1.0:bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeibt7dq5ux6h4j55jp25r7fuy7tbx4c3z6mwcjxqdjbiegijtzpyey
+agent: valory/mech:0.1.0:bafybeigoua7bvwpd5ns5nlkl57taljbmksqd3jdnpto2c2ijtidrp5e4au
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigoua7bvwpd5ns5nlkl57taljbmksqd3jdnpto2c2ijtidrp5e4au
+agent: valory/mech:0.1.0:bafybeid7ihrotxlbbqtplxoohqmdurrc7gczw5cixafjkgaytjxztwx7im
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424
-- valory/task_submission_abci:0.1.0:bafybeieitcdvu4nvop6lmbwgqpluxlg42yludxl2t5ps747dy37rb5ew3y
+- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
+- valory/task_submission_abci:0.1.0:bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
-- valory/task_submission_abci:0.1.0:bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a
+- valory/task_execution:0.1.0:bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424
+- valory/task_submission_abci:0.1.0:bafybeieitcdvu4nvop6lmbwgqpluxlg42yludxl2t5ps747dy37rb5ew3y
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1441,6 +1441,10 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._invalid_request = True
             return
 
+        self.context.shared_state.setdefault(IN_MEMORY_REQUESTS, {})[
+            str(req_id)
+        ] = json.dumps(task_data)
+
         my_mech = self._get_designated_marketplace_mech_address().lower()
         exec_prio = str(executing_task.get("priorityMech", "")).lower()
         # Off-chain tasks never carry ``priorityMech`` (the field is set

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1441,9 +1441,9 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._invalid_request = True
             return
 
-        self.context.shared_state.setdefault(IN_MEMORY_REQUESTS, {})[
-            str(req_id)
-        ] = json.dumps(task_data)
+        self.context.shared_state.setdefault(IN_MEMORY_REQUESTS, {})[str(req_id)] = (
+            json.dumps(task_data)
+        )
 
         my_mech = self._get_designated_marketplace_mech_address().lower()
         exec_prio = str(executing_task.get("priorityMech", "")).lower()

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeigatm6ewxxop733etomyxei7pmfocjlbye3gk7c2jra5w5u5inira
+  behaviours.py: bafybeiamcdpje7kdfrt6piy3zfgmewm2fgxy3sf2xstsdtytvnebwbhjsq
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeigbaekfxjzhzynskbxbxyxy6p2ue6hcxcctadv44cmvag3ufs6mla
+  tests/test_behaviours.py: bafybeic4frmiuzm246vteoafrtcgvwvasoca7pkbpooesqnpwisvukukc4
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeiamcdpje7kdfrt6piy3zfgmewm2fgxy3sf2xstsdtytvnebwbhjsq
+  behaviours.py: bafybeigks53ajx5s7tptr3bdwi7p3zq3d75ctmkeiksdvkewoitxv5rfii
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeic4frmiuzm246vteoafrtcgvwvasoca7pkbpooesqnpwisvukukc4
+  tests/test_behaviours.py: bafybeiaez65jd3b5gehs6pntgi4bfwealj4uhk7fn6zzuonddrdpp3mg7m
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3125,6 +3125,52 @@ def test_handle_get_task_rejects_prompt_over_cap(
     assert mech_lookup_calls == [], "prompt cap did not gate the happy path"
 
 
+def test_handle_get_task_populates_in_memory_requests(
+    behaviour: Any, params_stub: Any, monkeypatch: Any
+) -> None:
+    """Validated IPFS content lands in ``in_memory_requests`` keyed by ``str(req_id)``.
+
+    ``_build_predict_api_event`` reads content from this cache when
+    constructing the analytics row. The off-chain path writes here from
+    ``handlers._enqueue_offchain_request``; the on-chain path must
+    write from here in ``_handle_get_task`` after content validation so
+    both paths hand real content to the analytics builder instead of
+    the ``[offchain request]`` fallback.
+    """
+    from types import SimpleNamespace as NS
+
+    my_mech = "0xmymech"
+    params_stub.mech_to_config = {
+        my_mech: NS(is_marketplace_mech=True, use_dynamic_pricing=False)
+    }
+    other_mech = "0xothermech"
+    behaviour._executing_task = {
+        "requestId": 77,
+        "priorityMech": other_mech,
+        "request_delivery_rate": 100,
+        "contract_address": "0xmech",
+    }
+    behaviour._request_handling_deadline = None
+    behaviour._invalid_request = False
+    behaviour.context.shared_state[beh_mod.IN_MEMORY_REQUESTS] = {}
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+
+    task_data = {
+        "prompt": "With the given question 'Will X happen?' and the `yes` option...",
+        "tool": "unknown_tool",
+        "nonce": "abc123",
+        "request_context": {"market_id": "0xmarket", "market_prob": "0.42"},
+    }
+    msg = SimpleNamespace(files={"task.json": json.dumps(task_data)})
+
+    behaviour._handle_get_task(msg, MagicMock())
+
+    cached = behaviour.context.shared_state[beh_mod.IN_MEMORY_REQUESTS].get("77")
+    assert cached is not None, "in_memory_requests not populated for request 77"
+    assert json.loads(cached) == task_data
+
+
 # ---------------------------------------------------------------------------
 # Payment-model request deadline
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3136,6 +3136,10 @@ def test_handle_get_task_populates_in_memory_requests(
     write from here in ``_handle_get_task`` after content validation so
     both paths hand real content to the analytics builder instead of
     the ``[offchain request]`` fallback.
+
+    :param behaviour: TaskExecutionBehaviour fixture.
+    :param params_stub: params fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
     """
     from types import SimpleNamespace as NS
 

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
+- valory/task_execution:0.1.0:bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeig3cjyihj5giza5wuxtatkywmquby3v75sbc56sti2gjlmhq3l424
+- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:


### PR DESCRIPTION
## Summary

The mech's `_build_predict_api_event` (behaviours.py:1822) reads request-side content — `prompt`, `raw_content`, `model`, `tool_params` — from `in_memory_requests`. That cache is populated at accept time by the off-chain handler (`handlers._enqueue_offchain_request:2787`). The on-chain path had no equivalent hook, so the cache lookup always returned empty for on-chain requests and the payload builder fell back to `prompt='[offchain request]'` and `raw_content={}`.

## Impact

Reproduced end-to-end against production predict-api on 2026-08-13. **100% of `source='mech_onchain'` rows carry the placeholder shape:**
- Gnosis (chain 100): 2,594 / 2,594 rows
- Polygon (chain 137): 107 / 107 rows
- Spread across every requester (many different Safes including trader agents), so it isn't a per-client issue.

Downstream: mech-analytics's ETL correctly extracts NULL for `question_title` and `market_id` from placeholder content, which cascades into the olas-website parity check failing row_parity by 1,446 rows on a 2-day recent window. The pre-cutover parity artifact ran cleanly only because the tested window predated the on-chain live poller (100% `ipfs_historical` source).

The bug has existed since the mech first started writing to predict-api (commit `06cab97d`, 2026-06-23) — this is not a regression, just an on-chain path that was never wired.

## Fix

In `_handle_get_task`, after the validated IPFS content passes the prompt-size check, write it to `in_memory_requests[str(req_id)]` in the same shape the off-chain handler already uses (JSON-encoded task metadata keyed by request_id string):

```python
self.context.shared_state.setdefault(IN_MEMORY_REQUESTS, {})[
    str(req_id)
] = json.dumps(task_data)
```

## Test plan

- [x] New unit test `test_handle_get_task_populates_in_memory_requests` — verifies content lands in the cache with the same key + shape as the off-chain writer.
- [x] Sibling `handle_get_task` tests (7 total including the new one) all pass.
- [x] `autonomy packages lock --check` clean.
- [x] `autonomy push-all` succeeded (see PR CI for the hashes).

## Rollout notes

- Fixes go-forward. Every new `mech_onchain` row after this ships will land with real content.
- Existing predict-api rows with the placeholder are not overwritten by this change. Backfilling those requires the predict-api on-chain backfill (which fetches IPFS and populates content) to run over the affected window, followed by a mech-analytics one-shot to re-extract `question_title` and `market_id` on already-scored rows. Both are separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)