### PR TITLE
fix(task_execution): put request CID on predict-api content_cid

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay",
-        "skill/valory/task_execution/0.1.0": "bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq",
+        "skill/valory/mech_abci/0.1.0": "bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere",
+        "skill/valory/task_execution/0.1.0": "bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeid7ihrotxlbbqtplxoohqmdurrc7gczw5cixafjkgaytjxztwx7im",
-        "service/valory/mech/0.1.0": "bafybeib7gux2jya6qchl2kus3zpz5vgzop5hdlccvrpirdx4lhougctuwq"
+        "agent/valory/mech/0.1.0": "bafybeifq4omhuopf3knrov3sgliuotaep35dbiglkvh5j22ogkks2gyt7y",
+        "service/valory/mech/0.1.0": "bafybeicrhegoo7ckyjq4zvlfpgzbyr6fycr6nyikpnrjtyszrmqsmcuaqy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay
+- valory/mech_abci:0.1.0:bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
-- valory/task_submission_abci:0.1.0:bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq
+- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
+- valory/task_submission_abci:0.1.0:bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeid7ihrotxlbbqtplxoohqmdurrc7gczw5cixafjkgaytjxztwx7im
+agent: valory/mech:0.1.0:bafybeifq4omhuopf3knrov3sgliuotaep35dbiglkvh5j22ogkks2gyt7y
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
-- valory/task_submission_abci:0.1.0:bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq
+- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
+- valory/task_submission_abci:0.1.0:bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -944,6 +944,14 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 )
                 self._invalid_request = True
                 return
+            try:
+                task_data["request_cid"] = to_v1(get_ipfs_file_hash(task_data["data"]))
+            except Exception as e:  # pylint: disable=W0718
+                self.context.logger.warning(
+                    f"Could not derive request CID for offchain request "
+                    f"{request_id}: {e}."
+                )
+                task_data["request_cid"] = None
             self._handle_get_task(
                 cast(Any, SimpleNamespace(files={"metadata.json": inline_payload})),
                 cast(Any, None),
@@ -959,6 +967,13 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             )
             self._invalid_request = True
             return
+        try:
+            task_data["request_cid"] = to_v1(ipfs_hash)
+        except Exception as e:  # pylint: disable=W0718
+            self.context.logger.warning(
+                f"Could not normalise request CID for request {request_id}: {e}."
+            )
+            task_data["request_cid"] = ipfs_hash
         self.context.logger.info(f"IPFS hash: {ipfs_hash}")
         ipfs_msg, message = self._build_ipfs_get_file_req(ipfs_hash)
         self.send_message(
@@ -2056,7 +2071,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "payment_type": str(executing_task.get("payment_type") or "") or None,
                 "delivery_rate": delivery_rate_str,
                 "nonce": nonce_int,
-                "content_cid": cid,
+                "content_cid": executing_task.get("request_cid") or cid,
                 "prompt": prompt,
                 "tool": tool,
                 "model": (
@@ -2098,7 +2113,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                     if isinstance(response_data, dict)
                     else {"result": result_value or "", "status": status}
                 ),
-                "response_cid": None,
+                "response_cid": cid,
                 "delivered_at": now_iso,
             },
             "source": predict_api_source,

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeigks53ajx5s7tptr3bdwi7p3zq3d75ctmkeiksdvkewoitxv5rfii
+  behaviours.py: bafybeig53gpzsxmrv66n3ypbjoipyazilmnbywdi2ql3i6pfjzbtbrpiuu
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeiaez65jd3b5gehs6pntgi4bfwealj4uhk7fn6zzuonddrdpp3mg7m
+  tests/test_behaviours.py: bafybeie7rwkuiiowlqon453bz33s5tcl4hwr4sc2kuhk7xmrfsxe5hq6g4
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1487,6 +1487,92 @@ def test_execute_task_bytes_request_id_converted(
     assert behaviour._executing_task["requestId"] == req_id_int
 
 
+def test_execute_task_onchain_stamps_request_cid_on_executing_task(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    fake_dialogue: Any,
+    monkeypatch: Any,
+    patch_ipfs_multihash: Callable,
+) -> None:
+    """On-chain ``_execute_task`` stamps the derived request CID on the executing task.
+
+    The value must be the CID the mech uses to fetch the request payload from
+    IPFS. ``_build_predict_api_event`` reads it back as the request-side
+    ``content_cid`` on the predict-api event.
+
+    :param behaviour: task_execution behaviour under test.
+    :param params_stub: params fixture — sets ``in_flight_req`` and the mech
+        contract address.
+    :param shared_state: shared_state fixture used to enqueue the pending task.
+    :param fake_dialogue: dialogue fixture consumed by the stubbed
+        ``_build_ipfs_get_file_req``.
+    :param monkeypatch: pytest monkeypatch fixture.
+    :param patch_ipfs_multihash: fixture-provided callable that stubs
+        ``get_ipfs_file_hash`` / ``to_v1`` / ``to_multihash`` to deterministic
+        values.
+    """
+    patch_ipfs_multihash(file_hash="bafyREQUESTcid")
+    params_stub.in_flight_req = False
+    task: Dict[str, Any] = {
+        "requestId": 314,
+        "request_delivery_rate": 100,
+        "data": b"raw-bytes",
+        "contract_address": "0xmech",
+    }
+    shared_state[beh_mod.PENDING_TASKS].append(task)
+    monkeypatch.setattr(
+        behaviour,
+        "_build_ipfs_get_file_req",
+        lambda h, timeout=None: (object(), fake_dialogue),
+    )
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
+    behaviour._execute_task()
+    assert behaviour._executing_task["request_cid"] == "bafyREQUESTcid"
+
+
+def test_execute_task_offchain_stamps_request_cid_on_executing_task(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    patch_ipfs_multihash: Callable,
+) -> None:
+    """Off-chain ``_execute_task`` stamps the derived request CID on the executing task.
+
+    The off-chain branch skips the IPFS round-trip and hands
+    ``_handle_get_task`` a synthetic message directly. The request CID must
+    still be derived from ``task_data["data"]`` (the bytes-decoded
+    requester-supplied ipfs_hash) before the handler runs so the downstream
+    predict-api event carries the correct value.
+
+    :param behaviour: task_execution behaviour under test.
+    :param params_stub: params fixture — sets ``in_flight_req`` and the mech
+        contract address.
+    :param shared_state: shared_state fixture used to enqueue the pending task.
+    :param monkeypatch: pytest monkeypatch fixture — stubs ``_handle_get_task``
+        so the assertion runs against the plumbing, not the handler's side
+        effects.
+    :param patch_ipfs_multihash: fixture-provided callable that stubs
+        ``get_ipfs_file_hash`` / ``to_v1`` / ``to_multihash`` to deterministic
+        values.
+    """
+    patch_ipfs_multihash(file_hash="bafyREQUESTcidOFF")
+    params_stub.in_flight_req = False
+    task: Dict[str, Any] = {
+        "requestId": 315,
+        "request_delivery_rate": 100,
+        "data": b"raw-hex-bytes",
+        "is_offchain": True,
+        "ipfs_data": json.dumps({"prompt": "p", "tool": "prediction-offline"}),
+        "contract_address": "0xmech",
+    }
+    shared_state[beh_mod.PENDING_TASKS].append(task)
+    monkeypatch.setattr(behaviour, "_handle_get_task", lambda *a, **k: None)
+    behaviour._execute_task()
+    assert behaviour._executing_task["request_cid"] == "bafyREQUESTcidOFF"
+
+
 # ---------------------------------------------------------------------------
 # _update_pending_tasks
 # ---------------------------------------------------------------------------
@@ -3708,6 +3794,83 @@ def test_build_predict_api_event_marketplace_task_falls_back_to_requester_key(
     )
     assert event["request"]["requester"] == "0xMARKETPLACE_REQUESTER"
     assert event["source"] == "mech_onchain"
+
+
+# ---------------------------------------------------------------------------
+# content_cid / response_cid semantics on _build_predict_api_event
+# ---------------------------------------------------------------------------
+#
+# Predict-api's ``mech_requests.content_cid`` is defined as the request-body
+# CID (the CID the mech fetches the request payload from), and
+# ``mech_responses.response_cid`` is the response-body CID. The builder must
+# carry them under those columns, not swap them.
+
+
+def test_build_predict_api_event_content_cid_is_request_cid_not_response_cid(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """``request.content_cid`` carries the request CID; ``response.response_cid`` carries the response CID."""
+    request_data = {
+        "prompt": "Will BTC reach $100k?",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    request_cid = "bafyREQUESTcid"
+    response_cid = "bafyRESPONSEcid"
+    executing_task["request_cid"] = request_cid
+
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid=response_cid, executing_task=executing_task
+    )
+
+    assert event["request"]["content_cid"] == request_cid
+    assert event["request"]["content_cid"] != response_cid
+    assert event["response"]["response_cid"] == response_cid
+
+
+def test_build_predict_api_event_content_cid_falls_back_to_response_cid_when_missing(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A missing ``request_cid`` on the executing_task falls back to the response CID.
+
+    The defensive fallback keeps the predict-api row schema-valid on an
+    edge-case task shape where the request CID couldn't be derived
+    (e.g. malformed on-chain ``data`` bytes surviving past the
+    ``_execute_task`` guard, or a legacy path that doesn't populate
+    ``request_cid``). The regular happy path is covered by the sibling
+    test above; this pins the fallback so a future refactor doesn't
+    silently start emitting NULL.
+
+    :param behaviour: task_execution behaviour under test.
+    :param params_stub: params fixture — consumed by
+        ``_predict_api_event_setup`` to populate ``self.params`` bits.
+    :param shared_state: shared_state fixture used by
+        ``_predict_api_event_setup`` for ``IN_MEMORY_REQUESTS`` /
+        ``OFFCHAIN_REQUEST_RESPONSES`` seeding.
+    """
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    executing_task.pop("request_cid", None)
+
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafyRESPONSEcid", executing_task=executing_task
+    )
+
+    assert event["request"]["content_cid"] == "bafyRESPONSEcid"
+    assert event["response"]["response_cid"] == "bafyRESPONSEcid"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
+- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:


### PR DESCRIPTION
## Summary

Predict-api's schema has `mech_requests.content_cid` (request-body CID) and
`mech_responses.response_cid` (response-body CID). The mech was writing the
response CID into `content_cid` and leaving `response_cid` empty on the event
payload built by `task_execution.behaviours._build_predict_api_event`. Any
future consumer that reads `mech_requests.content_cid` expecting the request
CID (the one they can `ipfs cat` to get the prompt / tool params) gets the
response CID instead — silent semantic breakage.

This fix threads the request CID from where it's already computed
(`_execute_task`) through `_executing_task["request_cid"]` and into the
event payload, and moves the response CID onto `response_cid` where the
schema puts it.

- On-chain path: request CID is `to_v1(get_ipfs_file_hash(task_data["data"]))`
  — the same value already handed to `_build_ipfs_get_file_req` to fetch the
  request body.
- Off-chain path: request CID is derived from `task_data["data"]`
  (`bytes.fromhex(ipfs_hash[2:])` set by `_enqueue_offchain_request`),
  computed just before the synthetic `_handle_get_task` call so the request
  CID is on `_executing_task` by the time `_build_predict_api_event` runs.
- `content_cid` falls back to the response `cid` when `request_cid` isn't on
  the task (edge case: malformed on-chain `data` bytes, legacy shapes). The
  fallback keeps the row schema-valid; the happy-path assertion is pinned
  by a sibling test so a future refactor can't silently start swapping the
  two CIDs again.

## Why it matters

No live consumer breaks today (predict-api hasn't wired a `content_cid`
reader yet), but the schema semantics were wrong. The
`mech-analytics` service and any downstream analytics consumer will read
`content_cid` expecting the request body CID. Fixing this at the source
now costs one small PR and one backfill; fixing after consumers wire up
is a much wider migration.

## Follow-up (out of scope)

Predict-api needs a one-liner backfill so already-written rows carry the
correct `content_cid`. That lands in the predict-api repo separately.

## Test plan

- [x] `pytest packages/valory/skills/task_execution/tests/` (509 pass, includes 4 new tests)
- [x] `pytest packages/valory/skills/task_submission_abci/tests/` (269 pass, no regressions on the sibling `_build_request_only_event`)
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint`
- [x] `tomte tox -e check-copyright`
- [x] `tomte tox -e check-packages`
- [x] `tomte tox -e check-hash` (relocked)
- [x] `tomte tox -e check-abci-docstrings -e check-abciapp-specs -e check-handlers`
- [x] `tomte tox -e check-doc-hashes -e check-dependencies -e check-third-party-hashes`
- [x] `tomte tox -e gitleaks`
- [x] `uv lock --check`

Skipped locally (network / long-running): `liccheck`, `safety`, `bandit`, `check-doc-links`. Will run in CI.

New tests added to `packages/valory/skills/task_execution/tests/test_behaviours.py`:

- `test_execute_task_onchain_stamps_request_cid_on_executing_task` — on-chain `_execute_task` writes the CID onto `task_data["request_cid"]`.
- `test_execute_task_offchain_stamps_request_cid_on_executing_task` — off-chain branch does the same before the synthetic `_handle_get_task` fires.
- `test_build_predict_api_event_content_cid_is_request_cid_not_response_cid` — happy path: `request.content_cid == request_cid`, `response.response_cid == response_cid`.
- `test_build_predict_api_event_content_cid_falls_back_to_response_cid_when_missing` — defensive fallback keeps the row valid when `request_cid` is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)