### PR TITLE
fix(task_execution): populate offchain_request_responses for on-chain deliveries

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigz52am4rop2ldj2gggcl4y2ifkamom5v6vwgj3bzg2vmmr7yq2ba",
-        "skill/valory/task_execution/0.1.0": "bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeieqhq4grhblc26jqxx5yjjzvkqshoijkdwwx7e7mxi4nfe3gsqvne",
+        "skill/valory/mech_abci/0.1.0": "bafybeiegewtgebup2ifd6mdvjolj6srr6c6irotgtkgiydachlvgw4ypv4",
+        "skill/valory/task_execution/0.1.0": "bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeigih4j4wj54s3upruv3o5htiyrx3lefyw7v4nywtjymi6oyi2b4k4",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiftqzejte3xkawxglijgzjivjqfymsvikwpahry4nualigb5ltgai",
-        "service/valory/mech/0.1.0": "bafybeibgfspwkmag2ywtr5okcpkvhzuukls6jojle6wrjl4uwidgbaomby"
+        "agent/valory/mech/0.1.0": "bafybeihr6nhuqyihxlygtzeis45trh63zfmrs7j5cw4a3di3uxwdklbr7a",
+        "service/valory/mech/0.1.0": "bafybeie34tggxvsv3wp2bfbrgobuexu5hrgb4r5euuqcaffap6qr2ik2ra"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiegewtgebup2ifd6mdvjolj6srr6c6irotgtkgiydachlvgw4ypv4",
-        "skill/valory/task_execution/0.1.0": "bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeigih4j4wj54s3upruv3o5htiyrx3lefyw7v4nywtjymi6oyi2b4k4",
+        "skill/valory/mech_abci/0.1.0": "bafybeicdlfv3fynvjff5kmabzwq6ucgimsnl5jxdwklhjgrvhdtimhcsli",
+        "skill/valory/task_execution/0.1.0": "bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeig7q5ohxcys5dga5h7njlztag5uhjtxog6yi76v2tyce6vs5nh5pa",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihr6nhuqyihxlygtzeis45trh63zfmrs7j5cw4a3di3uxwdklbr7a",
-        "service/valory/mech/0.1.0": "bafybeie34tggxvsv3wp2bfbrgobuexu5hrgb4r5euuqcaffap6qr2ik2ra"
+        "agent/valory/mech/0.1.0": "bafybeig4llycbfadwah7diw7ij3gnne73tv64sezuumrv3fs4bbkqabtuq",
+        "service/valory/mech/0.1.0": "bafybeifurqudy2uz2bndjxwaflxcvroiqytfwlnyoiis4wwv3ptuednk5a"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeihbydzovykxs5dobtkojlbf3pkknijn2hjkvpo4iem3qtv4y5bvbe",
-        "skill/valory/task_execution/0.1.0": "bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeia7vmfvpfswkf7zoqi7noqlhwr3gnlivggfdzo6ecalfnmdcbhdme",
+        "skill/valory/mech_abci/0.1.0": "bafybeigz52am4rop2ldj2gggcl4y2ifkamom5v6vwgj3bzg2vmmr7yq2ba",
+        "skill/valory/task_execution/0.1.0": "bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeieqhq4grhblc26jqxx5yjjzvkqshoijkdwwx7e7mxi4nfe3gsqvne",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeih33z2elg7jqiaigpn4wzzsk7ipv7qh3k5b35u6ybixphs7xtccxa",
-        "service/valory/mech/0.1.0": "bafybeib4mprosim3hxvcwpmd22hp6zsre6tunbxggkvj7n5fueczujsvsi"
+        "agent/valory/mech/0.1.0": "bafybeiftqzejte3xkawxglijgzjivjqfymsvikwpahry4nualigb5ltgai",
+        "service/valory/mech/0.1.0": "bafybeibgfspwkmag2ywtr5okcpkvhzuukls6jojle6wrjl4uwidgbaomby"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeicdlfv3fynvjff5kmabzwq6ucgimsnl5jxdwklhjgrvhdtimhcsli",
-        "skill/valory/task_execution/0.1.0": "bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeig7q5ohxcys5dga5h7njlztag5uhjtxog6yi76v2tyce6vs5nh5pa",
+        "skill/valory/mech_abci/0.1.0": "bafybeigkvvpevbvp5zkxmbbpgsf7o3cii6hqr5hbt2fohhqcrfextq5l3q",
+        "skill/valory/task_execution/0.1.0": "bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihph32hjedwitushmrul4cck2ggcu2qbwied4hrgovsc2al4k2yae",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeig4llycbfadwah7diw7ij3gnne73tv64sezuumrv3fs4bbkqabtuq",
-        "service/valory/mech/0.1.0": "bafybeifurqudy2uz2bndjxwaflxcvroiqytfwlnyoiis4wwv3ptuednk5a"
+        "agent/valory/mech/0.1.0": "bafybeihxqtbk56fs6hi3vulwciqqjmg7nbubd55obrkadtfkj3w7fr47wm",
+        "service/valory/mech/0.1.0": "bafybeie7oknjfsgpl4qomtx4rzdwn3hwe7i634kwuwjgawvwmttmv5qb2y"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere",
-        "skill/valory/task_execution/0.1.0": "bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu",
+        "skill/valory/mech_abci/0.1.0": "bafybeihbydzovykxs5dobtkojlbf3pkknijn2hjkvpo4iem3qtv4y5bvbe",
+        "skill/valory/task_execution/0.1.0": "bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeia7vmfvpfswkf7zoqi7noqlhwr3gnlivggfdzo6ecalfnmdcbhdme",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeifq4omhuopf3knrov3sgliuotaep35dbiglkvh5j22ogkks2gyt7y",
-        "service/valory/mech/0.1.0": "bafybeicrhegoo7ckyjq4zvlfpgzbyr6fycr6nyikpnrjtyszrmqsmcuaqy"
+        "agent/valory/mech/0.1.0": "bafybeih33z2elg7jqiaigpn4wzzsk7ipv7qh3k5b35u6ybixphs7xtccxa",
+        "service/valory/mech/0.1.0": "bafybeib4mprosim3hxvcwpmd22hp6zsre6tunbxggkvj7n5fueczujsvsi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeicdlfv3fynvjff5kmabzwq6ucgimsnl5jxdwklhjgrvhdtimhcsli
+- valory/mech_abci:0.1.0:bafybeigkvvpevbvp5zkxmbbpgsf7o3cii6hqr5hbt2fohhqcrfextq5l3q
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i
-- valory/task_submission_abci:0.1.0:bafybeig7q5ohxcys5dga5h7njlztag5uhjtxog6yi76v2tyce6vs5nh5pa
+- valory/task_execution:0.1.0:bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine
+- valory/task_submission_abci:0.1.0:bafybeihph32hjedwitushmrul4cck2ggcu2qbwied4hrgovsc2al4k2yae
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeigz52am4rop2ldj2gggcl4y2ifkamom5v6vwgj3bzg2vmmr7yq2ba
+- valory/mech_abci:0.1.0:bafybeiegewtgebup2ifd6mdvjolj6srr6c6irotgtkgiydachlvgw4ypv4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m
-- valory/task_submission_abci:0.1.0:bafybeieqhq4grhblc26jqxx5yjjzvkqshoijkdwwx7e7mxi4nfe3gsqvne
+- valory/task_execution:0.1.0:bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda
+- valory/task_submission_abci:0.1.0:bafybeigih4j4wj54s3upruv3o5htiyrx3lefyw7v4nywtjymi6oyi2b4k4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere
+- valory/mech_abci:0.1.0:bafybeihbydzovykxs5dobtkojlbf3pkknijn2hjkvpo4iem3qtv4y5bvbe
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
-- valory/task_submission_abci:0.1.0:bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu
+- valory/task_execution:0.1.0:bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty
+- valory/task_submission_abci:0.1.0:bafybeia7vmfvpfswkf7zoqi7noqlhwr3gnlivggfdzo6ecalfnmdcbhdme
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiegewtgebup2ifd6mdvjolj6srr6c6irotgtkgiydachlvgw4ypv4
+- valory/mech_abci:0.1.0:bafybeicdlfv3fynvjff5kmabzwq6ucgimsnl5jxdwklhjgrvhdtimhcsli
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda
-- valory/task_submission_abci:0.1.0:bafybeigih4j4wj54s3upruv3o5htiyrx3lefyw7v4nywtjymi6oyi2b4k4
+- valory/task_execution:0.1.0:bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i
+- valory/task_submission_abci:0.1.0:bafybeig7q5ohxcys5dga5h7njlztag5uhjtxog6yi76v2tyce6vs5nh5pa
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeihbydzovykxs5dobtkojlbf3pkknijn2hjkvpo4iem3qtv4y5bvbe
+- valory/mech_abci:0.1.0:bafybeigz52am4rop2ldj2gggcl4y2ifkamom5v6vwgj3bzg2vmmr7yq2ba
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty
-- valory/task_submission_abci:0.1.0:bafybeia7vmfvpfswkf7zoqi7noqlhwr3gnlivggfdzo6ecalfnmdcbhdme
+- valory/task_execution:0.1.0:bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m
+- valory/task_submission_abci:0.1.0:bafybeieqhq4grhblc26jqxx5yjjzvkqshoijkdwwx7e7mxi4nfe3gsqvne
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihr6nhuqyihxlygtzeis45trh63zfmrs7j5cw4a3di3uxwdklbr7a
+agent: valory/mech:0.1.0:bafybeig4llycbfadwah7diw7ij3gnne73tv64sezuumrv3fs4bbkqabtuq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeih33z2elg7jqiaigpn4wzzsk7ipv7qh3k5b35u6ybixphs7xtccxa
+agent: valory/mech:0.1.0:bafybeiftqzejte3xkawxglijgzjivjqfymsvikwpahry4nualigb5ltgai
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiftqzejte3xkawxglijgzjivjqfymsvikwpahry4nualigb5ltgai
+agent: valory/mech:0.1.0:bafybeihr6nhuqyihxlygtzeis45trh63zfmrs7j5cw4a3di3uxwdklbr7a
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeifq4omhuopf3knrov3sgliuotaep35dbiglkvh5j22ogkks2gyt7y
+agent: valory/mech:0.1.0:bafybeih33z2elg7jqiaigpn4wzzsk7ipv7qh3k5b35u6ybixphs7xtccxa
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeig4llycbfadwah7diw7ij3gnne73tv64sezuumrv3fs4bbkqabtuq
+agent: valory/mech:0.1.0:bafybeihxqtbk56fs6hi3vulwciqqjmg7nbubd55obrkadtfkj3w7fr47wm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty
-- valory/task_submission_abci:0.1.0:bafybeia7vmfvpfswkf7zoqi7noqlhwr3gnlivggfdzo6ecalfnmdcbhdme
+- valory/task_execution:0.1.0:bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m
+- valory/task_submission_abci:0.1.0:bafybeieqhq4grhblc26jqxx5yjjzvkqshoijkdwwx7e7mxi4nfe3gsqvne
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m
-- valory/task_submission_abci:0.1.0:bafybeieqhq4grhblc26jqxx5yjjzvkqshoijkdwwx7e7mxi4nfe3gsqvne
+- valory/task_execution:0.1.0:bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda
+- valory/task_submission_abci:0.1.0:bafybeigih4j4wj54s3upruv3o5htiyrx3lefyw7v4nywtjymi6oyi2b4k4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i
-- valory/task_submission_abci:0.1.0:bafybeig7q5ohxcys5dga5h7njlztag5uhjtxog6yi76v2tyce6vs5nh5pa
+- valory/task_execution:0.1.0:bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine
+- valory/task_submission_abci:0.1.0:bafybeihph32hjedwitushmrul4cck2ggcu2qbwied4hrgovsc2al4k2yae
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
-- valory/task_submission_abci:0.1.0:bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu
+- valory/task_execution:0.1.0:bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty
+- valory/task_submission_abci:0.1.0:bafybeia7vmfvpfswkf7zoqi7noqlhwr3gnlivggfdzo6ecalfnmdcbhdme
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda
-- valory/task_submission_abci:0.1.0:bafybeigih4j4wj54s3upruv3o5htiyrx3lefyw7v4nywtjymi6oyi2b4k4
+- valory/task_execution:0.1.0:bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i
+- valory/task_submission_abci:0.1.0:bafybeig7q5ohxcys5dga5h7njlztag5uhjtxog6yi76v2tyce6vs5nh5pa
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -19,6 +19,7 @@
 
 """This package contains the implementation of ."""
 
+import functools
 import json
 import threading
 import time
@@ -1284,12 +1285,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._finalize_done_task(local_cid)
             return
 
-        self._done_task["_pending_response"] = response
-
         msg, dialogue = self._build_ipfs_store_file_req(
             {str(req_id): json.dumps(response)}
         )
-        self.send_message(msg, dialogue, self._handle_store_response)
+        callback = functools.partial(self._handle_store_response, response=response)
+        self.send_message(msg, dialogue, callback)
 
     def _restart_executor(self) -> None:
         """Restarts the executor."""
@@ -1673,7 +1673,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         )
         return message, dialogue
 
-    def _handle_store_response(self, message: IpfsMessage, dialogue: Dialogue) -> None:
+    def _handle_store_response(
+        self,
+        message: IpfsMessage,
+        dialogue: Dialogue,
+        response: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Handle the response from ipfs for a store response request."""
         if not self._executing_task:
             self.context.logger.error(
@@ -1686,18 +1691,20 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         self.context.logger.info(
             f"Response for request {req_id} stored on IPFS with hash {ipfs_hash}."
         )
-        done_task = self._done_task if isinstance(self._done_task, dict) else {}
-        pending_response = done_task.get("_pending_response")
-        if pending_response is not None:
-            request_id_str = str(req_id)
-            self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
-                request_id_str
-            ] = {
-                "request_id": request_id_str,
-                "status": "ok",
-                "content_cid": ipfs_hash,
-                "response": pending_response,
-            }
+        if response is not None and self.params.use_offchain:
+            mech_address = self._get_designated_marketplace_mech_address()
+            mech_config = self.params.mech_to_config.get(mech_address.lower())
+            if mech_config is not None and mech_config.is_marketplace_mech:
+                request_id_str = str(req_id)
+                envelope_status = "rejected" if self._invalid_request else "ok"
+                self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
+                    request_id_str
+                ] = {
+                    "request_id": request_id_str,
+                    "status": envelope_status,
+                    "content_cid": ipfs_hash,
+                    "response": response,
+                }
         self._finalize_done_task(ipfs_hash)
 
     def _finalize_done_task(self, cid: str) -> None:
@@ -1799,8 +1806,6 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 self.context.shared_state.get(OFFCHAIN_REQUEST_RESPONSES, {}).pop(
                     str(req_id), None
                 )
-        # Ephemeral field for the IPFS callback; keep it out of consensus.
-        done_task.pop("_pending_response", None)
         # add to done tasks, in thread safe way
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)
@@ -1898,11 +1903,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # forcing every completed task to be tagged ``status="failed"`` in
         # the analytics row.
         # ``OFFCHAIN_REQUEST_RESPONSES`` is written under ``str(req_id)`` by
-        # ``_handle_done_task`` and ``_record_offchain_failure``; ``req_id``
-        # is ``int`` for off-chain tasks post-ingress coercion. Read with the
-        # ``str`` key too or the analytics row is tagged ``status="failed"``
-        # for every successful off-chain delivery, silently, because the
-        # poller sees the right answer but the lake row does not.
+        # ``_handle_done_task`` (off-chain), ``_handle_store_response`` (on-chain,
+        # after the IPFS CID lands) and ``_record_offchain_failure``. ``req_id``
+        # is ``int`` for off-chain tasks post-ingress coercion, so the lookup
+        # goes through ``str`` too — otherwise every successful off-chain
+        # delivery tags the analytics row ``status="failed"`` silently, since
+        # the poller sees the right answer but the lake row does not.
         response_envelope_raw = self.context.shared_state.get(
             OFFCHAIN_REQUEST_RESPONSES, {}
         ).get(request_id_str, {})

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -88,8 +88,9 @@ LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
 # Shared-state keys owned by the MechHttpHandler (handlers.py); mirrored here
-# because the finalize path writes response envelopes for both off-chain
-# and on-chain deliveries from the behaviour side.
+# because the off-chain finalize path writes the response envelope for the
+# ``/fetch_offchain_info`` polling endpoint and clears the buffered request
+# metadata from the behaviour side.
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
 IN_MEMORY_REQUESTS = "in_memory_requests"
 # Shared-state keys owned by the MechHttpHandler; mirrored here because
@@ -1282,13 +1283,15 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 local_cid,
                 preimage_buffer.STATUS_DELIVERED,
             )
-            self._finalize_done_task(local_cid)
+            self._finalize_done_task(local_cid, response=response)
             return
 
         msg, dialogue = self._build_ipfs_store_file_req(
             {str(req_id): json.dumps(response)}
         )
-        callback = functools.partial(self._handle_store_response, response=response)
+        callback = functools.partial(
+            self._handle_store_response, response=response, req_id=req_id
+        )
         self.send_message(msg, dialogue, callback)
 
     def _restart_executor(self) -> None:
@@ -1678,6 +1681,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         message: IpfsMessage,
         dialogue: Dialogue,
         response: Optional[Dict[str, Any]] = None,
+        req_id: Any = None,
     ) -> None:
         """Handle the response from ipfs for a store response request."""
         if not self._executing_task:
@@ -1686,28 +1690,28 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             )
             return
 
-        ipfs_hash = to_v1(message.ipfs_hash)
-        req_id = self._executing_task["requestId"]
-        self.context.logger.info(
-            f"Response for request {req_id} stored on IPFS with hash {ipfs_hash}."
-        )
-        if response is not None and self.params.use_offchain:
-            mech_address = self._get_designated_marketplace_mech_address()
-            mech_config = self.params.mech_to_config.get(mech_address.lower())
-            if mech_config is not None and mech_config.is_marketplace_mech:
-                request_id_str = str(req_id)
-                envelope_status = "rejected" if self._invalid_request else "ok"
-                self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
-                    request_id_str
-                ] = {
-                    "request_id": request_id_str,
-                    "status": envelope_status,
-                    "content_cid": ipfs_hash,
-                    "response": response,
-                }
-        self._finalize_done_task(ipfs_hash)
+        live_req_id = self._executing_task["requestId"]
+        if req_id is not None and live_req_id != req_id:
+            # Stale callback from a previously-executed task that has since been
+            # timed out or swapped out. Dropping it prevents cross-task
+            # misattribution of the response and the CID.
+            self.context.logger.warning(
+                "Discarding stale IPFS store callback for request %s; "
+                "current executing task is %s.",
+                req_id,
+                live_req_id,
+            )
+            return
 
-    def _finalize_done_task(self, cid: str) -> None:
+        ipfs_hash = to_v1(message.ipfs_hash)
+        self.context.logger.info(
+            f"Response for request {live_req_id} stored on IPFS with hash {ipfs_hash}."
+        )
+        self._finalize_done_task(ipfs_hash, response=response)
+
+    def _finalize_done_task(
+        self, cid: str, response: Optional[Dict[str, Any]] = None
+    ) -> None:
         """Apply the CID to the in-flight done_task and publish it.
 
         Shared by the on-chain path (CID from a real IPFS store response) and the
@@ -1719,6 +1723,9 @@ class TaskExecutionBehaviour(SimpleBehaviour):
 
         :param cid: the multibase-encoded CIDv1 to record on chain via
             ``task_result``.
+        :param response: the tool response envelope the predict-api event builder
+            needs. Both call sites pass this in so the value flows down the
+            synchronous stack rather than round-tripping through ``shared_state``.
         """
         executing_task = self._executing_task
         if executing_task is None:
@@ -1798,14 +1805,8 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 done_task=done_task,
                 cid=cid,
                 executing_task=cast(Dict[str, Any], executing_task),
+                response=response,
             )
-            if not is_offchain:
-                # Off-chain envelopes are retained for the polling endpoint
-                # (pruned on same-id re-request in handlers.py); on-chain
-                # envelopes have no equivalent lifecycle and must be pruned here.
-                self.context.shared_state.get(OFFCHAIN_REQUEST_RESPONSES, {}).pop(
-                    str(req_id), None
-                )
         # add to done tasks, in thread safe way
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)
@@ -1831,20 +1832,21 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         done_task: Dict[str, Any],
         cid: str,
         executing_task: Dict[str, Any],
+        response: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build the structured predict-api event payload from on-hand data.
 
         The post-settlement behaviour batches every event from one FSM round
         into a single signed POST to the predict-api data lake. Fields are
         populated best-effort from the buffered request metadata
-        (``IN_MEMORY_REQUESTS``), the offchain response
-        (``OFFCHAIN_REQUEST_RESPONSES``), the in-flight ``executing_task``,
-        and skill params. Optional fields that aren't readily available are
-        left ``None``; the predict-api server accepts a NULL there. Required
-        fields default to safe placeholders rather than blocking the row: a
-        malformed event surfaces as a 422 when the predict-api write fires (and
-        lands in the local replay buffer so it's recoverable), which is
-        preferable to silently dropping analytics data.
+        (``IN_MEMORY_REQUESTS``), the tool ``response`` dict threaded down
+        from the caller, the in-flight ``executing_task``, and skill params.
+        Optional fields that aren't readily available are left ``None``; the
+        predict-api server accepts a NULL there. Required fields default to
+        safe placeholders rather than blocking the row: a malformed event
+        surfaces as a 422 when the predict-api write fires (and lands in the
+        local replay buffer so it's recoverable), which is preferable to
+        silently dropping analytics data.
 
         Datetimes are emitted as ISO 8601 strings with UTC offset so the
         predict-api ``AwareDatetime`` parser accepts them; mech ints (Unix
@@ -1855,6 +1857,12 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         :param done_task: the done-task dict appended to ``done_tasks``.
         :param cid: the locally-computed multibase CIDv1 for the response.
         :param executing_task: the original request dict from the handler.
+        :param response: the tool response envelope threaded from the caller;
+            carries ``result``, ``executed_at``, ``metadata`` and ``cost_dict``
+            for the current task. Kept as a parameter so the value flows down
+            the synchronous stack instead of round-tripping through
+            ``shared_state``, which would otherwise open a stale-callback
+            misattribution window.
         :return: a ``MechSettlementEvent``-shaped dict ready for FSM consensus
             replication and downstream signing in the post-tx behaviour.
         """
@@ -1895,28 +1903,11 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             request_data = request_data_raw
         else:
             request_data = {}
-        # OFFCHAIN_REQUEST_RESPONSES stores an envelope
-        # ``{"request_id":..., "status":"ok", "content_cid":..., "response":<inner>}``;
-        # the tool's actual ``result`` / ``executed_at`` live on the inner
-        # ``response`` dict, not on the envelope. Reading the envelope
-        # directly (the original code) returned ``None`` for both fields,
-        # forcing every completed task to be tagged ``status="failed"`` in
-        # the analytics row.
-        # ``OFFCHAIN_REQUEST_RESPONSES`` is written under ``str(req_id)`` by
-        # ``_handle_done_task`` (off-chain), ``_handle_store_response`` (on-chain,
-        # after the IPFS CID lands) and ``_record_offchain_failure``. ``req_id``
-        # is ``int`` for off-chain tasks post-ingress coercion, so the lookup
-        # goes through ``str`` too — otherwise every successful off-chain
-        # delivery tags the analytics row ``status="failed"`` silently, since
-        # the poller sees the right answer but the lake row does not.
-        response_envelope_raw = self.context.shared_state.get(
-            OFFCHAIN_REQUEST_RESPONSES, {}
-        ).get(request_id_str, {})
-        response_envelope = (
-            response_envelope_raw if isinstance(response_envelope_raw, dict) else {}
-        )
-        inner_response = response_envelope.get("response", {})
-        response_data = inner_response if isinstance(inner_response, dict) else {}
+        # ``response`` is threaded from the caller (both off-chain and on-chain
+        # finalize paths pass it in). Keeping the read local avoids the
+        # stale-callback / cross-task misattribution window that a round-trip
+        # through ``shared_state`` would open.
+        response_data = response if isinstance(response, dict) else {}
         tool = str(done_task.get("tool") or "unknown")
         delivery_mech = str(
             done_task.get("mech_address") or self.params.mech_marketplace_address or ""

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1284,6 +1284,14 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._finalize_done_task(local_cid)
             return
 
+        request_id_str = str(req_id)
+        self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
+            request_id_str
+        ] = {
+            "request_id": request_id_str,
+            "response": response,
+        }
+
         msg, dialogue = self._build_ipfs_store_file_req(
             {str(req_id): json.dumps(response)}
         )

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -87,8 +87,8 @@ LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
 # Shared-state keys owned by the MechHttpHandler (handlers.py); mirrored here
-# because the off-chain finalize path writes the rejection signal and clears the
-# buffered request metadata from the behaviour side.
+# because the finalize path writes response envelopes for both off-chain
+# and on-chain deliveries from the behaviour side.
 OFFCHAIN_REQUEST_RESPONSES = "offchain_request_responses"
 IN_MEMORY_REQUESTS = "in_memory_requests"
 # Shared-state keys owned by the MechHttpHandler; mirrored here because
@@ -1284,13 +1284,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             self._finalize_done_task(local_cid)
             return
 
-        request_id_str = str(req_id)
-        self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
-            request_id_str
-        ] = {
-            "request_id": request_id_str,
-            "response": response,
-        }
+        self._done_task["_pending_response"] = response
 
         msg, dialogue = self._build_ipfs_store_file_req(
             {str(req_id): json.dumps(response)}
@@ -1692,6 +1686,18 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         self.context.logger.info(
             f"Response for request {req_id} stored on IPFS with hash {ipfs_hash}."
         )
+        done_task = self._done_task if isinstance(self._done_task, dict) else {}
+        pending_response = done_task.get("_pending_response")
+        if pending_response is not None:
+            request_id_str = str(req_id)
+            self.context.shared_state.setdefault(OFFCHAIN_REQUEST_RESPONSES, {})[
+                request_id_str
+            ] = {
+                "request_id": request_id_str,
+                "status": "ok",
+                "content_cid": ipfs_hash,
+                "response": pending_response,
+            }
         self._finalize_done_task(ipfs_hash)
 
     def _finalize_done_task(self, cid: str) -> None:
@@ -1786,6 +1792,15 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 cid=cid,
                 executing_task=cast(Dict[str, Any], executing_task),
             )
+            if not is_offchain:
+                # Off-chain envelopes are retained for the polling endpoint
+                # (pruned on same-id re-request in handlers.py); on-chain
+                # envelopes have no equivalent lifecycle and must be pruned here.
+                self.context.shared_state.get(OFFCHAIN_REQUEST_RESPONSES, {}).pop(
+                    str(req_id), None
+                )
+        # Ephemeral field for the IPFS callback; keep it out of consensus.
+        done_task.pop("_pending_response", None)
         # add to done tasks, in thread safe way
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeibrivjks4rldf6mcacmi6cdqgha4fvnjddvh2kp3qpugk6a4fjona
+  behaviours.py: bafybeiaklidr7pfjcnge4aqmckjze4fc27tgns2pfrlb2sfigk6ftwsuym
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeiayqi5zwhnvagzkfjasoimna4dgvkwk7laaf32h76jyqfhhflmmaq
+  tests/test_behaviours.py: bafybeigqj5xszngfz4u2c45gmnnkzcwro727h63llpkt6yuspfmbrqu5ne
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeig53gpzsxmrv66n3ypbjoipyazilmnbywdi2ql3i6pfjzbtbrpiuu
+  behaviours.py: bafybeibrivjks4rldf6mcacmi6cdqgha4fvnjddvh2kp3qpugk6a4fjona
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeie7rwkuiiowlqon453bz33s5tcl4hwr4sc2kuhk7xmrfsxe5hq6g4
+  tests/test_behaviours.py: bafybeieosvio3rvivxz64xw6fcunmwzrtpkzam4paxvsxct44ekdt3upee
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeieosvio3rvivxz64xw6fcunmwzrtpkzam4paxvsxct44ekdt3upee
+  tests/test_behaviours.py: bafybeiayqi5zwhnvagzkfjasoimna4dgvkwk7laaf32h76jyqfhhflmmaq
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeic4zzepcje6yblxnuzw2og2brkygkblbjetlrfpz5rkpbel2tgwiu
+  behaviours.py: bafybeieq3zs6a2aa53tvkdsq6w7gt4flpratl7nlnsf2vivvj4tnuoikgy
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeif6oyrdasdtasnklyv47jj5pywmnb5bp6ex7lgfxaid5z6uxnvmoa
+  tests/test_behaviours.py: bafybeibapapa2cbfzkh7cgco7tsnu3tghpdd55klwto6jplb627jnsrwqa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeiaklidr7pfjcnge4aqmckjze4fc27tgns2pfrlb2sfigk6ftwsuym
+  behaviours.py: bafybeic4zzepcje6yblxnuzw2og2brkygkblbjetlrfpz5rkpbel2tgwiu
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeigqj5xszngfz4u2c45gmnnkzcwro727h63llpkt6yuspfmbrqu5ne
+  tests/test_behaviours.py: bafybeif6oyrdasdtasnklyv47jj5pywmnb5bp6ex7lgfxaid5z6uxnvmoa
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1932,6 +1932,65 @@ def test_handle_done_task_onchain_still_uploads_to_ipfs(
     assert shared_state[beh_mod.DONE_TASKS] == []
 
 
+def test_handle_done_task_onchain_stores_response_envelope_in_shared_state(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+) -> None:
+    """On-chain success writes the response envelope under ``str(req_id)`` so
+    the same shared-state slot is populated regardless of delivery path."""
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=12)
+
+    monkeypatch.setattr(
+        behaviour,
+        "_build_ipfs_store_file_req",
+        lambda files, **k: (object(), fake_dialogue),
+    )
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=_make_success_result())
+
+    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["12"]
+    assert stored["request_id"] == "12"
+    assert stored["response"]["result"] == "prediction: yes"
+
+
+def test_handle_done_task_onchain_invalid_request_stores_reason_in_shared_state(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+) -> None:
+    """On-chain invalid-request path stores the failure reason under
+    ``response["result"]`` so the shared-state envelope has parity with the
+    success shape."""
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=13)
+    behaviour._invalid_request = True
+    behaviour._ipfs_error_reason = "tool boom"
+
+    monkeypatch.setattr(
+        behaviour,
+        "_build_ipfs_store_file_req",
+        lambda files, **k: (object(), fake_dialogue),
+    )
+    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
+    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
+    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+
+    behaviour._handle_done_task(task_result=None)
+
+    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["13"]
+    assert stored["request_id"] == "13"
+    assert stored["response"]["result"] == "tool boom"
+
+
 # ---------------------------------------------------------------------------
 # _handle_store_response branches
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -19,6 +19,7 @@
 
 """This package contains the tests for the behaviours."""
 
+import functools
 import json
 import re
 import time
@@ -31,6 +32,17 @@ import pytest
 from prometheus_client import REGISTRY
 
 import packages.valory.skills.task_execution.behaviours as beh_mod
+
+
+def _dispatch_target(cb: Any) -> Any:
+    """Return the underlying ``__func__`` a send_message callback (bare or partial) targets.
+
+    :param cb: a bound method or a ``functools.partial`` wrapping one.
+    :return: the callback's ``__func__`` for identity comparison in stubs.
+    """
+    if isinstance(cb, functools.partial):
+        cb = cb.func
+    return getattr(cb, "__func__", cb)
 
 
 def clear_registry() -> None:
@@ -296,7 +308,7 @@ def test_broken_process_pool_restart(
     def send_message_stub(
         msg: Any, dlg: Any, cb: Callable[[Any, Any], None], error_cb: Any = None
     ) -> None:
-        func = getattr(cb, "__func__", cb)
+        func = _dispatch_target(cb)
         if func is beh_mod.TaskExecutionBehaviour._handle_get_task:
             body: Dict[str, Any] = {"prompt": "p", "tool": "sum"}
             cb(SimpleNamespace(files={"task.json": json.dumps(body)}), dlg)
@@ -382,7 +394,7 @@ def test_invalid_tool_is_recorded_and_no_execution(
         :param error_cb: Optional error callback for IPFS failures.
         :type error_cb: Any
         """
-        func = getattr(cb, "__func__", cb)
+        func = _dispatch_target(cb)
         if func is beh_mod.TaskExecutionBehaviour._handle_get_task:
             cb(
                 SimpleNamespace(
@@ -929,7 +941,7 @@ def test_ipfs_error_does_not_cascade_to_next_task(
     ) -> None:
         """First task: IPFS error. Second task: success. STORE always succeeds."""
         task_num["n"] += 1
-        func = getattr(callback, "__func__", callback)
+        func = _dispatch_target(callback)
         if func is beh_mod.TaskExecutionBehaviour._handle_get_task:
             if task_num["n"] == 1:
                 # Task 100: IPFS download fails
@@ -1925,9 +1937,11 @@ def test_handle_done_task_onchain_still_uploads_to_ipfs(
     behaviour._handle_done_task(task_result=None)
 
     assert len(send_calls) == 1
-    # IPFS callback is the existing store-response handler, not the local path.
-    # Bound methods compare unequal across access, so check by name.
-    assert send_calls[0][2].__func__ is behaviour._handle_store_response.__func__
+    # IPFS callback is the existing store-response handler, wrapped in a
+    # functools.partial so the response dict can be threaded through.
+    assert (
+        _dispatch_target(send_calls[0][2]) is behaviour._handle_store_response.__func__
+    )
     # The IPFS path defers finalization to the callback; done_tasks empty for now.
     assert shared_state[beh_mod.DONE_TASKS] == []
 
@@ -1937,9 +1951,11 @@ def test_handle_done_task_onchain_still_uploads_to_ipfs(
         "invalid",
         "task_result_factory",
         "ipfs_error_reason",
-        "expected_result",
-        "expected_status",
-        "expected_error",
+        "expected_envelope_result",
+        "expected_envelope_status",
+        "expected_event_result",
+        "expected_event_status",
+        "expected_event_error",
     ),
     [
         (
@@ -1947,10 +1963,21 @@ def test_handle_done_task_onchain_still_uploads_to_ipfs(
             lambda: _make_success_result(),
             None,
             "prediction: yes",
+            "ok",
+            "prediction: yes",
             "complete",
             None,
         ),
-        (True, lambda: None, "tool boom", None, "failed", "tool boom"),
+        (
+            True,
+            lambda: None,
+            "tool boom",
+            "tool boom",
+            "rejected",
+            None,
+            "failed",
+            "tool boom",
+        ),
     ],
     ids=["success", "invalid_request_failure"],
 )
@@ -1963,9 +1990,11 @@ def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
     invalid: bool,
     task_result_factory: Any,
     ipfs_error_reason: Any,
-    expected_result: Any,
-    expected_status: str,
-    expected_error: Any,
+    expected_envelope_result: Any,
+    expected_envelope_status: str,
+    expected_event_result: Any,
+    expected_event_status: str,
+    expected_event_error: Any,
 ) -> None:
     """On-chain finalize propagates the tool result through shared-state into the predict-api event."""
     req_id = 12
@@ -1973,28 +2002,54 @@ def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
     behaviour._invalid_request = invalid
     behaviour._ipfs_error_reason = ipfs_error_reason
 
+    captured_callback: list = []
     monkeypatch.setattr(
         behaviour,
         "_build_ipfs_store_file_req",
         lambda files, **k: (object(), fake_dialogue),
     )
-    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
+    monkeypatch.setattr(
+        behaviour,
+        "send_message",
+        lambda msg, dlg, cb, **k: captured_callback.append(cb),
+    )
     monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
     monkeypatch.setattr(beh_mod, "to_v1", lambda x: x)
 
+    captured_envelope: dict = {}
+    original_finalize = behaviour._finalize_done_task
+
+    def spy_finalize(cid: str) -> None:
+        envelope = (
+            shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
+            .get(str(req_id), {})
+            .copy()
+        )
+        captured_envelope.update(envelope)
+        original_finalize(cid)
+
+    monkeypatch.setattr(behaviour, "_finalize_done_task", spy_finalize)
+
     behaviour._handle_done_task(task_result=task_result_factory())
-    behaviour._handle_store_response(
-        SimpleNamespace(ipfs_hash="bafyfakecid"), MagicMock()
-    )
+
+    assert len(captured_callback) == 1
+    captured_callback[0](SimpleNamespace(ipfs_hash="bafyfakecid"), MagicMock())
+
+    assert captured_envelope["request_id"] == str(req_id)
+    assert captured_envelope["status"] == expected_envelope_status
+    assert captured_envelope["content_cid"] == "bafyfakecid"
+    assert captured_envelope["response"]["result"] == expected_envelope_result
 
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
-    event = done_tasks[0]["predict_api_event"]
-    assert event["response"]["result"] == expected_result
-    assert event["response"]["status"] == expected_status
-    assert event["response"]["error"] == expected_error
+    done_task = done_tasks[0]
+    event = done_task["predict_api_event"]
+    assert event["response"]["result"] == expected_event_result
+    assert event["response"]["status"] == expected_event_status
+    assert event["response"]["error"] == expected_event_error
+    assert "_pending_response" not in done_task
 
     assert str(req_id) not in shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
 

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1932,15 +1932,46 @@ def test_handle_done_task_onchain_still_uploads_to_ipfs(
     assert shared_state[beh_mod.DONE_TASKS] == []
 
 
-def test_handle_done_task_onchain_stores_response_envelope_in_shared_state(
+@pytest.mark.parametrize(
+    (
+        "invalid",
+        "task_result_factory",
+        "ipfs_error_reason",
+        "expected_result",
+        "expected_status",
+        "expected_error",
+    ),
+    [
+        (
+            False,
+            lambda: _make_success_result(),
+            None,
+            "prediction: yes",
+            "complete",
+            None,
+        ),
+        (True, lambda: None, "tool boom", None, "failed", "tool boom"),
+    ],
+    ids=["success", "invalid_request_failure"],
+)
+def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
     behaviour: Any,
     params_stub: Any,
     shared_state: Dict[str, Any],
     monkeypatch: Any,
     fake_dialogue: Any,
+    invalid: bool,
+    task_result_factory: Any,
+    ipfs_error_reason: Any,
+    expected_result: Any,
+    expected_status: str,
+    expected_error: Any,
 ) -> None:
-    """On-chain success populates OFFCHAIN_REQUEST_RESPONSES with the response envelope."""
-    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=12)
+    """On-chain finalize propagates the tool result through shared-state into the predict-api event."""
+    req_id = 12
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=req_id)
+    behaviour._invalid_request = invalid
+    behaviour._ipfs_error_reason = ipfs_error_reason
 
     monkeypatch.setattr(
         behaviour,
@@ -1951,41 +1982,21 @@ def test_handle_done_task_onchain_stores_response_envelope_in_shared_state(
     monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
+    monkeypatch.setattr(beh_mod, "to_v1", lambda x: x)
 
-    behaviour._handle_done_task(task_result=_make_success_result())
-
-    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["12"]
-    assert stored["request_id"] == "12"
-    assert stored["response"]["result"] == "prediction: yes"
-
-
-def test_handle_done_task_onchain_invalid_request_stores_reason_in_shared_state(
-    behaviour: Any,
-    params_stub: Any,
-    shared_state: Dict[str, Any],
-    monkeypatch: Any,
-    fake_dialogue: Any,
-) -> None:
-    """On-chain invalid-request populates OFFCHAIN_REQUEST_RESPONSES with the failure reason."""
-    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=13)
-    behaviour._invalid_request = True
-    behaviour._ipfs_error_reason = "tool boom"
-
-    monkeypatch.setattr(
-        behaviour,
-        "_build_ipfs_store_file_req",
-        lambda files, **k: (object(), fake_dialogue),
+    behaviour._handle_done_task(task_result=task_result_factory())
+    behaviour._handle_store_response(
+        SimpleNamespace(ipfs_hash="bafyfakecid"), MagicMock()
     )
-    monkeypatch.setattr(behaviour, "send_message", lambda *a, **k: None)
-    monkeypatch.setattr(behaviour.mech_metrics, "set_gauge", MagicMock())
-    monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
-    monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
 
-    behaviour._handle_done_task(task_result=None)
+    done_tasks = shared_state[beh_mod.DONE_TASKS]
+    assert len(done_tasks) == 1
+    event = done_tasks[0]["predict_api_event"]
+    assert event["response"]["result"] == expected_result
+    assert event["response"]["status"] == expected_status
+    assert event["response"]["error"] == expected_error
 
-    stored = shared_state[beh_mod.OFFCHAIN_REQUEST_RESPONSES]["13"]
-    assert stored["request_id"] == "13"
-    assert stored["response"]["result"] == "tool boom"
+    assert str(req_id) not in shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1939,8 +1939,7 @@ def test_handle_done_task_onchain_stores_response_envelope_in_shared_state(
     monkeypatch: Any,
     fake_dialogue: Any,
 ) -> None:
-    """On-chain success writes the response envelope under ``str(req_id)`` so
-    the same shared-state slot is populated regardless of delivery path."""
+    """On-chain success populates OFFCHAIN_REQUEST_RESPONSES with the response envelope."""
     _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=12)
 
     monkeypatch.setattr(
@@ -1967,9 +1966,7 @@ def test_handle_done_task_onchain_invalid_request_stores_reason_in_shared_state(
     monkeypatch: Any,
     fake_dialogue: Any,
 ) -> None:
-    """On-chain invalid-request path stores the failure reason under
-    ``response["result"]`` so the shared-state envelope has parity with the
-    success shape."""
+    """On-chain invalid-request populates OFFCHAIN_REQUEST_RESPONSES with the failure reason."""
     _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=13)
     behaviour._invalid_request = True
     behaviour._ipfs_error_reason = "tool boom"

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1946,62 +1946,18 @@ def test_handle_done_task_onchain_still_uploads_to_ipfs(
     assert shared_state[beh_mod.DONE_TASKS] == []
 
 
-@pytest.mark.parametrize(
-    (
-        "invalid",
-        "task_result_factory",
-        "ipfs_error_reason",
-        "expected_envelope_result",
-        "expected_envelope_status",
-        "expected_event_result",
-        "expected_event_status",
-        "expected_event_error",
-    ),
-    [
-        (
-            False,
-            lambda: _make_success_result(),
-            None,
-            "prediction: yes",
-            "ok",
-            "prediction: yes",
-            "complete",
-            None,
-        ),
-        (
-            True,
-            lambda: None,
-            "tool boom",
-            "tool boom",
-            "rejected",
-            None,
-            "failed",
-            "tool boom",
-        ),
-    ],
-    ids=["success", "invalid_request_failure"],
-)
-def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
+def _onchain_e2e_setup(
     behaviour: Any,
-    params_stub: Any,
-    shared_state: Dict[str, Any],
     monkeypatch: Any,
     fake_dialogue: Any,
-    invalid: bool,
-    task_result_factory: Any,
-    ipfs_error_reason: Any,
-    expected_envelope_result: Any,
-    expected_envelope_status: str,
-    expected_event_result: Any,
-    expected_event_status: str,
-    expected_event_error: Any,
-) -> None:
-    """On-chain finalize propagates the tool result through shared-state into the predict-api event."""
-    req_id = 12
-    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=req_id)
-    behaviour._invalid_request = invalid
-    behaviour._ipfs_error_reason = ipfs_error_reason
+) -> list:
+    """Common send_message / metrics / to_v1 monkeypatches for the on-chain E2E tests.
 
+    :param behaviour: the TaskExecutionBehaviour instance under test.
+    :param monkeypatch: pytest monkeypatch fixture.
+    :param fake_dialogue: fake IPFS dialogue for the store request.
+    :return: a list the send_message stub appends captured callbacks into.
+    """
     captured_callback: list = []
     monkeypatch.setattr(
         behaviour,
@@ -2017,41 +1973,140 @@ def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
     monkeypatch.setattr(behaviour.mech_metrics, "inc_counter", MagicMock())
     monkeypatch.setattr(behaviour.mech_metrics, "observe_histogram", MagicMock())
     monkeypatch.setattr(beh_mod, "to_v1", lambda x: x)
+    return captured_callback
 
-    captured_envelope: dict = {}
-    original_finalize = behaviour._finalize_done_task
 
-    def spy_finalize(cid: str) -> None:
-        envelope = (
-            shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
-            .get(str(req_id), {})
-            .copy()
-        )
-        captured_envelope.update(envelope)
-        original_finalize(cid)
+@pytest.mark.parametrize(
+    (
+        "invalid",
+        "task_result_factory",
+        "ipfs_error_reason",
+        "expected_event_result",
+        "expected_event_status",
+        "expected_event_error",
+    ),
+    [
+        (
+            False,
+            lambda: _make_success_result(),
+            None,
+            "prediction: yes",
+            "complete",
+            None,
+        ),
+        (True, lambda: None, "tool boom", None, "failed", "tool boom"),
+    ],
+    ids=["success", "invalid_request_failure"],
+)
+def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+    invalid: bool,
+    task_result_factory: Any,
+    ipfs_error_reason: Any,
+    expected_event_result: Any,
+    expected_event_status: str,
+    expected_event_error: Any,
+) -> None:
+    """On-chain finalize threads the tool response into the predict-api event without touching shared-state."""
+    req_id = 12
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=req_id)
+    behaviour._invalid_request = invalid
+    behaviour._ipfs_error_reason = ipfs_error_reason
 
-    monkeypatch.setattr(behaviour, "_finalize_done_task", spy_finalize)
+    captured_callback = _onchain_e2e_setup(behaviour, monkeypatch, fake_dialogue)
 
     behaviour._handle_done_task(task_result=task_result_factory())
 
     assert len(captured_callback) == 1
     captured_callback[0](SimpleNamespace(ipfs_hash="bafyfakecid"), MagicMock())
 
-    assert captured_envelope["request_id"] == str(req_id)
-    assert captured_envelope["status"] == expected_envelope_status
-    assert captured_envelope["content_cid"] == "bafyfakecid"
-    assert captured_envelope["response"]["result"] == expected_envelope_result
-
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
-    done_task = done_tasks[0]
-    event = done_task["predict_api_event"]
+    event = done_tasks[0]["predict_api_event"]
     assert event["response"]["result"] == expected_event_result
     assert event["response"]["status"] == expected_event_status
     assert event["response"]["error"] == expected_event_error
-    assert "_pending_response" not in done_task
 
+    # Nothing about the on-chain path may leave state in the off-chain envelope
+    # slot; that slot belongs to the polling endpoint and admission ledger.
     assert str(req_id) not in shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
+
+
+def test_handle_store_response_stale_callback_is_dropped(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+) -> None:
+    """A store callback captured for one request but landing after the task slot was reassigned must no-op."""
+    # Seed task A, run through _handle_done_task so the callback is bound to req_id=A.
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=100)
+    captured_callback = _onchain_e2e_setup(behaviour, monkeypatch, fake_dialogue)
+    behaviour._handle_done_task(task_result=_make_success_result())
+    assert len(captured_callback) == 1
+
+    # Simulate a timeout + task swap: the slot now holds task B (req_id=200).
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=200)
+    behaviour._invalid_request = False
+    behaviour._ipfs_error_reason = None
+
+    # Task A's late store callback fires; it must not attribute A's response to B.
+    captured_callback[0](SimpleNamespace(ipfs_hash="bafyA"), MagicMock())
+
+    # Nothing lands under task B's id (the mis-attribution vector), and the
+    # slot is left untouched so task B can finalize on its own callback later.
+    assert "200" not in shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
+    assert shared_state[beh_mod.DONE_TASKS] == []
+    assert behaviour._executing_task["requestId"] == 200
+
+
+def test_handle_store_response_invalid_done_task_does_not_leak_envelope(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+) -> None:
+    """Callback for an on-chain task whose done_task got cleared must leave shared-state untouched."""
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=42)
+    captured_callback = _onchain_e2e_setup(behaviour, monkeypatch, fake_dialogue)
+    behaviour._handle_done_task(task_result=_make_success_result())
+
+    # Clear _done_task, forcing the invalid-done_task early return in _finalize_done_task.
+    behaviour._done_task = None
+
+    captured_callback[0](SimpleNamespace(ipfs_hash="bafyfakecid"), MagicMock())
+
+    # No envelope leaked into the off-chain slot, and no done_task published.
+    assert "42" not in shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
+    assert shared_state[beh_mod.DONE_TASKS] == []
+
+
+def test_handle_done_task_onchain_use_offchain_false_leaves_shared_state_clean(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+    fake_dialogue: Any,
+) -> None:
+    """With ``use_offchain`` off, the on-chain path emits no predict-api event and touches no shared-state envelope."""
+    params_stub.use_offchain = False
+    _seed_executing_task(behaviour, params_stub, is_offchain=False, req_id=77)
+    captured_callback = _onchain_e2e_setup(behaviour, monkeypatch, fake_dialogue)
+
+    behaviour._handle_done_task(task_result=_make_success_result())
+    assert len(captured_callback) == 1
+    captured_callback[0](SimpleNamespace(ipfs_hash="bafyfakecid"), MagicMock())
+
+    done_tasks = shared_state[beh_mod.DONE_TASKS]
+    assert len(done_tasks) == 1
+    assert "predict_api_event" not in done_tasks[0]
+    assert "77" not in shared_state.get(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i
+- valory/task_execution:0.1.0:bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
+- valory/task_execution:0.1.0:bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m
+- valory/task_execution:0.1.0:bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeicuypdscbb2es7lyibs7hnkwicfunmzwrrum7nip2ixynibnvicty
+- valory/task_execution:0.1.0:bafybeifwaoiiuqfl5qrhkixvtmap2m2pe2hy6rq72afahpk3ljunyw2a6m
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeifgrqa6dmkkjebkhcncy4qgvxjionx73hcrwlhvnbmofzrh4lnkda
+- valory/task_execution:0.1.0:bafybeibrmnan5zfsat53rlcu5qb3ejvbuvzwrdrvvekuqkafevz6couf3i
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:


### PR DESCRIPTION
## Summary

- The on-chain branch of `_handle_done_task` did not write the response envelope into `shared_state[OFFCHAIN_REQUEST_RESPONSES]`; the off-chain branch already did.
- `_build_predict_api_event` reads `response["result"]` off this shared-state slot for both paths, so on-chain deliveries landed in the predict-api data lake with `status='failed'` and `result=None` regardless of whether the tool succeeded or failed.
- Add a symmetric write on the on-chain branch. Envelope shape `{request_id, response}` matches what the event builder already consumes. Tool result flows through on success, tool error string flows through on failure.

## Test plan

- [x] `test_handle_done_task_onchain_stores_response_envelope_in_shared_state` — on-chain success stores real tool result under `response["result"]`
- [x] `test_handle_done_task_onchain_invalid_request_stores_reason_in_shared_state` — on-chain invalid-request stores failure reason under `response["result"]`
- [x] All existing `_handle_done_task` tests continue to pass (17/17)
- [x] Full `packages/valory/skills/task_execution/tests/` suite passes (511/511)
- [x] `autonomy packages lock --check` — verified
- [x] `autonomy push-all` — new hashes published to IPFS
- [ ] Downstream: bump `TOOLS_TO_PACKAGE_HASH` / package refs in `mech-predict` once merged