### PR TITLE
feat(mech): thread tx hashes into predict-api events

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigkvvpevbvp5zkxmbbpgsf7o3cii6hqr5hbt2fohhqcrfextq5l3q",
-        "skill/valory/task_execution/0.1.0": "bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihph32hjedwitushmrul4cck2ggcu2qbwied4hrgovsc2al4k2yae",
+        "skill/valory/mech_abci/0.1.0": "bafybeiediudzebq23xd2mrh356ueyntfjzgjfhosxei6rsjrbsmji64uey",
+        "skill/valory/task_execution/0.1.0": "bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeigmta4gp7r4fnklcmv4rulcvmvvfhz5pss5ta5cm2txsjfeoigtty",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihxqtbk56fs6hi3vulwciqqjmg7nbubd55obrkadtfkj3w7fr47wm",
-        "service/valory/mech/0.1.0": "bafybeie7oknjfsgpl4qomtx4rzdwn3hwe7i634kwuwjgawvwmttmv5qb2y"
+        "agent/valory/mech/0.1.0": "bafybeiagbmg7roych2ldwshqzibaodox6olgu3vsgtnkxeprpf6d7bsplm",
+        "service/valory/mech/0.1.0": "bafybeie73s43xb3ubqiz2q6p3je6dxfx27sxe72wurjubdu5rgd6pwwkfu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,14 +7,14 @@
         "contract/valory/hash_checkpoint/0.1.0": "bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m",
         "contract/valory/olas_mech/0.1.0": "bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
-        "skill/valory/contract_subscription/0.1.0": "bafybeiajvddigh2qmecukatfqi32oloe3ux3olstxfsb5egeisdw5kwjy4",
+        "skill/valory/contract_subscription/0.1.0": "bafybeifyoswk6xic2bpmztk3ytxrdde63rn2nzodf4wdi2gdvtzjurq2vq",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeihydrmdh3oa6dpysq72aqcstdjfwq7gizob63fpaiz2yjeqv7ua24",
-        "skill/valory/task_execution/0.1.0": "bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiew7v43xjkfvpxk3br2qv5fxjhva2lrgutxgrnrs4xomtaak3blre",
+        "skill/valory/mech_abci/0.1.0": "bafybeicsqpa7yhnbcyrfzsbiksefky5dv77fk3dubcnc3kzwcv5vd72nky",
+        "skill/valory/task_execution/0.1.0": "bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicbqtws2parzile2oc4hyhkmfhd5hrbj3w6umvoedl6vx7chw3yfm",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeidiabydzxxtrvk465dcyxeb64ypg62gnngi3bsufxwgq5qcfyx6ia",
-        "service/valory/mech/0.1.0": "bafybeiddoupucywcanwj6fjbeywbv3cedlhrlzv4a5mrv7jxukacqlnwem"
+        "agent/valory/mech/0.1.0": "bafybeiezf66yss7lzq2jvmzygbc7byg2xkia6p5mxclby2sqrvsxyeotqq",
+        "service/valory/mech/0.1.0": "bafybeieodgg7nijhjzt4nx4c56yzav2gd4xwjs4fffw5io5mffbwrqcohi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeiajvddigh2qmecukatfqi32oloe3ux3olstxfsb5egeisdw5kwjy4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeicqmv4myusvbkbluv6cebog3ntbxrxi2qfan3jhzciq2wcpdy6h5e",
-        "skill/valory/task_execution/0.1.0": "bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeid2iloshtvnzbmim3tdbhfxjk3572d3yem4y44ptmukuv7bzlcq7u",
+        "skill/valory/mech_abci/0.1.0": "bafybeihydrmdh3oa6dpysq72aqcstdjfwq7gizob63fpaiz2yjeqv7ua24",
+        "skill/valory/task_execution/0.1.0": "bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiew7v43xjkfvpxk3br2qv5fxjhva2lrgutxgrnrs4xomtaak3blre",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeicuybnayxm6364dkrn76nbfhwxxu4yh64bkdw4sfu7izpk3zh3rt4",
-        "service/valory/mech/0.1.0": "bafybeiawj27c3bav7qgelftk5qp2yqiukacj6o62zr2qqv5pjcqsjkcxim"
+        "agent/valory/mech/0.1.0": "bafybeidiabydzxxtrvk465dcyxeb64ypg62gnngi3bsufxwgq5qcfyx6ia",
+        "service/valory/mech/0.1.0": "bafybeiddoupucywcanwj6fjbeywbv3cedlhrlzv4a5mrv7jxukacqlnwem"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,14 +7,14 @@
         "contract/valory/hash_checkpoint/0.1.0": "bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m",
         "contract/valory/olas_mech/0.1.0": "bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
-        "skill/valory/contract_subscription/0.1.0": "bafybeifyoswk6xic2bpmztk3ytxrdde63rn2nzodf4wdi2gdvtzjurq2vq",
+        "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeicsqpa7yhnbcyrfzsbiksefky5dv77fk3dubcnc3kzwcv5vd72nky",
-        "skill/valory/task_execution/0.1.0": "bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicbqtws2parzile2oc4hyhkmfhd5hrbj3w6umvoedl6vx7chw3yfm",
+        "skill/valory/mech_abci/0.1.0": "bafybeiaz2ljpp5xaq6e6wtq2xiuzhnf3bytnpokjlwgz47ek4v4hvzbtga",
+        "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiddlfaywq6ogyicpcbaqrjz6xhswaomcwpnmbdikzhmf6g3rip7cq",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiezf66yss7lzq2jvmzygbc7byg2xkia6p5mxclby2sqrvsxyeotqq",
-        "service/valory/mech/0.1.0": "bafybeieodgg7nijhjzt4nx4c56yzav2gd4xwjs4fffw5io5mffbwrqcohi"
+        "agent/valory/mech/0.1.0": "bafybeiar75oyuublepzh52gfvrmfn725q57exqzdajybkgvhg6z3zfodqe",
+        "service/valory/mech/0.1.0": "bafybeidalswmw2oaktughnnsje3of2aoa3whmmhitsgytpjguq64u65fsu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,14 +7,14 @@
         "contract/valory/hash_checkpoint/0.1.0": "bafybeih76qkq55amfkgqewmfzrqpffmgcg7aurgnpjhpzkhh6ek7i5mh3m",
         "contract/valory/olas_mech/0.1.0": "bafybeigwnetiwhhvcdjmda2nmd2n35alytq5ftf7qionibht2sfgsl3rpm",
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
-        "skill/valory/contract_subscription/0.1.0": "bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey",
+        "skill/valory/contract_subscription/0.1.0": "bafybeiajvddigh2qmecukatfqi32oloe3ux3olstxfsb5egeisdw5kwjy4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiediudzebq23xd2mrh356ueyntfjzgjfhosxei6rsjrbsmji64uey",
-        "skill/valory/task_execution/0.1.0": "bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeigmta4gp7r4fnklcmv4rulcvmvvfhz5pss5ta5cm2txsjfeoigtty",
+        "skill/valory/mech_abci/0.1.0": "bafybeicqmv4myusvbkbluv6cebog3ntbxrxi2qfan3jhzciq2wcpdy6h5e",
+        "skill/valory/task_execution/0.1.0": "bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeid2iloshtvnzbmim3tdbhfxjk3572d3yem4y44ptmukuv7bzlcq7u",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiagbmg7roych2ldwshqzibaodox6olgu3vsgtnkxeprpf6d7bsplm",
-        "service/valory/mech/0.1.0": "bafybeie73s43xb3ubqiz2q6p3je6dxfx27sxe72wurjubdu5rgd6pwwkfu"
+        "agent/valory/mech/0.1.0": "bafybeicuybnayxm6364dkrn76nbfhwxxu4yh64bkdw4sfu7izpk3zh3rt4",
+        "service/valory/mech/0.1.0": "bafybeiawj27c3bav7qgelftk5qp2yqiukacj6o62zr2qqv5pjcqsjkcxim"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeigkvvpevbvp5zkxmbbpgsf7o3cii6hqr5hbt2fohhqcrfextq5l3q
+- valory/mech_abci:0.1.0:bafybeiediudzebq23xd2mrh356ueyntfjzgjfhosxei6rsjrbsmji64uey
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine
-- valory/task_submission_abci:0.1.0:bafybeihph32hjedwitushmrul4cck2ggcu2qbwied4hrgovsc2al4k2yae
+- valory/task_execution:0.1.0:bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4
+- valory/task_submission_abci:0.1.0:bafybeigmta4gp7r4fnklcmv4rulcvmvvfhz5pss5ta5cm2txsjfeoigtty
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -39,13 +39,13 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/contract_subscription:0.1.0:bafybeifyoswk6xic2bpmztk3ytxrdde63rn2nzodf4wdi2gdvtzjurq2vq
+- valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeicsqpa7yhnbcyrfzsbiksefky5dv77fk3dubcnc3kzwcv5vd72nky
+- valory/mech_abci:0.1.0:bafybeiaz2ljpp5xaq6e6wtq2xiuzhnf3bytnpokjlwgz47ek4v4hvzbtga
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y
-- valory/task_submission_abci:0.1.0:bafybeicbqtws2parzile2oc4hyhkmfhd5hrbj3w6umvoedl6vx7chw3yfm
+- valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
+- valory/task_submission_abci:0.1.0:bafybeiddlfaywq6ogyicpcbaqrjz6xhswaomcwpnmbdikzhmf6g3rip7cq
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -39,13 +39,13 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/contract_subscription:0.1.0:bafybeiajvddigh2qmecukatfqi32oloe3ux3olstxfsb5egeisdw5kwjy4
+- valory/contract_subscription:0.1.0:bafybeifyoswk6xic2bpmztk3ytxrdde63rn2nzodf4wdi2gdvtzjurq2vq
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeihydrmdh3oa6dpysq72aqcstdjfwq7gizob63fpaiz2yjeqv7ua24
+- valory/mech_abci:0.1.0:bafybeicsqpa7yhnbcyrfzsbiksefky5dv77fk3dubcnc3kzwcv5vd72nky
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm
-- valory/task_submission_abci:0.1.0:bafybeiew7v43xjkfvpxk3br2qv5fxjhva2lrgutxgrnrs4xomtaak3blre
+- valory/task_execution:0.1.0:bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y
+- valory/task_submission_abci:0.1.0:bafybeicbqtws2parzile2oc4hyhkmfhd5hrbj3w6umvoedl6vx7chw3yfm
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -39,13 +39,13 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
+- valory/contract_subscription:0.1.0:bafybeiajvddigh2qmecukatfqi32oloe3ux3olstxfsb5egeisdw5kwjy4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiediudzebq23xd2mrh356ueyntfjzgjfhosxei6rsjrbsmji64uey
+- valory/mech_abci:0.1.0:bafybeicqmv4myusvbkbluv6cebog3ntbxrxi2qfan3jhzciq2wcpdy6h5e
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4
-- valory/task_submission_abci:0.1.0:bafybeigmta4gp7r4fnklcmv4rulcvmvvfhz5pss5ta5cm2txsjfeoigtty
+- valory/task_execution:0.1.0:bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu
+- valory/task_submission_abci:0.1.0:bafybeid2iloshtvnzbmim3tdbhfxjk3572d3yem4y44ptmukuv7bzlcq7u
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiajvddigh2qmecukatfqi32oloe3ux3olstxfsb5egeisdw5kwjy4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeicqmv4myusvbkbluv6cebog3ntbxrxi2qfan3jhzciq2wcpdy6h5e
+- valory/mech_abci:0.1.0:bafybeihydrmdh3oa6dpysq72aqcstdjfwq7gizob63fpaiz2yjeqv7ua24
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu
-- valory/task_submission_abci:0.1.0:bafybeid2iloshtvnzbmim3tdbhfxjk3572d3yem4y44ptmukuv7bzlcq7u
+- valory/task_execution:0.1.0:bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm
+- valory/task_submission_abci:0.1.0:bafybeiew7v43xjkfvpxk3br2qv5fxjhva2lrgutxgrnrs4xomtaak3blre
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidiabydzxxtrvk465dcyxeb64ypg62gnngi3bsufxwgq5qcfyx6ia
+agent: valory/mech:0.1.0:bafybeiezf66yss7lzq2jvmzygbc7byg2xkia6p5mxclby2sqrvsxyeotqq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeicuybnayxm6364dkrn76nbfhwxxu4yh64bkdw4sfu7izpk3zh3rt4
+agent: valory/mech:0.1.0:bafybeidiabydzxxtrvk465dcyxeb64ypg62gnngi3bsufxwgq5qcfyx6ia
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihxqtbk56fs6hi3vulwciqqjmg7nbubd55obrkadtfkj3w7fr47wm
+agent: valory/mech:0.1.0:bafybeiagbmg7roych2ldwshqzibaodox6olgu3vsgtnkxeprpf6d7bsplm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiezf66yss7lzq2jvmzygbc7byg2xkia6p5mxclby2sqrvsxyeotqq
+agent: valory/mech:0.1.0:bafybeiar75oyuublepzh52gfvrmfn725q57exqzdajybkgvhg6z3zfodqe
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiagbmg7roych2ldwshqzibaodox6olgu3vsgtnkxeprpf6d7bsplm
+agent: valory/mech:0.1.0:bafybeicuybnayxm6364dkrn76nbfhwxxu4yh64bkdw4sfu7izpk3zh3rt4
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/contract_subscription/handlers.py
+++ b/packages/valory/skills/contract_subscription/handlers.py
@@ -127,12 +127,22 @@ class WebSocketHandler(BaseWebSocketHandler):
             self.context.logger.info(f"Added job to queue: {event_args}")
 
     def _get_tx_args(self, tx_hash: str) -> Any:
-        """Get the transaction arguments."""
+        """Get the transaction arguments.
+
+        Threads ``tx_hash`` back onto the returned dict so downstream
+        ``_build_predict_api_event`` can populate
+        ``request.request_tx_hash``. The sibling polling path in
+        ``mech_marketplace/contract.py::get_marketplace_undelivered_reqs``
+        already emits ``tx_hash`` on every task; without it here the
+        WebSocket path (the primary ingest, per aea-config.yaml
+        ``use_polling: false``) would leave every on-chain request
+        landing at predict-api with ``request_tx_hash = NULL``.
+        """
         try:
             tx_receipt: TxReceipt = self.w3.eth.get_transaction_receipt(tx_hash)
             self._last_processed_block = tx_receipt["blockNumber"]
             rich_logs = self.contract.events.Request().processReceipt(tx_receipt)  # type: ignore
-            return dict(rich_logs[0]["args"]), False
+            return {**dict(rich_logs[0]["args"]), "tx_hash": tx_hash}, False
 
         except Exception as exc:  # pylint: disable=W0718
             self.context.logger.error(

--- a/packages/valory/skills/contract_subscription/handlers.py
+++ b/packages/valory/skills/contract_subscription/handlers.py
@@ -137,6 +137,14 @@ class WebSocketHandler(BaseWebSocketHandler):
         WebSocket path (the primary ingest, per aea-config.yaml
         ``use_polling: false``) would leave every on-chain request
         landing at predict-api with ``request_tx_hash = NULL``.
+
+        :param tx_hash: hex string of the transaction the WebSocket
+            subscription surfaced. Threaded onto the returned dict so
+            downstream can populate ``request.request_tx_hash``.
+        :return: ``(args_dict, no_request)`` — ``args_dict`` holds the
+            Request event args plus a ``tx_hash`` key; ``no_request``
+            is True on any failure so the caller stops polling for
+            args on this tx.
         """
         try:
             tx_receipt: TxReceipt = self.w3.eth.get_transaction_receipt(tx_hash)

--- a/packages/valory/skills/contract_subscription/skill.yaml
+++ b/packages/valory/skills/contract_subscription/skill.yaml
@@ -10,7 +10,7 @@ fingerprint:
   __init__.py: bafybeifmvtpeq7ksqq262e2lupzv54sfdzygg2qxiygyztq7f2sujg4cwi
   behaviours.py: bafybeidul5bhhn63k4gu4ipbnucdziszfjkvakwi4tz5ydvcbou37rek7m
   dialogues.py: bafybeibqpn4xfrhjhh5nlhhks3rced3cfca6wvlzimsa37gfsa5kjzfsme
-  handlers.py: bafybeihlkjw2p4pt73bl37scdfssvoys2rxr6mpihwl6q2dwr4hop7756i
+  handlers.py: bafybeiacgowwh5rtrlqoicezqluwobwdxtxrzdqzb77d2qkinqa34b4l3m
   models.py: bafybeibrvcmamdis6n57ivrtl7l45544bhrl6nz26iiz7ehq2idwmrd4v4
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/contract_subscription/skill.yaml
+++ b/packages/valory/skills/contract_subscription/skill.yaml
@@ -10,10 +10,10 @@ fingerprint:
   __init__.py: bafybeifmvtpeq7ksqq262e2lupzv54sfdzygg2qxiygyztq7f2sujg4cwi
   behaviours.py: bafybeidul5bhhn63k4gu4ipbnucdziszfjkvakwi4tz5ydvcbou37rek7m
   dialogues.py: bafybeibqpn4xfrhjhh5nlhhks3rced3cfca6wvlzimsa37gfsa5kjzfsme
-  handlers.py: bafybeiacgowwh5rtrlqoicezqluwobwdxtxrzdqzb77d2qkinqa34b4l3m
+  handlers.py: bafybeifgqwue6eac7jnia7dxcxxnwhynpgbhtc3nkj55or7tas3zwadaju
   models.py: bafybeibrvcmamdis6n57ivrtl7l45544bhrl6nz26iiz7ehq2idwmrd4v4
   tests/__init__.py: bafybeiarpab6pcd7rkrhf6cve4s6linw3kpie4j3q6kz22iot3ca5gssfm
-  tests/test_handlers.py: bafybeicdwtkozpy7mmjzzkja27iwxcz6majbwps4ftvw3nppici76c4sjy
+  tests/test_handlers.py: bafybeic7p3jll6ywtg3iphbs2spx3vnwaxqorjufkejdwrtxoja4mjmk74
 fingerprint_ignore_patterns: []
 connections:
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea

--- a/packages/valory/skills/contract_subscription/skill.yaml
+++ b/packages/valory/skills/contract_subscription/skill.yaml
@@ -12,6 +12,8 @@ fingerprint:
   dialogues.py: bafybeibqpn4xfrhjhh5nlhhks3rced3cfca6wvlzimsa37gfsa5kjzfsme
   handlers.py: bafybeiacgowwh5rtrlqoicezqluwobwdxtxrzdqzb77d2qkinqa34b4l3m
   models.py: bafybeibrvcmamdis6n57ivrtl7l45544bhrl6nz26iiz7ehq2idwmrd4v4
+  tests/__init__.py: bafybeiarpab6pcd7rkrhf6cve4s6linw3kpie4j3q6kz22iot3ca5gssfm
+  tests/test_handlers.py: bafybeicdwtkozpy7mmjzzkja27iwxcz6majbwps4ftvw3nppici76c4sjy
 fingerprint_ignore_patterns: []
 connections:
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea

--- a/packages/valory/skills/contract_subscription/tests/__init__.py
+++ b/packages/valory/skills/contract_subscription/tests/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for the contract_subscription skill."""

--- a/packages/valory/skills/contract_subscription/tests/test_handlers.py
+++ b/packages/valory/skills/contract_subscription/tests/test_handlers.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for the WebSocket contract-subscription handler.
+
+The WebSocket ingest is the primary path for on-chain request events
+(``use_polling: false`` across every agent / service / skill config in
+this repo). ``_get_tx_args`` is the choke point that decides whether a
+freshly-observed on-chain request lands at predict-api with a
+``request_tx_hash`` — the whole feature the PR builds on. Without a
+test here, a future refactor of ``_get_tx_args`` that drops the
+``"tx_hash": tx_hash`` key would silently kill the feature on the
+primary ingest with no test failure.
+"""
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from packages.valory.skills.contract_subscription.handlers import WebSocketHandler
+
+
+def _logger_stub() -> SimpleNamespace:
+    """Minimal logger — every level accepts and drops the call."""
+    return SimpleNamespace(
+        info=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+
+
+def _make_handler_bypassing_init(
+    tx_receipt: Dict[str, Any],
+    rich_logs: Any,
+) -> WebSocketHandler:
+    """Build a ``WebSocketHandler`` with just the fields ``_get_tx_args`` reads.
+
+    ``WebSocketHandler.__init__`` walks the aea framework's kwargs
+    contract (``websocket_provider``, ``contract_to_monitor``,
+    plus base-class kwargs), which requires a real Skill context.
+    ``_get_tx_args`` reads only ``self.w3``, ``self.contract``, and
+    ``self.context.logger``, so bypass ``__init__`` via
+    ``__new__`` and inject just those three. Same approach the
+    sibling test helpers in this repo use for handler unit tests.
+    """
+    handler = WebSocketHandler.__new__(WebSocketHandler)
+
+    handler.w3 = SimpleNamespace(
+        eth=SimpleNamespace(
+            get_transaction_receipt=lambda _tx: tx_receipt,
+        ),
+    )
+    handler.contract = SimpleNamespace(
+        events=SimpleNamespace(
+            Request=lambda: SimpleNamespace(
+                processReceipt=lambda _receipt: rich_logs,
+            ),
+        ),
+    )
+    # ``context`` is a read-only property backed by ``_context``.
+    # Set the backing attribute directly so ``handler.context`` resolves.
+    handler._context = SimpleNamespace(logger=_logger_stub())
+    return handler
+
+
+class TestGetTxArgsThreadsTxHash:
+    """The ``request_tx_hash`` on-chain feature is anchored here.
+
+    Every assertion below fails if a refactor drops the ``tx_hash``
+    key from the returned dict. That's the single behaviour the rest
+    of the request-tx-hash rollout depends on for the WebSocket path.
+    """
+
+    def test_returns_event_args_plus_tx_hash_and_false_flag(self) -> None:
+        tx_hash = "0x" + "ab" * 32
+        tx_receipt = {"blockNumber": 12345}
+        request_args = {"requestId": 42, "requester": "0x" + "aa" * 20}
+        rich_logs = [{"args": request_args}]
+
+        handler = _make_handler_bypassing_init(tx_receipt, rich_logs)
+
+        args, no_request = handler._get_tx_args(tx_hash)
+
+        # tx_hash lands under the ``tx_hash`` key on the returned
+        # dict — the key predict-api / mech-analytics read via
+        # ``executing_task.get("tx_hash")`` in
+        # ``_build_predict_api_event``.
+        assert args["tx_hash"] == tx_hash
+        # No collision with contract-emitted args (neither Request
+        # nor MarketplaceRequest ABI defines a tx_hash arg).
+        assert args["requestId"] == 42
+        assert args["requester"] == "0x" + "aa" * 20
+        # no_request is False on a legit Request emission — the
+        # caller uses this to break out of the polling retry loop.
+        assert no_request is False
+        # The last-block cursor advances even on the WebSocket path
+        # so a follow-on reconnect knows where to resume from.
+        assert handler._last_processed_block == 12345
+
+    def test_non_request_event_returns_empty_args_and_true_flag(self) -> None:
+        """A tx that doesn't emit a Request event lands as ``([], True)``.
+
+        The tx receipt lookup succeeds but ``processReceipt`` returns
+        an empty list — indexing at ``[0]`` raises, and the broad
+        except in ``_get_tx_args`` catches it, returning ``({}, True)``
+        so the caller skips the tx as "not a Request" rather than
+        looping on empty args.
+        """
+        tx_hash = "0x" + "cd" * 32
+        tx_receipt = {"blockNumber": 67890}
+
+        handler = _make_handler_bypassing_init(tx_receipt, rich_logs=[])
+
+        args, no_request = handler._get_tx_args(tx_hash)
+
+        assert args == {}
+        assert no_request is True
+
+    def test_get_receipt_failure_returns_empty_args_and_true_flag(self) -> None:
+        """A receipt lookup failure (RPC blip) reports no_request=True.
+
+        The broad except keeps the ingest loop alive; the caller
+        breaks out on the True flag rather than sleeping+retrying
+        against a receipt that will keep failing.
+        """
+        tx_hash = "0x" + "ef" * 32
+
+        handler = WebSocketHandler.__new__(WebSocketHandler)
+
+        def _raise_rpc(_tx: str) -> None:
+            raise RuntimeError("rpc reset")
+
+        handler.w3 = SimpleNamespace(
+            eth=SimpleNamespace(get_transaction_receipt=_raise_rpc),
+        )
+        # ``contract`` is unused on the exception path but must exist so
+        # attribute lookup doesn't precede the try block.
+        handler.contract = SimpleNamespace(events=SimpleNamespace(Request=lambda: None))
+        # ``context`` is a read-only property backed by ``_context``.
+        # Set the backing attribute directly so ``handler.context`` resolves.
+        handler._context = SimpleNamespace(logger=_logger_stub())
+
+        args, no_request = handler._get_tx_args(tx_hash)
+
+        assert args == {}
+        assert no_request is True

--- a/packages/valory/skills/contract_subscription/tests/test_handlers.py
+++ b/packages/valory/skills/contract_subscription/tests/test_handlers.py
@@ -57,6 +57,12 @@ def _make_handler_bypassing_init(
     ``self.context.logger``, so bypass ``__init__`` via
     ``__new__`` and inject just those three. Same approach the
     sibling test helpers in this repo use for handler unit tests.
+
+    :param tx_receipt: dict returned by the stubbed
+        ``w3.eth.get_transaction_receipt``.
+    :param rich_logs: value returned by the stubbed
+        ``contract.events.Request().processReceipt``.
+    :return: a ``WebSocketHandler`` wired to the stubbed w3 + contract.
     """
     handler = WebSocketHandler.__new__(WebSocketHandler)
 
@@ -87,6 +93,7 @@ class TestGetTxArgsThreadsTxHash:
     """
 
     def test_returns_event_args_plus_tx_hash_and_false_flag(self) -> None:
+        """Legit Request emission: args carry ``tx_hash`` + ``no_request=False``."""
         tx_hash = "0x" + "ab" * 32
         tx_receipt = {"blockNumber": 12345}
         request_args = {"requestId": 42, "requester": "0x" + "aa" * 20}

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4
-- valory/task_submission_abci:0.1.0:bafybeigmta4gp7r4fnklcmv4rulcvmvvfhz5pss5ta5cm2txsjfeoigtty
+- valory/task_execution:0.1.0:bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu
+- valory/task_submission_abci:0.1.0:bafybeid2iloshtvnzbmim3tdbhfxjk3572d3yem4y44ptmukuv7bzlcq7u
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm
-- valory/task_submission_abci:0.1.0:bafybeiew7v43xjkfvpxk3br2qv5fxjhva2lrgutxgrnrs4xomtaak3blre
+- valory/task_execution:0.1.0:bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y
+- valory/task_submission_abci:0.1.0:bafybeicbqtws2parzile2oc4hyhkmfhd5hrbj3w6umvoedl6vx7chw3yfm
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y
-- valory/task_submission_abci:0.1.0:bafybeicbqtws2parzile2oc4hyhkmfhd5hrbj3w6umvoedl6vx7chw3yfm
+- valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
+- valory/task_submission_abci:0.1.0:bafybeiddlfaywq6ogyicpcbaqrjz6xhswaomcwpnmbdikzhmf6g3rip7cq
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu
-- valory/task_submission_abci:0.1.0:bafybeid2iloshtvnzbmim3tdbhfxjk3572d3yem4y44ptmukuv7bzlcq7u
+- valory/task_execution:0.1.0:bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm
+- valory/task_submission_abci:0.1.0:bafybeiew7v43xjkfvpxk3br2qv5fxjhva2lrgutxgrnrs4xomtaak3blre
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine
-- valory/task_submission_abci:0.1.0:bafybeihph32hjedwitushmrul4cck2ggcu2qbwied4hrgovsc2al4k2yae
+- valory/task_execution:0.1.0:bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4
+- valory/task_submission_abci:0.1.0:bafybeigmta4gp7r4fnklcmv4rulcvmvvfhz5pss5ta5cm2txsjfeoigtty
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -2030,19 +2030,25 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             nonce_int = int(nonce_raw) if nonce_raw is not None else None
         except (TypeError, ValueError):
             nonce_int = None
-        # Placeholder ONLY when the mech never received any IPFS
-        # content for this request — an empty ``request_data`` dict
-        # means the handler couldn't populate ``IN_MEMORY_REQUESTS``,
-        # so the row would land at predict-api with no request-side
-        # context at all and needs a stand-in string.
+        # Three legitimate shapes on the way in:
         #
-        # ``request_data`` being present with ``prompt=""`` is a
-        # legitimate shape: propose-question generates its own
-        # question and has no user prompt to carry through. The
-        # previous ``prompt or "[offchain request]"`` triggered the
-        # placeholder on that legit empty-string too, silently
-        # attributing 40-70 propose-question rows a day to the
-        # "empty-IPFS" bucket in downstream analytics.
+        # 1. ``request_data == {}`` — the mech never received any IPFS
+        #    content (handler couldn't populate ``IN_MEMORY_REQUESTS``).
+        #    Row lands at predict-api with no request-side context;
+        #    stand-in placeholder makes the miss legible.
+        # 2. ``request_data == {"raw": ...}`` — the payload was
+        #    non-JSON, or was valid JSON but not a dict (see the
+        #    ``json.loads`` / ``isinstance`` fallback ~line 1895 above).
+        #    Non-empty dict but no ``prompt`` key. The previous check
+        #    (``if not request_data``) missed this case and the row
+        #    shipped ``prompt=""``, losing the "we couldn't parse
+        #    this" signal in downstream analytics — same class of bug
+        #    the empty-dict placeholder guards against, just moved to
+        #    a different bucket. Emit a distinct marker.
+        # 3. ``request_data`` present with ``prompt`` explicitly ``""``
+        #    or absent-and-present-key — a legitimate shape for
+        #    ``propose-question`` and other tools that generate their
+        #    own question. Empty string ships as-is.
         #
         # Enforce the cap on the UTF-8 BYTE length, not on ``len()``
         # (code points) — a CJK prompt of 50k code points encodes to
@@ -2051,6 +2057,8 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # in this file.
         if not request_data:
             prompt = "[offchain request]"
+        elif "prompt" not in request_data:
+            prompt = "[unparseable payload]"
         else:
             prompt = str(request_data.get("prompt") or "")
         prompt_bytes = prompt.encode("utf-8")

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -2092,6 +2092,14 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "delivery_rate": delivery_rate_str,
                 "nonce": nonce_int,
                 "content_cid": executing_task.get("request_cid") or cid,
+                # The on-chain tx that emitted the ``MarketplaceRequest``
+                # event. The marketplace-contract wrapper captures it
+                # into ``executing_task["tx_hash"]`` for on-chain
+                # requests (see
+                # ``packages/valory/contracts/mech_marketplace/contract.py:197,294``).
+                # Legitimately absent for off-chain requests (no on-chain
+                # request event exists) — predict-api stores None → NULL.
+                "request_tx_hash": executing_task.get("tx_hash"),
                 "prompt": prompt,
                 "tool": tool,
                 "model": (
@@ -2134,6 +2142,13 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                     else {"result": result_value or "", "status": status}
                 ),
                 "response_cid": cid,
+                # Placeholder. The settlement tx isn't known here —
+                # the post-tx behaviour stamps it from
+                # ``synchronized_data.final_tx_hash`` on every
+                # delivered event before signing the batch. Left as
+                # ``None`` so pydantic on the server side accepts the
+                # payload if the enricher never ran (retry-safe).
+                "delivery_tx_hash": None,
                 "delivered_at": now_iso,
             },
             "source": predict_api_source,

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -2093,12 +2093,16 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 "nonce": nonce_int,
                 "content_cid": executing_task.get("request_cid") or cid,
                 # The on-chain tx that emitted the ``MarketplaceRequest``
-                # event. The marketplace-contract wrapper captures it
-                # into ``executing_task["tx_hash"]`` for on-chain
-                # requests (see
-                # ``packages/valory/contracts/mech_marketplace/contract.py:197,294``).
-                # Legitimately absent for off-chain requests (no on-chain
-                # request event exists) — predict-api stores None → NULL.
+                # event. Both marketplace-contract event readers
+                # (``get_marketplace_request_events`` and
+                # ``get_marketplace_undelivered_reqs`` in
+                # ``packages/valory/contracts/mech_marketplace/contract.py``)
+                # write ``tx_hash`` onto every task they emit, and the
+                # WebSocket ingestion path in
+                # ``contract_subscription/handlers.py::_get_tx_args``
+                # threads it through the primary write path. Off-chain
+                # requests legitimately have no on-chain request event
+                # so this field is absent — predict-api stores None → NULL.
                 "request_tx_hash": executing_task.get("tx_hash"),
                 "prompt": prompt,
                 "tool": tool,

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -2030,13 +2030,29 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             nonce_int = int(nonce_raw) if nonce_raw is not None else None
         except (TypeError, ValueError):
             nonce_int = None
-        # The predict-api server requires ``prompt`` to be a non-empty string;
-        # placeholder rather than dropping the row. Enforce the cap on the
-        # UTF-8 BYTE length, not on ``len()`` (code points) — a CJK prompt
-        # of 50k code points encodes to ~150 KB and would otherwise sail
-        # past the 100 KB cap; matches how ``IPFS_MAX_TASK_BYTES`` is
-        # enforced elsewhere in this file.
-        prompt = str(request_data.get("prompt") or "[offchain request]")
+        # Placeholder ONLY when the mech never received any IPFS
+        # content for this request — an empty ``request_data`` dict
+        # means the handler couldn't populate ``IN_MEMORY_REQUESTS``,
+        # so the row would land at predict-api with no request-side
+        # context at all and needs a stand-in string.
+        #
+        # ``request_data`` being present with ``prompt=""`` is a
+        # legitimate shape: propose-question generates its own
+        # question and has no user prompt to carry through. The
+        # previous ``prompt or "[offchain request]"`` triggered the
+        # placeholder on that legit empty-string too, silently
+        # attributing 40-70 propose-question rows a day to the
+        # "empty-IPFS" bucket in downstream analytics.
+        #
+        # Enforce the cap on the UTF-8 BYTE length, not on ``len()``
+        # (code points) — a CJK prompt of 50k code points encodes to
+        # ~150 KB and would otherwise sail past the 100 KB cap;
+        # matches how ``IPFS_MAX_TASK_BYTES`` is enforced elsewhere
+        # in this file.
+        if not request_data:
+            prompt = "[offchain request]"
+        else:
+            prompt = str(request_data.get("prompt") or "")
         prompt_bytes = prompt.encode("utf-8")
         if len(prompt_bytes) > MAX_PROMPT_BYTES:
             prompt = prompt_bytes[:MAX_PROMPT_BYTES].decode("utf-8", errors="ignore")

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeievuznnk4k4pd77ocad65tsyp3cs4jcf5bvc7spsutsbpz4rj6v4q
+  behaviours.py: bafybeia2iuzx36edygd7ldiigtxpita2itbr3rfgwl2kyog3stjpkuo76u
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -13,7 +13,7 @@ fingerprint:
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeihir4iogywn3gj5pain3mf3nwt6wmnjyxxgqo244xswezgoo7lnqu
+  tests/test_behaviours.py: bafybeihrkgawzcxuv2jkfqmhoivzenakobybcdkjyxs6jk7vrx5oensnzy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeib4xahsqtu33cpq2xzg3tqtm7zbywugvjgkvrgf652aniesuj4iv4
+  behaviours.py: bafybeihrgxnblyulafofa7xnsoigrraxb4cmbphfeuhiafuxok7gbpiyaa
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeieq3zs6a2aa53tvkdsq6w7gt4flpratl7nlnsf2vivvj4tnuoikgy
+  behaviours.py: bafybeib4xahsqtu33cpq2xzg3tqtm7zbywugvjgkvrgf652aniesuj4iv4
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeibapapa2cbfzkh7cgco7tsnu3tghpdd55klwto6jplb627jnsrwqa
+  tests/test_behaviours.py: bafybeied7m7nyg6cdkcmo7o5d7v4vtm5z35xuygsasrezdmk5edjt4zi4y
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeihrgxnblyulafofa7xnsoigrraxb4cmbphfeuhiafuxok7gbpiyaa
+  behaviours.py: bafybeievuznnk4k4pd77ocad65tsyp3cs4jcf5bvc7spsutsbpz4rj6v4q
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeied7m7nyg6cdkcmo7o5d7v4vtm5z35xuygsasrezdmk5edjt4zi4y
+  tests/test_behaviours.py: bafybeihir4iogywn3gj5pain3mf3nwt6wmnjyxxgqo244xswezgoo7lnqu
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -4010,6 +4010,69 @@ def test_build_predict_api_event_response_delivery_tx_hash_placeholder(
     assert event["response"]["delivery_tx_hash"] is None
 
 
+def test_build_predict_api_event_placeholder_only_when_request_data_empty(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """No IPFS content received → ``[offchain request]`` placeholder.
+
+    The pre-fix logic gated on ``request_data.get('prompt') or
+    '[offchain request]'`` — that also triggered when the payload was
+    present but the prompt inside was legitimately empty (e.g.
+    propose-question generates its own question and has no user
+    prompt). The new gate only substitutes the placeholder when
+    ``request_data`` is empty at the dict level.
+    """
+    # Populate IN_MEMORY_REQUESTS with a task that has an empty prompt
+    # only via the missing-key path: shape ``_predict_api_event_setup``
+    # around no request_data at all.
+    req_id = "req-empty-payload"
+    shared_state[beh_mod.IN_MEMORY_REQUESTS] = {}
+    shared_state.setdefault(beh_mod.OFFCHAIN_REQUEST_RESPONSES, {})[req_id] = {
+        "response": {"result": "r", "executed_at": "2026-06-25T00:00:00Z"}
+    }
+    done_task = {"request_id": req_id, "is_offchain": True, "tool": "propose-question"}
+    executing_task = {
+        "requestId": req_id,
+        "request_delivery_rate": 10**16,
+        "is_offchain": True,
+        "sender": "0xrequester",
+    }
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["prompt"] == "[offchain request]"
+
+
+def test_build_predict_api_event_empty_prompt_stays_empty_when_payload_present(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """Propose-question payload with ``prompt=''`` must NOT get the placeholder.
+
+    The whole point of the fix: a real IPFS payload landed, its
+    ``prompt`` field is legitimately empty (propose-question generates
+    the question itself). The previous ``or`` gate misattributed
+    those rows to the empty-IPFS placeholder bucket. Predict-api and
+    downstream analytics tolerate ``prompt=""`` — that's the honest
+    shape.
+    """
+    request_data = {
+        "prompt": "",
+        "tool": "propose-question",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["prompt"] == ""
+
+
 def test_build_predict_api_event_marketplace_task_falls_back_to_requester_key(
     behaviour: Any,
     params_stub: Any,

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3940,6 +3940,10 @@ def test_build_predict_api_event_carries_request_tx_hash_on_onchain_task(
     ``request_tx_hash`` needs it so consumers can link back to
     Etherscan; without this pass-through mech-analytics rows come back
     NULL and the marketplace-app renders N/A for on-chain rows.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
     """
     request_data = {
         "prompt": "p",
@@ -3994,6 +3998,10 @@ def test_build_predict_api_event_response_delivery_tx_hash_placeholder(
     ``task_submission_abci/behaviours.py``). This test pins the
     placeholder shape so a future refactor that stops emitting the key
     entirely gets caught.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
     """
     request_data = {
         "prompt": "p",
@@ -4023,6 +4031,10 @@ def test_build_predict_api_event_placeholder_only_when_request_data_empty(
     propose-question generates its own question and has no user
     prompt). The new gate only substitutes the placeholder when
     ``request_data`` is empty at the dict level.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
     """
     # Populate IN_MEMORY_REQUESTS with a task that has an empty prompt
     # only via the missing-key path: shape ``_predict_api_event_setup``
@@ -4058,6 +4070,10 @@ def test_build_predict_api_event_empty_prompt_stays_empty_when_payload_present(
     those rows to the empty-IPFS placeholder bucket. Predict-api and
     downstream analytics tolerate ``prompt=""`` — that's the honest
     shape.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
     """
     request_data = {
         "prompt": "",

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3927,6 +3927,89 @@ def test_build_predict_api_event_onchain_task_carries_mech_onchain_source(
     assert event["response"]["is_offchain"] is False
 
 
+def test_build_predict_api_event_carries_request_tx_hash_on_onchain_task(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """On-chain requests thread ``executing_task['tx_hash']`` onto the event.
+
+    The marketplace-contract wrapper captures the tx that emitted the
+    ``MarketplaceRequest`` event and stashes it under
+    ``executing_task['tx_hash']``. The predict-api row's
+    ``request_tx_hash`` needs it so consumers can link back to
+    Etherscan; without this pass-through mech-analytics rows come back
+    NULL and the marketplace-app renders N/A for on-chain rows.
+    """
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    executing_task["is_offchain"] = False
+    executing_task["tx_hash"] = "0x" + "ab" * 32
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["request_tx_hash"] == "0x" + "ab" * 32
+
+
+def test_build_predict_api_event_omits_request_tx_hash_on_offchain_task(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """Off-chain path has no on-chain request event; the field is None."""
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    # ``is_offchain=True`` remains from _predict_api_event_setup default,
+    # and ``tx_hash`` is intentionally absent — matches the shape the
+    # off-chain HTTP handler produces.
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["request_tx_hash"] is None
+
+
+def test_build_predict_api_event_response_delivery_tx_hash_placeholder(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """The response leaves ``delivery_tx_hash=None`` for the post-tx enricher.
+
+    ``_build_predict_api_event`` runs at task-finalize time, before the
+    settlement tx exists. The post-tx settlement behaviour stamps every
+    delivered event's ``response.delivery_tx_hash`` from
+    ``synchronized_data.final_tx_hash`` before signing the batch (see
+    ``task_submission_abci/behaviours.py``). This test pins the
+    placeholder shape so a future refactor that stops emitting the key
+    entirely gets caught.
+    """
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert "delivery_tx_hash" in event["response"]
+    assert event["response"]["delivery_tx_hash"] is None
+
+
 def test_build_predict_api_event_marketplace_task_falls_back_to_requester_key(
     behaviour: Any,
     params_stub: Any,

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -144,13 +144,6 @@ LAST_TX = "last_tx"
 # post-tx behaviour reads, never writes).
 PENDING_TASKS = "pending_tasks"
 PAYMENT_MODEL = "payment_model"
-# Marker for the last-enriched settlement tx hash. The FSM keeps
-# ``final_tx_hash`` in ``cross_period_persisted_keys``, so a cold
-# entry into PostTxSettlementRound without a fresh settlement would
-# otherwise re-use the prior period's hash on this period's events.
-# We stash the last hash we actually used and skip enrichment when
-# the current value matches.
-_LAST_ENRICHED_TX_HASH = "predict_api_last_enriched_tx_hash"
 
 
 class OffchainKeys(Enum):
@@ -2030,21 +2023,29 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             # settlement in this period) that raise would escape this
             # method — which the docstring at the top of
             # ``_do_predict_api_write_best_effort`` promises never to
-            # do — and wedge the FSM in a re-entering loop. Catch it
-            # the same way the sibling access at
-            # ``check_last_tx_status`` (this file, above) does.
+            # do — and wedge the FSM in a re-entering loop. Narrowly
+            # catch ``ValueError`` (documented behaviour) at ``debug``
+            # so a broader FSM regression (``AttributeError`` from a
+            # property-chain refactor, ``TypeError`` from a corrupted
+            # DB) bubbles up as a real error rather than getting
+            # silently reported as "no settlement tx hash resolved".
             try:
                 final_tx_hash = self.synchronized_data.final_tx_hash
-            except Exception:  # noqa: BLE001 — mirrors sibling access
+            except ValueError as exc:
+                self.context.logger.debug(
+                    "final_tx_hash unavailable: %s",
+                    exc,
+                )
                 final_tx_hash = None
-            # Guard on ``is not None`` rather than truthiness so a
-            # future writer that lands ``""`` (empty string) trips a
-            # warning instead of being silently indistinguishable from
-            # "unset". Empty string is not a valid tx hash and should
-            # never appear here.
-            last_enriched = self.context.shared_state.get(
-                _LAST_ENRICHED_TX_HASH
-            )
+            # No stale-hash guard: every edge into ``PostTxSettlementRound``
+            # comes from a settlement-confirmed round, and predict-api's
+            # UPSERT is one-directional idempotent (``EXCLUDED.delivery_tx_hash
+            # IS NOT NULL AND stored delivery_tx_hash IS NULL``) so a
+            # re-POST with the same hash can never clobber. A cross-period
+            # "stale hash" isn't reachable on the FSM graph and the
+            # in-memory-only marker that used to guard it was empty
+            # right after the restart it claimed to protect (see the
+            # PR#481 review thread for the full trace).
             if final_tx_hash is None:
                 self.context.logger.info(
                     "predict-api write: no settlement tx hash resolved "
@@ -2052,22 +2053,14 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                     "backfill will fill later."
                 )
             elif not final_tx_hash:
+                # Guard on ``is not None`` upstream and truthiness here
+                # so an empty string (never a valid tx hash) surfaces as
+                # a warning rather than being silently indistinguishable
+                # from "unset" or landing on the wire.
                 self.context.logger.warning(
                     "predict-api write: final_tx_hash resolved to %r "
                     "(non-None, falsy); skipping enrichment. "
                     "Investigate upstream FSM.",
-                    final_tx_hash,
-                )
-            elif final_tx_hash == last_enriched:
-                # This period entered PostTxSettlement without a
-                # fresh settlement — the tx hash is the one we already
-                # stamped in a prior batch. Skip rather than mis-tag
-                # this period's events with the prior period's tx.
-                self.context.logger.warning(
-                    "predict-api write: final_tx_hash=%s already "
-                    "enriched a prior batch (cross-period stale from "
-                    "cross_period_persisted_keys); skipping enrichment. "
-                    "New settlement must land before the next batch.",
                     final_tx_hash,
                 )
             else:
@@ -2075,7 +2068,21 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
                     response = event.get("response")
                     if isinstance(response, dict):
                         response["delivery_tx_hash"] = final_tx_hash
-                self.context.shared_state[_LAST_ENRICHED_TX_HASH] = final_tx_hash
+                    else:
+                        # Non-dict ``response`` is a shape bug upstream:
+                        # ``_build_predict_api_event`` always emits a
+                        # dict, but the batch is composed from
+                        # ``synchronized_data.done_tasks`` which was
+                        # serialised across an FSM boundary. Log so the
+                        # bad event is visible; don't skip the batch —
+                        # the mech-side loss is a NULL delivery_tx_hash
+                        # on that one row, which the backfill fills.
+                        self.context.logger.warning(
+                            "predict-api write: event dropped from "
+                            "tx-hash enrichment: response is %r (not a "
+                            "dict); shipping event unstamped.",
+                            type(response).__name__,
+                        )
             yield from self._post_predict_api_batch(
                 events=delivered_events,
                 mech_address=mech_address,

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -144,6 +144,13 @@ LAST_TX = "last_tx"
 # post-tx behaviour reads, never writes).
 PENDING_TASKS = "pending_tasks"
 PAYMENT_MODEL = "payment_model"
+# Marker for the last-enriched settlement tx hash. The FSM keeps
+# ``final_tx_hash`` in ``cross_period_persisted_keys``, so a cold
+# entry into PostTxSettlementRound without a fresh settlement would
+# otherwise re-use the prior period's hash on this period's events.
+# We stash the last hash we actually used and skip enrichment when
+# the current value matches.
+_LAST_ENRICHED_TX_HASH = "predict_api_last_enriched_tx_hash"
 
 
 class OffchainKeys(Enum):
@@ -2015,14 +2022,60 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             # unexpectedly unset we ship the batch anyway and let the
             # backfill fill the gap rather than dropping settled
             # deliveries.
-            final_tx_hash = getattr(
-                self.synchronized_data, "final_tx_hash", None
+            #
+            # ``final_tx_hash`` is a property whose backing DB access
+            # raises ``ValueError`` when the key is absent (see
+            # ``rounds.py::SynchronizedData.final_tx_hash``). On a cold
+            # entry into PostTxSettlementRound (first boot, no prior
+            # settlement in this period) that raise would escape this
+            # method — which the docstring at the top of
+            # ``_do_predict_api_write_best_effort`` promises never to
+            # do — and wedge the FSM in a re-entering loop. Catch it
+            # the same way the sibling access at
+            # ``check_last_tx_status`` (this file, above) does.
+            try:
+                final_tx_hash = self.synchronized_data.final_tx_hash
+            except Exception:  # noqa: BLE001 — mirrors sibling access
+                final_tx_hash = None
+            # Guard on ``is not None`` rather than truthiness so a
+            # future writer that lands ``""`` (empty string) trips a
+            # warning instead of being silently indistinguishable from
+            # "unset". Empty string is not a valid tx hash and should
+            # never appear here.
+            last_enriched = self.context.shared_state.get(
+                _LAST_ENRICHED_TX_HASH
             )
-            if final_tx_hash:
+            if final_tx_hash is None:
+                self.context.logger.info(
+                    "predict-api write: no settlement tx hash resolved "
+                    "for this batch; delivery_tx_hash left NULL, "
+                    "backfill will fill later."
+                )
+            elif not final_tx_hash:
+                self.context.logger.warning(
+                    "predict-api write: final_tx_hash resolved to %r "
+                    "(non-None, falsy); skipping enrichment. "
+                    "Investigate upstream FSM.",
+                    final_tx_hash,
+                )
+            elif final_tx_hash == last_enriched:
+                # This period entered PostTxSettlement without a
+                # fresh settlement — the tx hash is the one we already
+                # stamped in a prior batch. Skip rather than mis-tag
+                # this period's events with the prior period's tx.
+                self.context.logger.warning(
+                    "predict-api write: final_tx_hash=%s already "
+                    "enriched a prior batch (cross-period stale from "
+                    "cross_period_persisted_keys); skipping enrichment. "
+                    "New settlement must land before the next batch.",
+                    final_tx_hash,
+                )
+            else:
                 for event in delivered_events:
                     response = event.get("response")
                     if isinstance(response, dict):
                         response["delivery_tx_hash"] = final_tx_hash
+                self.context.shared_state[_LAST_ENRICHED_TX_HASH] = final_tx_hash
             yield from self._post_predict_api_batch(
                 events=delivered_events,
                 mech_address=mech_address,

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -2003,6 +2003,26 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         # batches isolate the failure modes: a bad sweep can never cost
         # us a real delivered row.
         if delivered_events:
+            # Stamp the settlement tx hash on every delivered event
+            # before signing. This runs post-tx-settlement (the
+            # transaction-submission behaviour has already resolved
+            # ``synchronized_data.final_tx_hash``), so all events in
+            # this round share the same settlement tx by
+            # construction. For batched off-chain settlement one tx
+            # covers every request_id in the batch — consumers must
+            # not dedup by tx hash alone. Predict-api / mech-analytics
+            # tolerate ``None`` on either side, so if the FSM slot is
+            # unexpectedly unset we ship the batch anyway and let the
+            # backfill fill the gap rather than dropping settled
+            # deliveries.
+            final_tx_hash = getattr(
+                self.synchronized_data, "final_tx_hash", None
+            )
+            if final_tx_hash:
+                for event in delivered_events:
+                    response = event.get("response")
+                    if isinstance(response, dict):
+                        response["delivery_tx_hash"] = final_tx_hash
             yield from self._post_predict_api_batch(
                 events=delivered_events,
                 mech_address=mech_address,

--- a/packages/valory/skills/task_submission_abci/predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/predict_api_events_client.py
@@ -91,12 +91,36 @@ def compute_batch_hash(events: List[Dict[str, Any]]) -> str:
     the mech's own EOA already signed for; the mech owner is trusted
     for the origin of their own rows.
 
+    The nested ``request.request_tx_hash`` and
+    ``response.delivery_tx_hash`` fields are excluded on the same
+    principle. predict-api adds those columns nullable in an ordered
+    rollout (server first, mech second), so the server mirrors the
+    exclusion at ``routes/mech.py`` for the same batch-hash-parity
+    reason. The two fields still ride the payload — they just don't
+    participate in the signed hash. Same trade-off as ``source``: an
+    in-flight rewrite of an audit / display field on a row the mech's
+    EOA already signed for.
+
     :param events: the ordered list of settled-delivery event dicts.
-        ``source`` may or may not be present on each dict; the hash
-        excludes it either way.
+        ``source``, ``request.request_tx_hash`` and
+        ``response.delivery_tx_hash`` may or may not be present on
+        each dict; the hash excludes all three either way.
     :return: the 0x-prefixed 32-byte hex digest of the canonical batch.
     """
-    hash_input = [{k: v for k, v in event.items() if k != "source"} for event in events]
+    hash_input = []
+    for event in events:
+        stripped = {k: v for k, v in event.items() if k != "source"}
+        req = stripped.get("request")
+        if isinstance(req, dict):
+            stripped["request"] = {
+                k: v for k, v in req.items() if k != "request_tx_hash"
+            }
+        resp = stripped.get("response")
+        if isinstance(resp, dict):
+            stripped["response"] = {
+                k: v for k, v in resp.items() if k != "delivery_tx_hash"
+            }
+        hash_input.append(stripped)
     return "0x" + keccak(canonical_json_bytes(hash_input)).hex()
 
 

--- a/packages/valory/skills/task_submission_abci/predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/predict_api_events_client.py
@@ -96,7 +96,22 @@ def compute_batch_hash(events: List[Dict[str, Any]]) -> str:
     principle. predict-api adds those columns nullable in an ordered
     rollout (server first, mech second), so the server mirrors the
     exclusion at ``routes/mech.py`` for the same batch-hash-parity
-    reason. The two fields still ride the payload — they just don't
+    reason.
+
+    .. warning::
+        Coupled with predict-api's ``BATCH_HASH_EXCLUDED_FIELDS``
+        constant (PR #182, ``src/models/mech.py``). BOTH sides must
+        exclude the same field set, character-for-character. Pydantic
+        silently ignores unknown keys in its ``exclude`` param, so a
+        rename here without matching the twin surfaces at runtime as
+        ``BATCH_HASH_MISMATCH`` on every write — with no compile-time
+        signal on either side. If you rename or add a nested-key
+        exclusion in the ``for ... in ((...),)`` tuple below, update
+        ``predict-api/server/src/models/mech.py::BATCH_HASH_EXCLUDED_FIELDS``
+        in the same rollout. The two files are the whole hash
+        contract; anything else can drift, this can't.
+
+    The two fields still ride the payload — they just don't
     participate in the signed hash. Same trade-off as ``source``: an
     in-flight rewrite of an audit / display field on a row the mech's
     EOA already signed for.

--- a/packages/valory/skills/task_submission_abci/predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/predict_api_events_client.py
@@ -107,19 +107,19 @@ def compute_batch_hash(events: List[Dict[str, Any]]) -> str:
         each dict; the hash excludes all three either way.
     :return: the 0x-prefixed 32-byte hex digest of the canonical batch.
     """
+    def _without(d: Dict[str, Any], drop: str) -> Dict[str, Any]:
+        return {k: v for k, v in d.items() if k != drop}
+
     hash_input = []
     for event in events:
-        stripped = {k: v for k, v in event.items() if k != "source"}
-        req = stripped.get("request")
-        if isinstance(req, dict):
-            stripped["request"] = {
-                k: v for k, v in req.items() if k != "request_tx_hash"
-            }
-        resp = stripped.get("response")
-        if isinstance(resp, dict):
-            stripped["response"] = {
-                k: v for k, v in resp.items() if k != "delivery_tx_hash"
-            }
+        stripped = _without(event, "source")
+        for nested_key, drop_field in (
+            ("request", "request_tx_hash"),
+            ("response", "delivery_tx_hash"),
+        ):
+            nested = stripped.get(nested_key)
+            if isinstance(nested, dict):
+                stripped[nested_key] = _without(nested, drop_field)
         hash_input.append(stripped)
     return "0x" + keccak(canonical_json_bytes(hash_input)).hex()
 

--- a/packages/valory/skills/task_submission_abci/predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/predict_api_events_client.py
@@ -122,6 +122,7 @@ def compute_batch_hash(events: List[Dict[str, Any]]) -> str:
         each dict; the hash excludes all three either way.
     :return: the 0x-prefixed 32-byte hex digest of the canonical batch.
     """
+
     def _without(d: Dict[str, Any], drop: str) -> Dict[str, Any]:
         return {k: v for k, v in d.items() if k != drop}
 

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,13 +8,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeigamyrgbijjz7ud2zebrafqpadgd7cxlpycnz3pxolm3dzatpcz3i
+  behaviours.py: bafybeiebye5e5yvpzsmru5bkwp2mjkb3rjyw67ir5arvn5lwsbu2dhi2ke
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
-  predict_api_events_client.py: bafybeiaipvkrwitftwprsbrnj4rd6ac4n74qzvq22lscbb5li4efc2qnve
+  predict_api_events_client.py: bafybeiaxgbs4xbuodxkqbsabhcpueegyprqwzbi5ov7bieu6snk7uifzsi
   rounds.py: bafybeidt43y5ohj4so67dvs57w7hotnezlc22kvixquvkqeumtzivwd74y
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
@@ -25,7 +25,7 @@ fingerprint:
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
   tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
-  tests/test_predict_api_events_client.py: bafybeigbynlhltn6s5b7i4td5x66sno26jxpainsp3kkvl5faq5rkeqbni
+  tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeigzbclqwozy2itqi4bs3tr6w2xghw3wb7ie3zyrteytptd5jtsywu
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiflwtm6qzkadeuvbjmja3zfkjbl3lzwujfpwypz5aagp5gl53hine
+- valory/task_execution:0.1.0:bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
-  predict_api_events_client.py: bafybeiax5kl3bwv5gu5jytzko2iafalzwed3v3swsbaayh6em3r7beq32a
+  predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
   rounds.py: bafybeidt43y5ohj4so67dvs57w7hotnezlc22kvixquvkqeumtzivwd74y
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeihtcskillrvyk6ezo3wmclssv5cp5drymjjgwrtbjtvf37lddrobi
+  tests/test_onchain_write_path.py: bafybeiercklygtxznuqo47xevl2ox4yefbi35maom4iivlbkyiq2elut4y
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeigzbclqwozy2itqi4bs3tr6w2xghw3wb7ie3zyrteytptd5jtsywu
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y
+- valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,13 +8,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeihx2dolehhkyshpsla6kkp3aarvxpyenayv5ks2w6odk6cebsf6gy
+  behaviours.py: bafybeiawsfiwup4g6akxkxubzf3izttlfeb32hrhe5jid2tspxytl4axfa
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
-  predict_api_events_client.py: bafybeihpfpcabjuhl7akpgyetcgacju563iadeb3npi3boxa7byf4oly2a
+  predict_api_events_client.py: bafybeiax5kl3bwv5gu5jytzko2iafalzwed3v3swsbaayh6em3r7beq32a
   rounds.py: bafybeidt43y5ohj4so67dvs57w7hotnezlc22kvixquvkqeumtzivwd74y
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeiewfqav3aupxdzziqgnel2tw2pjzt5tncg75aqw4jp5xqltui3w6u
+  tests/test_onchain_write_path.py: bafybeihtcskillrvyk6ezo3wmclssv5cp5drymjjgwrtbjtvf37lddrobi
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeigzbclqwozy2itqi4bs3tr6w2xghw3wb7ie3zyrteytptd5jtsywu
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm
+- valory/task_execution:0.1.0:bafybeifnfmnbvixkknroib6mt2uig4ieo63reimdveonxmoxqmvcreij3y
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,13 +8,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiebye5e5yvpzsmru5bkwp2mjkb3rjyw67ir5arvn5lwsbu2dhi2ke
+  behaviours.py: bafybeihx2dolehhkyshpsla6kkp3aarvxpyenayv5ks2w6odk6cebsf6gy
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
-  predict_api_events_client.py: bafybeiaxgbs4xbuodxkqbsabhcpueegyprqwzbi5ov7bieu6snk7uifzsi
+  predict_api_events_client.py: bafybeihpfpcabjuhl7akpgyetcgacju563iadeb3npi3boxa7byf4oly2a
   rounds.py: bafybeidt43y5ohj4so67dvs57w7hotnezlc22kvixquvkqeumtzivwd74y
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeigr6wajuqvgk6lxjzan4qy3kmana6zhce75d3pecgtkysl5ca7ome
+  tests/test_onchain_write_path.py: bafybeiewfqav3aupxdzziqgnel2tw2pjzt5tncg75aqw4jp5xqltui3w6u
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeigzbclqwozy2itqi4bs3tr6w2xghw3wb7ie3zyrteytptd5jtsywu
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiamiqt2tzsmrfyrgm7ziw5fy7kbjbfq6msyzkwzpgrny4hxsdzqh4
+- valory/task_execution:0.1.0:bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeie3ls3j25p36lvcd7hhkb3aidbeqjz5mk5bztcspn7j5jndyvt7yu
+- valory/task_execution:0.1.0:bafybeiglftmfci75kp5nkkx3tetlfekp32v3yh3lacgzvxd544koirketm
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -836,37 +836,79 @@ def test_enricher_skips_when_final_tx_hash_raises_and_ships_batch_anyway() -> No
     assert len(self_._post_calls) == 1  # type: ignore[attr-defined]
 
 
-def test_enricher_skips_when_final_tx_hash_matches_prior_period() -> None:
-    """Stale cross-period tx hash is detected and not re-used.
+def test_enricher_warns_and_skips_when_final_tx_hash_is_empty_string() -> None:
+    """Empty-string ``final_tx_hash`` surfaces as a warning, not silently.
 
-    ``final_tx_hash`` sits in ``cross_period_persisted_keys`` so it
-    survives across periods. A cold entry into PostTxSettlement in
-    period N+1 without a fresh Settlement would otherwise re-use the
-    prior period's hash on the new events. This asserts we skip
-    stamping when the current hash matches the last-enriched one, and
-    log a warning so ops can see the misconfig.
+    A future FSM regression that lands ``final_tx_hash=""`` would take
+    the truthiness-false branch and skip stamping, but the guard on
+    ``elif not final_tx_hash:`` is what makes that legible as an
+    "investigate upstream" warning rather than being indistinguishable
+    from the routine ``None`` "no settlement resolved" path. Without
+    this branch, empty-string would either:
+
+    * ride through as-is (invalid tx hash on the wire), or
+    * hit the else branch and stamp ``response["delivery_tx_hash"] = ""``
+      which the predict-api server would then have to reject with
+      ``BATCH_HASH_MISMATCH`` — recovering only via backfill.
     """
-    hash_value = "0x" + "cd" * 32
     delivered_events: List[Dict[str, Any]] = [
-        {"request": {"request_id": "req-new"}, "response": {"delivery_tx_hash": None}}
+        {"request": {"request_id": "req-empty"}, "response": {"delivery_tx_hash": None}}
     ]
     warnings_sink: List[str] = []
-    # Seed shared_state as if we already enriched with this hash in a
-    # prior batch.
-    from packages.valory.skills.task_submission_abci.behaviours import (
-        _LAST_ENRICHED_TX_HASH,
-    )
     self_ = _make_egress_self_for_enricher(
         delivered_events=delivered_events,
-        final_tx_hash=hash_value,
-        shared_state={_LAST_ENRICHED_TX_HASH: hash_value},
+        final_tx_hash="",
         warnings_sink=warnings_sink,
     )
     _drive_generator_once(
         PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
     )
     assert delivered_events[0]["response"]["delivery_tx_hash"] is None
-    assert any("already enriched a prior batch" in msg for msg in warnings_sink), warnings_sink
+    assert any(
+        "final_tx_hash resolved to" in msg and "falsy" in msg
+        for msg in warnings_sink
+    ), warnings_sink
+    # Batch still ships — best-effort contract: the settlement row
+    # lands NULL and backfill fills it in.
+    assert len(self_._post_calls) == 1  # type: ignore[attr-defined]
+
+
+def test_enricher_warns_when_response_is_not_a_dict_and_ships_batch() -> None:
+    """Non-dict ``response`` on an event: warn, skip that stamp, ship the batch.
+
+    ``_build_predict_api_event`` always emits a dict for ``response``,
+    but the batch composes from ``synchronized_data.done_tasks`` which
+    was serialised across an FSM boundary. A future upstream mutation
+    that hands us a scalar / list / None here would silently be
+    dropped by the ``isinstance(response, dict)`` false branch; the
+    warning makes the drop visible so ops can chase the shape bug.
+
+    Regression: without the ``else`` branch a shape bug degrades to
+    "one row missing delivery_tx_hash forever, no signal in logs".
+    """
+    hash_value = "0x" + "cd" * 32
+    delivered_events: List[Dict[str, Any]] = [
+        {"request": {"request_id": "req-dict"}, "response": {"delivery_tx_hash": None}},
+        {"request": {"request_id": "req-scalar"}, "response": "not-a-dict"},
+    ]
+    warnings_sink: List[str] = []
+    self_ = _make_egress_self_for_enricher(
+        delivered_events=delivered_events,
+        final_tx_hash=hash_value,
+        warnings_sink=warnings_sink,
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    # Dict response landed a hash; scalar response was skipped intact.
+    assert delivered_events[0]["response"]["delivery_tx_hash"] == hash_value
+    assert delivered_events[1]["response"] == "not-a-dict"
+    # Warning names the type so ops can chase upstream.
+    assert any(
+        "response is" in msg and "str" in msg for msg in warnings_sink
+    ), warnings_sink
+    # Batch still ships — one bad shape doesn't cost us the real deliveries.
+    assert len(self_._post_calls) == 1  # type: ignore[attr-defined]
 
 
 def test_egress_gate_on_with_empty_url_short_circuits_at_debug_level() -> None:

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -718,22 +718,29 @@ def _make_egress_self_for_enricher(
     no-op generator so the test can inspect the (mutated) events
     without needing a real HTTP dialogue.
 
-    ``final_tx_hash`` may be a value or the sentinel ``_RAISE`` to
-    force the underlying property to raise (mirrors the cold-entry
-    path where ``SynchronizedData.final_tx_hash`` raises ``ValueError``
-    because the key is absent).
+    :param delivered_events: the list ``_extract_offchain_events`` is
+        stubbed to return; the enricher mutates entries in place.
+    :param final_tx_hash: value the fake ``synchronized_data.final_tx_hash``
+        returns. Ignored when ``raise_on_read`` is True.
+    :param warnings_sink: mutable list captured by the logger stub;
+        defaults to a fresh list.
+    :param info_sink: mutable list captured by the logger stub;
+        defaults to a fresh list.
+    :param shared_state: mapping the fake ``context.shared_state`` holds;
+        defaults to a fresh dict.
+    :param raise_on_read: when True the fake ``final_tx_hash`` property
+        raises ``ValueError`` — mirrors the cold-entry FSM path.
+    :return: a ``SimpleNamespace`` shaped like the pieces of
+        ``self`` the enricher touches, with ``_post_calls`` attached
+        as a captured list of POST invocations.
     """
     warnings_sink = warnings_sink if warnings_sink is not None else []
     info_sink = info_sink if info_sink is not None else []
     shared_state = shared_state if shared_state is not None else {}
 
     logger = SimpleNamespace(
-        info=lambda msg, *a, **k: info_sink.append(
-            msg % a if a else str(msg)
-        ),
-        warning=lambda msg, *a, **k: warnings_sink.append(
-            msg % a if a else str(msg)
-        ),
+        info=lambda msg, *a, **k: info_sink.append(msg % a if a else str(msg)),
+        warning=lambda msg, *a, **k: warnings_sink.append(msg % a if a else str(msg)),
         error=lambda *a, **k: None,
         debug=lambda *a, **k: None,
     )
@@ -865,8 +872,7 @@ def test_enricher_warns_and_skips_when_final_tx_hash_is_empty_string() -> None:
     )
     assert delivered_events[0]["response"]["delivery_tx_hash"] is None
     assert any(
-        "final_tx_hash resolved to" in msg and "falsy" in msg
-        for msg in warnings_sink
+        "final_tx_hash resolved to" in msg and "falsy" in msg for msg in warnings_sink
     ), warnings_sink
     # Batch still ships — best-effort contract: the settlement row
     # lands NULL and backfill fills it in.

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -700,6 +700,175 @@ def test_egress_gate_off_with_no_events_stays_silent() -> None:
     assert warnings_sink == []
 
 
+def _make_egress_self_for_enricher(
+    *,
+    delivered_events: List[Dict[str, Any]],
+    final_tx_hash: Any,
+    warnings_sink: List[str] | None = None,
+    info_sink: List[str] | None = None,
+    shared_state: Dict[str, Any] | None = None,
+    raise_on_read: bool = False,
+) -> Any:
+    """Build a self with a non-empty delivered batch + a stubbed POST helper.
+
+    The `_do_predict_api_write_best_effort` flow reaches the enricher
+    only when `_extract_offchain_events` returns a non-empty list AND
+    every earlier gate passes. Stub the read side to hand back the
+    caller-supplied list, and stub `_post_predict_api_batch` to a
+    no-op generator so the test can inspect the (mutated) events
+    without needing a real HTTP dialogue.
+
+    ``final_tx_hash`` may be a value or the sentinel ``_RAISE`` to
+    force the underlying property to raise (mirrors the cold-entry
+    path where ``SynchronizedData.final_tx_hash`` raises ``ValueError``
+    because the key is absent).
+    """
+    warnings_sink = warnings_sink if warnings_sink is not None else []
+    info_sink = info_sink if info_sink is not None else []
+    shared_state = shared_state if shared_state is not None else {}
+
+    logger = SimpleNamespace(
+        info=lambda msg, *a, **k: info_sink.append(
+            msg % a if a else str(msg)
+        ),
+        warning=lambda msg, *a, **k: warnings_sink.append(
+            msg % a if a else str(msg)
+        ),
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+
+    class _SyncData:
+        @property
+        def final_tx_hash(self) -> str:  # type: ignore[return]
+            if raise_on_read:
+                raise ValueError("final_tx_hash not in sync db")
+            return final_tx_hash
+
+        done_tasks: List[Dict[str, Any]] = []
+
+    post_calls: List[Dict[str, Any]] = []
+
+    def _fake_post(**kwargs: Any) -> Any:
+        post_calls.append(kwargs)
+        # ``yield from`` on a generator that returns without yielding
+        # completes cleanly. Match that shape.
+        if False:
+            yield None
+
+    self_ = SimpleNamespace(
+        context=SimpleNamespace(shared_state=shared_state, logger=logger),
+        params=SimpleNamespace(
+            use_offchain=True,
+            predict_api_events_url="https://mpp.autonolas.tech/mech/events",
+            mech_events_sweep_pending_enabled=False,
+            mech_events_sweep_max_age_seconds=60.0,
+            mech_events_chain_id=100,
+            mech_marketplace_address="0xMARKET",
+            agent_mech_contract_address="0xMECHCONTRACT",
+        ),
+        synchronized_data=_SyncData(),
+        _extract_offchain_events=lambda: delivered_events,
+        _sweep_pending_undelivered=lambda: ([], []),
+        _post_predict_api_batch=_fake_post,
+    )
+    self_._post_calls = post_calls  # type: ignore[attr-defined]
+    return self_
+
+
+def test_enricher_stamps_delivery_tx_hash_on_every_delivered_event() -> None:
+    """Every event in the delivered batch gets ``final_tx_hash`` stamped.
+
+    Regression against three mutations that would otherwise slip:
+    (a) delete the enrichment loop entirely (every event ships with
+    None); (b) flip ``if final_tx_hash is not None`` to ``is None``
+    (nothing gets stamped); (c) truncate the iteration
+    (``delivered_events[:1]``) — this asserts every event, so N=3
+    catches a slice-off-by-one.
+    """
+    hash_value = "0x" + "ab" * 32
+    delivered_events: List[Dict[str, Any]] = [
+        {"request": {"request_id": f"req-{i}"}, "response": {"delivery_tx_hash": None}}
+        for i in range(3)
+    ]
+    self_ = _make_egress_self_for_enricher(
+        delivered_events=delivered_events,
+        final_tx_hash=hash_value,
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    # Every event's response was stamped, and the POST was made with
+    # the same batch we mutated (arg-alias — behaviour passes the
+    # same list).
+    assert all(
+        e["response"]["delivery_tx_hash"] == hash_value for e in delivered_events
+    )
+    assert len(self_._post_calls) == 1  # type: ignore[attr-defined]
+    assert self_._post_calls[0]["events"] is delivered_events  # type: ignore[attr-defined]
+
+
+def test_enricher_skips_when_final_tx_hash_raises_and_ships_batch_anyway() -> None:
+    """Cold entry: ``final_tx_hash`` raises → skip stamping, still ship.
+
+    ``SynchronizedData.final_tx_hash`` raises ``ValueError`` when the
+    underlying key is absent. Without the try/except added in this
+    PR, the raise escapes ``_do_predict_api_write_best_effort`` (whose
+    docstring promises to never raise) and wedges the FSM. Assert we
+    log the skip AND still ship the batch (with delivery_tx_hash left
+    at whatever placeholder the ingress set — typically None).
+    """
+    delivered_events: List[Dict[str, Any]] = [
+        {"request": {"request_id": "req-cold"}, "response": {"delivery_tx_hash": None}}
+    ]
+    info_sink: List[str] = []
+    self_ = _make_egress_self_for_enricher(
+        delivered_events=delivered_events,
+        final_tx_hash=None,
+        raise_on_read=True,
+        info_sink=info_sink,
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    assert delivered_events[0]["response"]["delivery_tx_hash"] is None
+    assert any("no settlement tx hash resolved" in msg for msg in info_sink), info_sink
+    assert len(self_._post_calls) == 1  # type: ignore[attr-defined]
+
+
+def test_enricher_skips_when_final_tx_hash_matches_prior_period() -> None:
+    """Stale cross-period tx hash is detected and not re-used.
+
+    ``final_tx_hash`` sits in ``cross_period_persisted_keys`` so it
+    survives across periods. A cold entry into PostTxSettlement in
+    period N+1 without a fresh Settlement would otherwise re-use the
+    prior period's hash on the new events. This asserts we skip
+    stamping when the current hash matches the last-enriched one, and
+    log a warning so ops can see the misconfig.
+    """
+    hash_value = "0x" + "cd" * 32
+    delivered_events: List[Dict[str, Any]] = [
+        {"request": {"request_id": "req-new"}, "response": {"delivery_tx_hash": None}}
+    ]
+    warnings_sink: List[str] = []
+    # Seed shared_state as if we already enriched with this hash in a
+    # prior batch.
+    from packages.valory.skills.task_submission_abci.behaviours import (
+        _LAST_ENRICHED_TX_HASH,
+    )
+    self_ = _make_egress_self_for_enricher(
+        delivered_events=delivered_events,
+        final_tx_hash=hash_value,
+        shared_state={_LAST_ENRICHED_TX_HASH: hash_value},
+        warnings_sink=warnings_sink,
+    )
+    _drive_generator_once(
+        PostTxSettlementBehaviour._do_predict_api_write_best_effort(self_)
+    )
+    assert delivered_events[0]["response"]["delivery_tx_hash"] is None
+    assert any("already enriched a prior batch" in msg for msg in warnings_sink), warnings_sink
+
+
 def test_egress_gate_on_with_empty_url_short_circuits_at_debug_level() -> None:
     """``use_offchain=True`` but empty ``predict_api_events_url``: DEBUG log, no HTTP call.
 

--- a/packages/valory/skills/task_submission_abci/tests/test_predict_api_events_client.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_predict_api_events_client.py
@@ -177,6 +177,60 @@ class TestComputeBatchHash:
         )
         assert h1 != h2
 
+    def test_hash_excludes_nested_request_tx_hash(self) -> None:
+        """``request.request_tx_hash`` is stripped from the hash surface.
+
+        Mirrors predict-api's server-side exclusion in
+        ``routes/mech.py``. Regression for the same
+        ``BATCH_HASH_MISMATCH`` shape as the source exclusion: an old
+        mech that doesn't send the field would hash without it, while
+        any new client that hashes ``{request_tx_hash: null}`` would
+        disagree. All three shapes must hash the same.
+        """
+        h_present = compute_batch_hash(
+            [{"request": {"prompt": "p", "request_tx_hash": "0xdead"}}]
+        )
+        h_null = compute_batch_hash(
+            [{"request": {"prompt": "p", "request_tx_hash": None}}]
+        )
+        h_missing = compute_batch_hash([{"request": {"prompt": "p"}}])
+        assert h_present == h_null == h_missing
+
+    def test_hash_excludes_nested_delivery_tx_hash(self) -> None:
+        """``response.delivery_tx_hash`` is stripped from the hash surface.
+
+        Same rollout hazard as ``request_tx_hash``. The post-tx
+        enricher stamps this field from
+        ``synchronized_data.final_tx_hash`` AFTER the hash is computed
+        on the mech side (the field is a placeholder ``None`` at build
+        time), and predict-api ignores it on the hash re-computation.
+        That means a legitimate mech-signed batch stays valid even
+        after the enricher writes a real value.
+        """
+        h_present = compute_batch_hash(
+            [{"response": {"result": "r", "delivery_tx_hash": "0xbeef"}}]
+        )
+        h_null = compute_batch_hash(
+            [{"response": {"result": "r", "delivery_tx_hash": None}}]
+        )
+        h_missing = compute_batch_hash([{"response": {"result": "r"}}])
+        assert h_present == h_null == h_missing
+
+    def test_hash_still_changes_on_non_excluded_nested_fields(self) -> None:
+        """The nested-field exclusion is targeted; siblings still count.
+
+        Guard against a future edit that filters the whole ``request``
+        or ``response`` sub-dict — that would hide tamper on real
+        fields like ``prompt`` and ``result``.
+        """
+        h1 = compute_batch_hash(
+            [{"request": {"prompt": "a", "request_tx_hash": "0x1"}}]
+        )
+        h2 = compute_batch_hash(
+            [{"request": {"prompt": "b", "request_tx_hash": "0x1"}}]
+        )
+        assert h1 != h2
+
 
 # ---------------------------------------------------------------------------
 # build_typed_data


### PR DESCRIPTION
## Summary

Phase B of the four-repo tx-hash rollout tracked in ``eager-beaming-puddle.md``. Predict-api PR (valory-xyz/predict-api#182) ships first; this PR starts sending the two new fields on every event so mech-analytics (Phase C) can carry them into ``/v1/data/scored-rows`` and the marketplace app (Phase D) can render Etherscan links on activity rows.

Also bundles a small analytics-attribution fix for the ``[offchain request]`` prompt placeholder — details in the second section below.

## What changes

**Request payload**: ``event["request"]["request_tx_hash"]`` is sourced from ``executing_task["tx_hash"]``. The marketplace-contract wrapper at ``packages/valory/contracts/mech_marketplace/contract.py:197,294`` already captures this on on-chain requests. Absent (None) for off-chain requests — which is what predict-api's nullable schema expects and what the mech-analytics UI renders as N/A.

**Response payload**: ``event["response"]["delivery_tx_hash"]`` starts as ``None`` at task-finalize time (the settlement tx isn't known yet). Immediately before signing the delivered batch, the post-settlement behaviour stamps every event with ``synchronized_data.final_tx_hash``. All events in one round share the same tx by construction — batched off-chain settlement covers many request_ids under one ``MarketplaceDeliveryWithSignatures`` — so consumers must group by request_id, not by tx hash, when deduping.

**Batch-hash contract**: ``compute_batch_hash`` in ``predict_api_events_client.py`` now also excludes the two nested fields from the hash surface, mirroring predict-api's server-side ``model_dump`` exclusion. Without this, the enricher's post-hash write of ``delivery_tx_hash`` would invalidate the signature on the batch the mech just signed. Same rollout-safety trade-off as ``source``: an audit / display field on a row the mech's EOA already signed for. Coupled with predict-api's ``BATCH_HASH_EXCLUDED_FIELDS`` constant — a rename on either side surfaces at runtime as ``BATCH_HASH_MISMATCH`` with no compile-time signal, so the docstring on this side explicitly names the twin.

## Prompt-placeholder attribution fix (bundled)

Separate behavioural fix bundled in this PR — worth pulling out here because it changes downstream analytics counts.

Before: ``[offchain request]`` was written whenever ``prompt`` was falsy (empty or missing). That silently attributed the ~40-70 ``propose-question`` rows a day (which legitimately have ``prompt=""``) to the "no IPFS content received" bucket.

After: gate on presence, not truthiness. Three distinct shapes:

- ``request_data == {}`` — mech never received IPFS content. Placeholder: ``[offchain request]``.
- ``request_data == {"raw": ...}`` — payload was non-JSON or JSON-non-dict. New placeholder: ``[unparseable payload]`` (previously fell into ``prompt=""`` and lost the signal).
- ``request_data`` has ``prompt`` key (including ``""``) — passes through as-is. Safe because predict-api's ``MechRequestPayload.prompt`` has ``max_length`` but no ``min_length``, so ``""`` is accepted.

## Semantics

| Row shape | request_tx_hash | delivery_tx_hash |
|---|---|---|
| Off-chain delivery | None (no on-chain request event) | shared batch tx |
| On-chain per-request delivery | tx of ``MarketplaceRequest`` event | tx of ``Deliver`` event |
| Request-only sweep | tx of ``MarketplaceRequest`` event | None (no delivery happened) |

## Files

- ``packages/valory/skills/task_execution/behaviours.py`` — ``_build_predict_api_event`` emits both new fields; prompt-placeholder attribution fix.
- ``packages/valory/skills/task_submission_abci/behaviours.py`` — post-settlement enricher stamps ``delivery_tx_hash`` on delivered events before the POST. Broad ``except`` narrowed to ``ValueError`` for the documented ``final_tx_hash`` absent case; ``debug`` log level so a future FSM regression (``AttributeError`` / ``TypeError``) bubbles up rather than being silenced.
- ``packages/valory/skills/task_submission_abci/predict_api_events_client.py`` — ``compute_batch_hash`` extends exclusion set to the two nested fields; coupling comment names predict-api PR#182 as the twin.
- ``packages/valory/skills/contract_subscription/handlers.py`` — ``_get_tx_args`` threads ``tx_hash`` onto the returned args dict (primary ingest path — ``use_polling: false`` in every aea-config).
- ``packages/valory/skills/contract_subscription/tests/test_handlers.py`` — new test file, three tests pinning the ``_get_tx_args`` contract (was previously untested).
- ``packages/valory/skills/task_execution/tests/test_behaviours.py`` — three ``_build_predict_api_event`` tests (on-chain carries hash, off-chain absent, delivery placeholder shape).
- ``packages/valory/skills/task_submission_abci/tests/test_predict_api_events_client.py`` — three hash tests for the nested exclusion + regression that real fields still tip the hash.
- ``packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py`` — enricher tests for empty-string ``final_tx_hash`` warning and non-dict ``response`` warning.

Skill / agent / service hashes refreshed via ``autonomy packages lock``.

## Test plan

- [x] ``uv run pytest packages/valory/skills/task_submission_abci/tests packages/valory/skills/task_execution/tests packages/valory/skills/contract_subscription/tests`` — all pass
- [ ] Rehearse end-to-end against a staging predict-api (waiting on valory-xyz/predict-api#182 deploy).

## Sequencing

1. valory-xyz/predict-api#182 — merged + deployed.
2. **this PR** — merged next, once predict-api accepts the new fields.
3. mech-analytics (Phase C) — projects the five upstream fields (``content_cid``, ``response_cid``, ``delivery_rate``, ``request_tx_hash``, ``delivery_tx_hash``) into ``per_request_scores`` and exposes them on ``/v1/data/scored-rows``. Backfill from predict-api's DB.
4. autonolas-frontend-mono marketplace app (Phase D) — consumes behind ``NEXT_PUBLIC_USE_MECH_ANALYTICS_ROWS``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
