### PR TITLE
fix(task_submission): drop done_tasks from cross-period persistence

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeidilx4pjimekvaoyf6arbzd4l73imucl7ceueibhn5bxlurtixtga",
+        "skill/valory/mech_abci/0.1.0": "bafybeic3ju4rlroomuzv3ef67wfhm37swtj5ie64js4hehukrm4biuzx6i",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeih2ihpwynoipvjmn5swduhc2cg7vqpxrmf7bvebrfyotvsfmg7ywe",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiggqmucj6qjkhxmqkytazw23i3be2jro6vjm2jej72o6kdwjgog3m",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeif2ws47nsvtrpdmwylathf6ya4q6pxmjmizp25vvy6cvxxaejfmbe",
-        "service/valory/mech/0.1.0": "bafybeiaadf3qqlirpudl4e27lysjwuvfpsk5nkxppfox7lpe37pmoja5f4"
+        "agent/valory/mech/0.1.0": "bafybeihywg4n3xcwk6jortlzdcw25u722rvo6bfdjgxc4gturvbzzfhzny",
+        "service/valory/mech/0.1.0": "bafybeidxgm6enrzyxuyz34r3ixbb73qkh5jkctvott4vuarueijr2if2aa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeidbdmwrxiuswuxqqdo2bxrwmuyxfzejftsn63yopi7tanvmrkqivq",
+        "skill/valory/mech_abci/0.1.0": "bafybeiehxuzywr7ld3bosooqvhewyrpbagmz2kljep6i3mls43jmtnktie",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeideducyb3iptcp5wmodpecp7lzoghlucpvvrlriavz2zx3j5rf7ya",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidxzddmqxhovneuxtplkdcmlbf7xlm3h75jhps7eddrwuuqnozeee",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeie4pzvw3jmrzqkev7x6vqgyafw5vjxcgr4nu7il3ppa6mu5tscp7q",
-        "service/valory/mech/0.1.0": "bafybeiespuvianyzriapuovq2hvyjevxzmgzwidp3nksyqon726pzf5nfu"
+        "agent/valory/mech/0.1.0": "bafybeighyndmb65rgptrifklfuimhvotz27dciemqyrnh2xbehovq6t5hm",
+        "service/valory/mech/0.1.0": "bafybeietnx4ctnxqswbtrcw7z6qrdncsiimf7xsbgp7pyw7mr7rblvxuhi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeib6pfxgti5lncu3cftjopmq6n7jtfyba6ojc3rshhfdt74kmkph6m",
+        "skill/valory/mech_abci/0.1.0": "bafybeidilx4pjimekvaoyf6arbzd4l73imucl7ceueibhn5bxlurtixtga",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibwrcgtvozebkoademhjogtvb6mojfve2bulctnidzdbgfzfigm5i",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeih2ihpwynoipvjmn5swduhc2cg7vqpxrmf7bvebrfyotvsfmg7ywe",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeidepuiao3m7wz6sqrh2qqydfe3d5lrcyr3oy7tgc4rshhxrfkrlrm",
-        "service/valory/mech/0.1.0": "bafybeigtgzgitwvm35qlkfendyujsckzxm342r6gggq6jq5w2belpcb4aq"
+        "agent/valory/mech/0.1.0": "bafybeif2ws47nsvtrpdmwylathf6ya4q6pxmjmizp25vvy6cvxxaejfmbe",
+        "service/valory/mech/0.1.0": "bafybeiaadf3qqlirpudl4e27lysjwuvfpsk5nkxppfox7lpe37pmoja5f4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiaz2ljpp5xaq6e6wtq2xiuzhnf3bytnpokjlwgz47ek4v4hvzbtga",
+        "skill/valory/mech_abci/0.1.0": "bafybeiby2cgkwzl5cczmdlovmxlh4akc3ad6ewfsuvhbteozlvno7oljne",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiddlfaywq6ogyicpcbaqrjz6xhswaomcwpnmbdikzhmf6g3rip7cq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibkhwbadzxuv27km4wmrxg5ktenazetso7nzgci65le5xrjj4gb3u",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiar75oyuublepzh52gfvrmfn725q57exqzdajybkgvhg6z3zfodqe",
-        "service/valory/mech/0.1.0": "bafybeidalswmw2oaktughnnsje3of2aoa3whmmhitsgytpjguq64u65fsu"
+        "agent/valory/mech/0.1.0": "bafybeid5h5xhjeydqyodxpd2vayh2ywvcgzpklrikgtitdm6x4dok24hyy",
+        "service/valory/mech/0.1.0": "bafybeiddrs32z2nmg6hpepsj5qc7v73ezi7yogpp74ar3bde46vm3dsdma"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiby2cgkwzl5cczmdlovmxlh4akc3ad6ewfsuvhbteozlvno7oljne",
+        "skill/valory/mech_abci/0.1.0": "bafybeib6pfxgti5lncu3cftjopmq6n7jtfyba6ojc3rshhfdt74kmkph6m",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeibkhwbadzxuv27km4wmrxg5ktenazetso7nzgci65le5xrjj4gb3u",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeibwrcgtvozebkoademhjogtvb6mojfve2bulctnidzdbgfzfigm5i",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeid5h5xhjeydqyodxpd2vayh2ywvcgzpklrikgtitdm6x4dok24hyy",
-        "service/valory/mech/0.1.0": "bafybeiddrs32z2nmg6hpepsj5qc7v73ezi7yogpp74ar3bde46vm3dsdma"
+        "agent/valory/mech/0.1.0": "bafybeidepuiao3m7wz6sqrh2qqydfe3d5lrcyr3oy7tgc4rshhxrfkrlrm",
+        "service/valory/mech/0.1.0": "bafybeigtgzgitwvm35qlkfendyujsckzxm342r6gggq6jq5w2belpcb4aq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeibfkfpkumrokq6uehtwdenb2ste4m3b6qz53bauqzbvwf5h3orgwq",
+        "skill/valory/mech_abci/0.1.0": "bafybeibsyn5zevutoqwlr3eghv4bbaswpgfyjk5ob3q6jppaz5btsr6bj4",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeids4ydmmiehodxo425qreg42w6iec22n6y22ahpgjd5qcdtyqaof4",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeid4efj3hpqffpw2ie76ne5gmczccehbtwklruxjskrot7ywdic5ky",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeigitplkhaza3kgeufk4bmyzswp2l2ukdnrwz5tcrfgclytcnyhu5e",
-        "service/valory/mech/0.1.0": "bafybeiecaouu6m77s7frvulanujuiays5pinw6gshxzcmcbfdjaxz6dd34"
+        "agent/valory/mech/0.1.0": "bafybeih6qkdhs6w7qrd6ifq6mwn3gkvxgvn25xw6vlynfdnpowrhigdobu",
+        "service/valory/mech/0.1.0": "bafybeidhepeuftgslty2rkqkripxlpszrrjq7tc5qazyp2bnninblvgca4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeibsyn5zevutoqwlr3eghv4bbaswpgfyjk5ob3q6jppaz5btsr6bj4",
+        "skill/valory/mech_abci/0.1.0": "bafybeidbdmwrxiuswuxqqdo2bxrwmuyxfzejftsn63yopi7tanvmrkqivq",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeid4efj3hpqffpw2ie76ne5gmczccehbtwklruxjskrot7ywdic5ky",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeideducyb3iptcp5wmodpecp7lzoghlucpvvrlriavz2zx3j5rf7ya",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeih6qkdhs6w7qrd6ifq6mwn3gkvxgvn25xw6vlynfdnpowrhigdobu",
-        "service/valory/mech/0.1.0": "bafybeidhepeuftgslty2rkqkripxlpszrrjq7tc5qazyp2bnninblvgca4"
+        "agent/valory/mech/0.1.0": "bafybeie4pzvw3jmrzqkev7x6vqgyafw5vjxcgr4nu7il3ppa6mu5tscp7q",
+        "service/valory/mech/0.1.0": "bafybeiespuvianyzriapuovq2hvyjevxzmgzwidp3nksyqon726pzf5nfu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeicrsvx33zmrcj7egbgb5rosp5dlxci6ktus32dh7gczu25azgzuuq",
+        "skill/valory/mech_abci/0.1.0": "bafybeibfkfpkumrokq6uehtwdenb2ste4m3b6qz53bauqzbvwf5h3orgwq",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeieryde54ktqz7manq65eboz76hlrzlfk6jqlujdfp6vkl5y7wtp2y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeids4ydmmiehodxo425qreg42w6iec22n6y22ahpgjd5qcdtyqaof4",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeic7zz6lt4ekxuqu36xuhw6j4xzlep4op57cnybsn4sjjtuhetwjjm",
-        "service/valory/mech/0.1.0": "bafybeig6ofkvshzifzj4fekcqp42immcuawkq4s2voksqqhf2rudgxn3yq"
+        "agent/valory/mech/0.1.0": "bafybeigitplkhaza3kgeufk4bmyzswp2l2ukdnrwz5tcrfgclytcnyhu5e",
+        "service/valory/mech/0.1.0": "bafybeiecaouu6m77s7frvulanujuiays5pinw6gshxzcmcbfdjaxz6dd34"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeic3ju4rlroomuzv3ef67wfhm37swtj5ie64js4hehukrm4biuzx6i",
+        "skill/valory/mech_abci/0.1.0": "bafybeicrsvx33zmrcj7egbgb5rosp5dlxci6ktus32dh7gczu25azgzuuq",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiggqmucj6qjkhxmqkytazw23i3be2jro6vjm2jej72o6kdwjgog3m",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeieryde54ktqz7manq65eboz76hlrzlfk6jqlujdfp6vkl5y7wtp2y",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihywg4n3xcwk6jortlzdcw25u722rvo6bfdjgxc4gturvbzzfhzny",
-        "service/valory/mech/0.1.0": "bafybeidxgm6enrzyxuyz34r3ixbb73qkh5jkctvott4vuarueijr2if2aa"
+        "agent/valory/mech/0.1.0": "bafybeic7zz6lt4ekxuqu36xuhw6j4xzlep4op57cnybsn4sjjtuhetwjjm",
+        "service/valory/mech/0.1.0": "bafybeig6ofkvshzifzj4fekcqp42immcuawkq4s2voksqqhf2rudgxn3yq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeidbdmwrxiuswuxqqdo2bxrwmuyxfzejftsn63yopi7tanvmrkqivq
+- valory/mech_abci:0.1.0:bafybeiehxuzywr7ld3bosooqvhewyrpbagmz2kljep6i3mls43jmtnktie
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeideducyb3iptcp5wmodpecp7lzoghlucpvvrlriavz2zx3j5rf7ya
+- valory/task_submission_abci:0.1.0:bafybeidxzddmqxhovneuxtplkdcmlbf7xlm3h75jhps7eddrwuuqnozeee
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiby2cgkwzl5cczmdlovmxlh4akc3ad6ewfsuvhbteozlvno7oljne
+- valory/mech_abci:0.1.0:bafybeib6pfxgti5lncu3cftjopmq6n7jtfyba6ojc3rshhfdt74kmkph6m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeibkhwbadzxuv27km4wmrxg5ktenazetso7nzgci65le5xrjj4gb3u
+- valory/task_submission_abci:0.1.0:bafybeibwrcgtvozebkoademhjogtvb6mojfve2bulctnidzdbgfzfigm5i
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeib6pfxgti5lncu3cftjopmq6n7jtfyba6ojc3rshhfdt74kmkph6m
+- valory/mech_abci:0.1.0:bafybeidilx4pjimekvaoyf6arbzd4l73imucl7ceueibhn5bxlurtixtga
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeibwrcgtvozebkoademhjogtvb6mojfve2bulctnidzdbgfzfigm5i
+- valory/task_submission_abci:0.1.0:bafybeih2ihpwynoipvjmn5swduhc2cg7vqpxrmf7bvebrfyotvsfmg7ywe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeibfkfpkumrokq6uehtwdenb2ste4m3b6qz53bauqzbvwf5h3orgwq
+- valory/mech_abci:0.1.0:bafybeibsyn5zevutoqwlr3eghv4bbaswpgfyjk5ob3q6jppaz5btsr6bj4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeids4ydmmiehodxo425qreg42w6iec22n6y22ahpgjd5qcdtyqaof4
+- valory/task_submission_abci:0.1.0:bafybeid4efj3hpqffpw2ie76ne5gmczccehbtwklruxjskrot7ywdic5ky
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiaz2ljpp5xaq6e6wtq2xiuzhnf3bytnpokjlwgz47ek4v4hvzbtga
+- valory/mech_abci:0.1.0:bafybeiby2cgkwzl5cczmdlovmxlh4akc3ad6ewfsuvhbteozlvno7oljne
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeiddlfaywq6ogyicpcbaqrjz6xhswaomcwpnmbdikzhmf6g3rip7cq
+- valory/task_submission_abci:0.1.0:bafybeibkhwbadzxuv27km4wmrxg5ktenazetso7nzgci65le5xrjj4gb3u
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeic3ju4rlroomuzv3ef67wfhm37swtj5ie64js4hehukrm4biuzx6i
+- valory/mech_abci:0.1.0:bafybeicrsvx33zmrcj7egbgb5rosp5dlxci6ktus32dh7gczu25azgzuuq
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeiggqmucj6qjkhxmqkytazw23i3be2jro6vjm2jej72o6kdwjgog3m
+- valory/task_submission_abci:0.1.0:bafybeieryde54ktqz7manq65eboz76hlrzlfk6jqlujdfp6vkl5y7wtp2y
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeibsyn5zevutoqwlr3eghv4bbaswpgfyjk5ob3q6jppaz5btsr6bj4
+- valory/mech_abci:0.1.0:bafybeidbdmwrxiuswuxqqdo2bxrwmuyxfzejftsn63yopi7tanvmrkqivq
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeid4efj3hpqffpw2ie76ne5gmczccehbtwklruxjskrot7ywdic5ky
+- valory/task_submission_abci:0.1.0:bafybeideducyb3iptcp5wmodpecp7lzoghlucpvvrlriavz2zx3j5rf7ya
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeicrsvx33zmrcj7egbgb5rosp5dlxci6ktus32dh7gczu25azgzuuq
+- valory/mech_abci:0.1.0:bafybeibfkfpkumrokq6uehtwdenb2ste4m3b6qz53bauqzbvwf5h3orgwq
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeieryde54ktqz7manq65eboz76hlrzlfk6jqlujdfp6vkl5y7wtp2y
+- valory/task_submission_abci:0.1.0:bafybeids4ydmmiehodxo425qreg42w6iec22n6y22ahpgjd5qcdtyqaof4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeidilx4pjimekvaoyf6arbzd4l73imucl7ceueibhn5bxlurtixtga
+- valory/mech_abci:0.1.0:bafybeic3ju4rlroomuzv3ef67wfhm37swtj5ie64js4hehukrm4biuzx6i
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeih2ihpwynoipvjmn5swduhc2cg7vqpxrmf7bvebrfyotvsfmg7ywe
+- valory/task_submission_abci:0.1.0:bafybeiggqmucj6qjkhxmqkytazw23i3be2jro6vjm2jej72o6kdwjgog3m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeid5h5xhjeydqyodxpd2vayh2ywvcgzpklrikgtitdm6x4dok24hyy
+agent: valory/mech:0.1.0:bafybeidepuiao3m7wz6sqrh2qqydfe3d5lrcyr3oy7tgc4rshhxrfkrlrm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeidepuiao3m7wz6sqrh2qqydfe3d5lrcyr3oy7tgc4rshhxrfkrlrm
+agent: valory/mech:0.1.0:bafybeif2ws47nsvtrpdmwylathf6ya4q6pxmjmizp25vvy6cvxxaejfmbe
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeic7zz6lt4ekxuqu36xuhw6j4xzlep4op57cnybsn4sjjtuhetwjjm
+agent: valory/mech:0.1.0:bafybeigitplkhaza3kgeufk4bmyzswp2l2ukdnrwz5tcrfgclytcnyhu5e
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihywg4n3xcwk6jortlzdcw25u722rvo6bfdjgxc4gturvbzzfhzny
+agent: valory/mech:0.1.0:bafybeic7zz6lt4ekxuqu36xuhw6j4xzlep4op57cnybsn4sjjtuhetwjjm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeie4pzvw3jmrzqkev7x6vqgyafw5vjxcgr4nu7il3ppa6mu5tscp7q
+agent: valory/mech:0.1.0:bafybeighyndmb65rgptrifklfuimhvotz27dciemqyrnh2xbehovq6t5hm
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiar75oyuublepzh52gfvrmfn725q57exqzdajybkgvhg6z3zfodqe
+agent: valory/mech:0.1.0:bafybeid5h5xhjeydqyodxpd2vayh2ywvcgzpklrikgtitdm6x4dok24hyy
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeif2ws47nsvtrpdmwylathf6ya4q6pxmjmizp25vvy6cvxxaejfmbe
+agent: valory/mech:0.1.0:bafybeihywg4n3xcwk6jortlzdcw25u722rvo6bfdjgxc4gturvbzzfhzny
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigitplkhaza3kgeufk4bmyzswp2l2ukdnrwz5tcrfgclytcnyhu5e
+agent: valory/mech:0.1.0:bafybeih6qkdhs6w7qrd6ifq6mwn3gkvxgvn25xw6vlynfdnpowrhigdobu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeih6qkdhs6w7qrd6ifq6mwn3gkvxgvn25xw6vlynfdnpowrhigdobu
+agent: valory/mech:0.1.0:bafybeie4pzvw3jmrzqkev7x6vqgyafw5vjxcgr4nu7il3ppa6mu5tscp7q
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeiggqmucj6qjkhxmqkytazw23i3be2jro6vjm2jej72o6kdwjgog3m
+- valory/task_submission_abci:0.1.0:bafybeieryde54ktqz7manq65eboz76hlrzlfk6jqlujdfp6vkl5y7wtp2y
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeids4ydmmiehodxo425qreg42w6iec22n6y22ahpgjd5qcdtyqaof4
+- valory/task_submission_abci:0.1.0:bafybeid4efj3hpqffpw2ie76ne5gmczccehbtwklruxjskrot7ywdic5ky
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeid4efj3hpqffpw2ie76ne5gmczccehbtwklruxjskrot7ywdic5ky
+- valory/task_submission_abci:0.1.0:bafybeideducyb3iptcp5wmodpecp7lzoghlucpvvrlriavz2zx3j5rf7ya
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeideducyb3iptcp5wmodpecp7lzoghlucpvvrlriavz2zx3j5rf7ya
+- valory/task_submission_abci:0.1.0:bafybeidxzddmqxhovneuxtplkdcmlbf7xlm3h75jhps7eddrwuuqnozeee
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeieryde54ktqz7manq65eboz76hlrzlfk6jqlujdfp6vkl5y7wtp2y
+- valory/task_submission_abci:0.1.0:bafybeids4ydmmiehodxo425qreg42w6iec22n6y22ahpgjd5qcdtyqaof4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeibwrcgtvozebkoademhjogtvb6mojfve2bulctnidzdbgfzfigm5i
+- valory/task_submission_abci:0.1.0:bafybeih2ihpwynoipvjmn5swduhc2cg7vqpxrmf7bvebrfyotvsfmg7ywe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeibkhwbadzxuv27km4wmrxg5ktenazetso7nzgci65le5xrjj4gb3u
+- valory/task_submission_abci:0.1.0:bafybeibwrcgtvozebkoademhjogtvb6mojfve2bulctnidzdbgfzfigm5i
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeih2ihpwynoipvjmn5swduhc2cg7vqpxrmf7bvebrfyotvsfmg7ywe
+- valory/task_submission_abci:0.1.0:bafybeiggqmucj6qjkhxmqkytazw23i3be2jro6vjm2jej72o6kdwjgog3m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeiddlfaywq6ogyicpcbaqrjz6xhswaomcwpnmbdikzhmf6g3rip7cq
+- valory/task_submission_abci:0.1.0:bafybeibkhwbadzxuv27km4wmrxg5ktenazetso7nzgci65le5xrjj4gb3u
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -344,9 +344,9 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         if not status:
             return
 
-        submitted_ids = list(
-            cast(SynchronizedData, self.synchronized_data).submitted_request_ids
-        )
+        submitted_ids = cast(
+            SynchronizedData, self.synchronized_data
+        ).submitted_request_ids
         if len(submitted_ids) == 0:
             return
 

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -228,30 +228,35 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
 
         :param submitted_tasks: the done tasks that have already been submitted
         """
+        # Extract ids and delegate; both entry points share
+        # ``remove_tasks_by_id`` so match semantics stay consistent.
+        submitted_ids = [
+            str(task["request_id"])
+            for task in submitted_tasks
+            if task.get("request_id") is not None and task.get("request_id") != ""
+        ]
+        self.remove_tasks_by_id(submitted_ids)
+
+    def remove_tasks_by_id(self, submitted_ids: List[str]) -> None:
+        """Pop already-submitted tasks from shared state, matched by request_id.
+
+        :param submitted_ids: request ids of tasks already delivered.
+        """
         # run this in a lock
         # the amount of done tasks will always be relatively low (<<20)
         # we can afford to do this in a lock
+        submitted_id_set = {str(rid) for rid in submitted_ids}
         with self.done_tasks_lock():
             done_tasks = self.done_tasks
-            not_submitted = []
-            # Normalize both sides to ``str`` before comparing so a mix of
-            # ``int`` (on-chain requestId) and ``str`` (pre-ingress-fix
-            # off-chain requestId) doesn't silently fail equality and leave
-            # a delivered task stuck in ``done_tasks`` for the next round to
-            # re-emit. Post the :mod:`task_execution.handlers` ingress fix
-            # both sides are ``int`` and the ``str`` cast is a no-op; the
-            # cast is retained for the same restart-transition reason
-            # called out in :meth:`task_submission_abci.rounds.
-            # TaskPoolingRound.end_block`.
-            for done_task in done_tasks:
-                done_key = str(done_task["request_id"])
-                is_submitted = False
-                for submitted_task in submitted_tasks:
-                    if str(submitted_task["request_id"]) == done_key:
-                        is_submitted = True
-                        break
-                if not is_submitted:
-                    not_submitted.append(done_task)
+            # ``str``-normalise the match key. The shared-state side
+            # may hold ``int`` or ``str`` ``request_id`` (mixed types
+            # can survive an in-place restart transition); normalising
+            # both sides here keeps the prune consistent regardless.
+            not_submitted = [
+                done_task
+                for done_task in done_tasks
+                if str(done_task.get("request_id")) not in submitted_id_set
+            ]
             self.context.shared_state[DONE_TASKS] = not_submitted
 
     @property
@@ -323,43 +328,87 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         return []
 
     def handle_submitted_tasks(self) -> Generator[None, None, None]:
-        """Handle tasks that have been already submitted before (in a prev. period)."""
+        """Handle tasks that have been already submitted before (in a prev. period).
+
+        Reads ``submitted_request_ids`` for the id list, or falls back
+        to ``done_tasks`` when the id field isn't yet in the DB (a
+        mech that resumes with pre-existing state written before this
+        code shipped will see ``None`` on the first read). Per-task
+        metrics are read from ``shared_state[DONE_TASKS]`` since the
+        id-only hand-off doesn't carry tool / start_time.
+
+        :yield: AEA protocol messages while fetching the tx block number.
+        """
         status, tx_hash = self.check_last_tx_status()
         self.context.logger.info(f"Last tx status is: {status}")
-        if status:
-            submitted_tasks = cast(
+        if not status:
+            return
+
+        # Fallback path for state that predates
+        # ``submitted_request_ids`` being written. Applies for at most
+        # one cycle per mech; subsequent cycles read the id list
+        # written by the previous ``PostTxSettlementRound``.
+        submitted_ids_raw = self.synchronized_data.db.get("submitted_request_ids", None)
+        if submitted_ids_raw is None:
+            self.context.logger.info(
+                "submitted_request_ids missing; falling back to done_tasks."
+            )
+            submitted_tasks_fallback = cast(
                 List[Dict[str, Any]], self.synchronized_data.done_tasks
             )
-            if len(submitted_tasks) > 0:
-                for task in submitted_tasks:
-                    req_id = task["request_id"]
-                    tool = task["tool"]
-                    start_time = task["start_time"]
-                    tool_delivery_time_duration = time.perf_counter() - start_time
-                    self.context.logger.info(
-                        f"Request id: {req_id} with tool: {tool} took {tool_delivery_time_duration} seconds to complete delivery"
-                    )
-                    self.observe_histogram(
-                        self.shared_state.tool_delivery_time,
-                        tool_delivery_time_duration,
-                        tool=tool,
-                    )
+            submitted_ids = [
+                str(task["request_id"])
+                for task in submitted_tasks_fallback
+                if task.get("request_id") is not None and task.get("request_id") != ""
+            ]
+        else:
+            submitted_ids = [str(rid) for rid in cast(List[Any], submitted_ids_raw)]
 
-                block_number = yield from self._fetch_tx_block_number(tx_hash)
-                self.context.logger.info(
-                    f"Block number for tx hash: {tx_hash} is {block_number}"
-                )
-                if block_number:
-                    self.set_gauge(
-                        self.shared_state.mech_delivery_last_block_number, block_number
-                    )
+        if len(submitted_ids) == 0:
+            return
 
+        # Emit per-task delivery-time metrics from in-memory state.
+        # A task not found in ``shared_state[DONE_TASKS]`` still
+        # contributes to the prune below, but its metric is skipped;
+        # the delivery already landed on-chain, only the timing
+        # dimension is dropped.
+        shared_done_tasks_by_id = {
+            str(task.get("request_id")): task for task in self.done_tasks
+        }
+        for req_id in submitted_ids:
+            task = shared_done_tasks_by_id.get(req_id)
+            if task is None:
+                continue
+            tool = task.get("tool")
+            start_time = task.get("start_time")
+            if tool is None or start_time is None:
+                continue
+            tool_delivery_time_duration = time.perf_counter() - float(start_time)
             self.context.logger.info(
-                f"Tasks {submitted_tasks} has already been submitted. The corresponding tx_hash is: {tx_hash}. "
-                f"Removing them from the list of tasks to be processed."
+                f"Request id: {req_id} with tool: {tool} took "
+                f"{tool_delivery_time_duration} seconds to complete delivery"
+            )
+            self.observe_histogram(
+                self.shared_state.tool_delivery_time,
+                tool_delivery_time_duration,
+                tool=tool,
             )
 
-            self.remove_tasks(submitted_tasks)
+        block_number = yield from self._fetch_tx_block_number(tx_hash)
+        self.context.logger.info(
+            f"Block number for tx hash: {tx_hash} is {block_number}"
+        )
+        if block_number:
+            self.set_gauge(
+                self.shared_state.mech_delivery_last_block_number, block_number
+            )
+
+        self.context.logger.info(
+            f"Tasks with ids {submitted_ids} have been submitted. "
+            f"The corresponding tx_hash is: {tx_hash}. "
+            f"Removing them from the list of tasks to be processed."
+        )
+        self.remove_tasks_by_id(submitted_ids)
 
     def check_last_tx_status(self) -> Tuple[bool, str]:
         """Check if the tx in the last round was successful or not"""

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -33,7 +33,6 @@ from typing import (
     Generator,
     List,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Type,
@@ -242,15 +241,12 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
         """
         self.remove_tasks_by_id(extract_request_ids(submitted_tasks))
 
-    def remove_tasks_by_id(self, submitted_ids: Sequence[Any]) -> None:
+    def remove_tasks_by_id(self, submitted_ids: List[str]) -> None:
         """Pop already-submitted tasks from shared state, matched by request_id.
 
         :param submitted_ids: request ids of tasks already delivered.
-            Accepts ``int`` or ``str`` shapes; both sides are
-            ``str``-normalised on the equality check.
         """
-        # Amount of done tasks is small (<<20); the lock cost is trivial.
-        submitted_id_set = {str(rid) for rid in submitted_ids}
+        submitted_id_set = set(submitted_ids)
         with self.done_tasks_lock():
             done_tasks = self.done_tasks
             not_submitted = [

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -340,9 +340,7 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         if not status:
             return
 
-        submitted_ids = cast(
-            SynchronizedData, self.synchronized_data
-        ).submitted_request_ids
+        submitted_ids = self.synchronized_data.submitted_request_ids
         if len(submitted_ids) == 0:
             return
 

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -241,20 +241,27 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
         """
         self.remove_tasks_by_id(extract_request_ids(submitted_tasks))
 
-    def remove_tasks_by_id(self, submitted_ids: List[str]) -> None:
-        """Pop already-submitted tasks from shared state, matched by request_id.
+    def remove_tasks_by_id(self, submitted_ids: List[str]) -> List[Dict[str, Any]]:
+        """Pop already-submitted tasks from shared state and return the pre-prune snapshot.
+
+        Returning the snapshot lets a caller drive per-task metrics
+        from the same list the prune ran on, without acquiring the
+        lock twice or risking a torn read against the background
+        executor. The snapshot is a ``deepcopy`` of the pre-prune
+        ``shared_state[DONE_TASKS]``.
 
         :param submitted_ids: request ids of tasks already delivered.
+        :return: the pre-prune snapshot of ``shared_state[DONE_TASKS]``.
         """
         submitted_id_set = set(submitted_ids)
         with self.done_tasks_lock():
-            done_tasks = self.done_tasks
-            not_submitted = [
-                done_task
-                for done_task in done_tasks
-                if str(done_task.get("request_id")) not in submitted_id_set
+            snapshot = self.done_tasks
+            self.context.shared_state[DONE_TASKS] = [
+                task
+                for task in snapshot
+                if str(task.get("request_id")) not in submitted_id_set
             ]
-            self.context.shared_state[DONE_TASKS] = not_submitted
+        return snapshot
 
     @property
     def mech_addresses(self) -> List[str]:
@@ -344,28 +351,22 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         if len(submitted_ids) == 0:
             return
 
-        # Take one snapshot under the lock and prune inline, so the
-        # metrics loop below and the prune both operate on the same
-        # entries. ``shared_state[DONE_TASKS]`` is written concurrently
-        # by the background executor, so an unlocked
-        # ``deepcopy(shared_state[DONE_TASKS])`` can produce a torn
-        # read: a task landing mid-copy would silently fall into the
-        # ``task is None`` skip branch below and its metric would be
-        # dropped, making a real desync indistinguishable from a race.
-        submitted_id_set = set(submitted_ids)
-        with self.done_tasks_lock():
-            shared_snapshot = list(self.context.shared_state.get(DONE_TASKS, []))
-            self.context.shared_state[DONE_TASKS] = [
-                task
-                for task in shared_snapshot
-                if str(task.get("request_id")) not in submitted_id_set
-            ]
+        # Prune + snapshot under one lock via ``remove_tasks_by_id``.
+        # Sharing the snapshot with the metrics loop below keeps the
+        # torn-read window closed (the background executor writes
+        # ``shared_state[DONE_TASKS]`` under the same lock) and keeps
+        # both paths on the single tested prune surface.
+        shared_snapshot = self.remove_tasks_by_id(submitted_ids)
+        self.context.logger.info(
+            f"Pruned tasks with ids {submitted_ids} from shared state; "
+            f"tx_hash={tx_hash}."
+        )
 
-        # Emit per-task delivery-time metrics from the snapshot. A
-        # task absent from ``shared_state[DONE_TASKS]`` at snapshot
-        # time still counted toward the prune above; the metric is
-        # skipped only because the timing data isn't locally
-        # available (the delivery already landed on-chain).
+        # Emit per-task delivery-time metrics from the same snapshot.
+        # A task absent from the snapshot still counted toward the
+        # prune above; the metric is skipped only because the local
+        # timing data isn't available (the delivery already landed
+        # on-chain).
         shared_done_tasks_by_id = {
             str(task.get("request_id")): task for task in shared_snapshot
         }
@@ -408,12 +409,6 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
             self.set_gauge(
                 self.shared_state.mech_delivery_last_block_number, block_number
             )
-
-        self.context.logger.info(
-            f"Tasks with ids {submitted_ids} have been submitted. "
-            f"The corresponding tx_hash is: {tx_hash}. "
-            f"Removing them from the list of tasks to be processed."
-        )
 
     def check_last_tx_status(self) -> Tuple[bool, str]:
         """Check if the tx in the last round was successful or not"""

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -346,20 +346,37 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         if len(submitted_ids) == 0:
             return
 
-        # Emit per-task delivery-time metrics from in-memory state.
-        # A task not found in shared_state[DONE_TASKS] still
-        # contributes to the prune below, but its metric is skipped;
-        # the delivery already landed on-chain, only the timing
-        # dimension is dropped.
+        # Take one snapshot under the lock and prune inline, so the
+        # metrics loop below and the prune both operate on the same
+        # entries. ``shared_state[DONE_TASKS]`` is written concurrently
+        # by the background executor, so an unlocked
+        # ``deepcopy(shared_state[DONE_TASKS])`` can produce a torn
+        # read: a task landing mid-copy would silently fall into the
+        # ``task is None`` skip branch below and its metric would be
+        # dropped, making a real desync indistinguishable from a race.
+        submitted_id_set = set(submitted_ids)
+        with self.done_tasks_lock():
+            shared_snapshot = list(self.context.shared_state.get(DONE_TASKS, []))
+            self.context.shared_state[DONE_TASKS] = [
+                task
+                for task in shared_snapshot
+                if str(task.get("request_id")) not in submitted_id_set
+            ]
+
+        # Emit per-task delivery-time metrics from the snapshot. A
+        # task absent from ``shared_state[DONE_TASKS]`` at snapshot
+        # time still counted toward the prune above; the metric is
+        # skipped only because the timing data isn't locally
+        # available (the delivery already landed on-chain).
         shared_done_tasks_by_id = {
-            str(task.get("request_id")): task for task in self.done_tasks
+            str(task.get("request_id")): task for task in shared_snapshot
         }
         for req_id in submitted_ids:
             task = shared_done_tasks_by_id.get(req_id)
             if task is None:
                 self.context.logger.debug(
                     "tool_delivery_time skipped for request_id=%s: "
-                    "not in shared_state[DONE_TASKS]",
+                    "not in shared_state[DONE_TASKS] snapshot",
                     req_id,
                 )
                 continue
@@ -399,7 +416,6 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
             f"The corresponding tx_hash is: {tx_hash}. "
             f"Removing them from the list of tasks to be processed."
         )
-        self.remove_tasks_by_id(submitted_ids)
 
     def check_last_tx_status(self) -> Tuple[bool, str]:
         """Check if the tx in the last round was successful or not"""

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -27,7 +27,18 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Type, cast
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    cast,
+)
 
 from aea.helpers.cid import CID, to_v1
 from prometheus_client import Counter, Gauge, Histogram
@@ -75,6 +86,7 @@ from packages.valory.skills.task_submission_abci.rounds import (
     TaskPoolingRound,
     TaskSubmissionAbciApp,
     TransactionPreparationRound,
+    extract_request_ids,
 )
 from packages.valory.skills.transaction_settlement_abci.payload_tools import (
     hash_payload_to_hex,
@@ -228,30 +240,19 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
 
         :param submitted_tasks: the done tasks that have already been submitted
         """
-        # Extract ids and delegate; both entry points share
-        # ``remove_tasks_by_id`` so match semantics stay consistent.
-        submitted_ids = [
-            str(task["request_id"])
-            for task in submitted_tasks
-            if task.get("request_id") is not None and task.get("request_id") != ""
-        ]
-        self.remove_tasks_by_id(submitted_ids)
+        self.remove_tasks_by_id(extract_request_ids(submitted_tasks))
 
-    def remove_tasks_by_id(self, submitted_ids: List[str]) -> None:
+    def remove_tasks_by_id(self, submitted_ids: Sequence[Any]) -> None:
         """Pop already-submitted tasks from shared state, matched by request_id.
 
         :param submitted_ids: request ids of tasks already delivered.
+            Accepts ``int`` or ``str`` shapes; both sides are
+            ``str``-normalised on the equality check.
         """
-        # run this in a lock
-        # the amount of done tasks will always be relatively low (<<20)
-        # we can afford to do this in a lock
+        # Amount of done tasks is small (<<20); the lock cost is trivial.
         submitted_id_set = {str(rid) for rid in submitted_ids}
         with self.done_tasks_lock():
             done_tasks = self.done_tasks
-            # ``str``-normalise the match key. The shared-state side
-            # may hold ``int`` or ``str`` ``request_id`` (mixed types
-            # can survive an in-place restart transition); normalising
-            # both sides here keeps the prune consistent regardless.
             not_submitted = [
                 done_task
                 for done_task in done_tasks
@@ -330,12 +331,11 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
     def handle_submitted_tasks(self) -> Generator[None, None, None]:
         """Handle tasks that have been already submitted before (in a prev. period).
 
-        Reads ``submitted_request_ids`` for the id list, or falls back
-        to ``done_tasks`` when the id field isn't yet in the DB (a
-        mech that resumes with pre-existing state written before this
-        code shipped will see ``None`` on the first read). Per-task
-        metrics are read from ``shared_state[DONE_TASKS]`` since the
-        id-only hand-off doesn't carry tool / start_time.
+        Reads ``submitted_request_ids`` for the id list and prunes
+        ``shared_state[DONE_TASKS]`` accordingly. Per-task
+        ``tool_delivery_time`` metrics are read from
+        ``shared_state[DONE_TASKS]`` since the id-only hand-off
+        doesn't carry tool / start_time.
 
         :yield: AEA protocol messages while fetching the tx block number.
         """
@@ -344,31 +344,14 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         if not status:
             return
 
-        # Fallback path for state that predates
-        # ``submitted_request_ids`` being written. Applies for at most
-        # one cycle per mech; subsequent cycles read the id list
-        # written by the previous ``PostTxSettlementRound``.
-        submitted_ids_raw = self.synchronized_data.db.get("submitted_request_ids", None)
-        if submitted_ids_raw is None:
-            self.context.logger.info(
-                "submitted_request_ids missing; falling back to done_tasks."
-            )
-            submitted_tasks_fallback = cast(
-                List[Dict[str, Any]], self.synchronized_data.done_tasks
-            )
-            submitted_ids = [
-                str(task["request_id"])
-                for task in submitted_tasks_fallback
-                if task.get("request_id") is not None and task.get("request_id") != ""
-            ]
-        else:
-            submitted_ids = [str(rid) for rid in cast(List[Any], submitted_ids_raw)]
-
+        submitted_ids = list(
+            cast(SynchronizedData, self.synchronized_data).submitted_request_ids
+        )
         if len(submitted_ids) == 0:
             return
 
         # Emit per-task delivery-time metrics from in-memory state.
-        # A task not found in ``shared_state[DONE_TASKS]`` still
+        # A task not found in shared_state[DONE_TASKS] still
         # contributes to the prune below, but its metric is skipped;
         # the delivery already landed on-chain, only the timing
         # dimension is dropped.
@@ -378,10 +361,22 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         for req_id in submitted_ids:
             task = shared_done_tasks_by_id.get(req_id)
             if task is None:
+                self.context.logger.debug(
+                    "tool_delivery_time skipped for request_id=%s: "
+                    "not in shared_state[DONE_TASKS]",
+                    req_id,
+                )
                 continue
             tool = task.get("tool")
             start_time = task.get("start_time")
             if tool is None or start_time is None:
+                self.context.logger.debug(
+                    "tool_delivery_time skipped for request_id=%s: "
+                    "missing field(s) tool=%r start_time=%r",
+                    req_id,
+                    tool,
+                    start_time,
+                )
                 continue
             tool_delivery_time_duration = time.perf_counter() - float(start_time)
             self.context.logger.info(

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -20,7 +20,6 @@
 """This package contains the rounds of TaskSubmissionAbciApp."""
 
 import json
-import logging
 from enum import Enum
 from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple, cast
 
@@ -118,7 +117,7 @@ class SynchronizedData(BaseSynchronizedData):
         if not isinstance(value, list) or not all(
             isinstance(item, str) for item in value
         ):
-            logging.getLogger(__name__).error(
+            self.db.logger.error(
                 "submitted_request_ids invariant broken: expected list[str], "
                 "got %s=%r; degrading to [] for this cycle",
                 type(value).__name__,
@@ -338,20 +337,21 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
         """Process the end of the block."""
         if self.threshold_reached:
-            done_tasks = cast(SynchronizedData, self.synchronized_data).done_tasks
+            sd = cast(SynchronizedData, self.synchronized_data)
+            done_tasks = sd.done_tasks
             if not done_tasks:
-                # ``PostTxSettlementRound`` is also reached from paths
-                # that carry no task batch: the delivery-rate settlement
-                # (``composition.py`` wires ``FinishedTransactionSubmissionRound``
-                # here for every settlement, not just task delivery) and
-                # a settlement-internal ``ResetRound`` retry (which
-                # drops ``done_tasks`` from the DB via ``db.create``'s
-                # allow-list). Writing ``submitted_request_ids = []``
-                # in those cases would clobber a still-pending hand-off
-                # from a prior real settlement, and the delivered batch
-                # would be re-pooled and re-submitted on-chain next
-                # cycle. When we have no task batch to record, leave
-                # any pending hand-off in place.
+                # ``composition.py`` wires
+                # ``FinishedTransactionSubmissionRound`` here for every
+                # settlement, not just task delivery, so the
+                # delivery-rate path arrives with ``done_tasks == []``.
+                # Overwriting a still-pending hand-off with ``[]`` here
+                # would clobber a prior real settlement's ids and the
+                # delivered batch would be re-pooled next cycle.
+                sd.db.logger.warning(
+                    "PostTxSettlementRound reached with empty done_tasks; "
+                    "preserving pending hand-off submitted_request_ids=%s",
+                    sd.submitted_request_ids,
+                )
                 return self.synchronized_data, Event.DONE
             submitted_ids = extract_request_ids(done_tasks)
             return (

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -99,9 +99,24 @@ class SynchronizedData(BaseSynchronizedData):
         across periods because it holds per-event request/response
         payload data that would inflate DB serialization.
 
+        The value is validated on read: writers must go through
+        :func:`extract_request_ids` so that only ``str`` ids land in
+        the DB. A future writer that bypasses the helper and stores a
+        non-list or non-``str`` entries surfaces as ``TypeError`` here
+        rather than as silent type drift at the consumer.
+
         :return: the list of request ids from the most recent settlement.
+        :raises TypeError: if the persisted value is not ``list[str]``.
         """
-        return cast(List[str], self.db.get("submitted_request_ids", []))
+        value = self.db.get("submitted_request_ids", [])
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) for item in value
+        ):
+            raise TypeError(
+                "submitted_request_ids must be a list[str]; got "
+                f"{type(value).__name__}={value!r}"
+            )
+        return value
 
     @property
     def final_tx_hash(self) -> str:

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -70,6 +70,22 @@ class SynchronizedData(BaseSynchronizedData):
         return cast(List[Dict[str, Any]], self.db.get("done_tasks", []))
 
     @property
+    def submitted_request_ids(self) -> List[str]:
+        """Return request ids of tasks submitted in the most recent settlement.
+
+        Written by :class:`PostTxSettlementRound` end_block and read by
+        :meth:`TaskPoolingBehaviour.handle_submitted_tasks` next period
+        to prune ``shared_state[DONE_TASKS]`` of already-delivered
+        entries. Cross-period-persisted because it's small and the next
+        cycle needs it; the full ``done_tasks`` list is not carried
+        across periods because it holds per-event request/response
+        payload data that would inflate DB serialization.
+
+        :return: the list of request ids from the most recent settlement.
+        """
+        return cast(List[str], self.db.get("submitted_request_ids", []))
+
+    @property
     def final_tx_hash(self) -> str:
         """Get the verified tx hash."""
         return cast(str, self.db.get_strict("final_tx_hash"))
@@ -264,18 +280,18 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     NO_MAJORITY arm only fires if the agents can't agree on having reached
     this round at all, which is the same shape as every consensus round.
 
-    ``done_tasks`` MUST survive this round untouched. It is in
-    ``cross_period_persisted_keys`` because
-    ``TaskPoolingBehaviour.handle_submitted_tasks`` reads it at the START
-    of the next cycle to know which ``request_id``s to prune from
-    ``shared_state[DONE_TASKS]``. Clearing here on DONE strands the
-    delivered tasks in shared state, so every subsequent cycle re-pools
-    and re-delivers the same batch — the Safe tx succeeds each time but
-    the inner ``mech.deliverMulti`` reverts on the already-delivered
-    ids, burning gas without emitting new Deliver events. Any re-fire
-    concern on the NO_MAJORITY / ROUND_TIMEOUT self-loop must be handled
-    inside the behaviour (idempotence flag) rather than by mutating a
-    field the next behaviour depends on.
+    On DONE the round writes ``submitted_request_ids`` — the id-only
+    hand-off used by the next cycle's
+    :meth:`TaskPoolingBehaviour.handle_submitted_tasks` to prune
+    ``shared_state[DONE_TASKS]``. ``done_tasks`` itself stays in the
+    period it was set and is not carried across; the ID hand-off is
+    what rides consensus between cycles.
+
+    Do NOT mutate ``done_tasks`` here. It is still read by predict-api
+    write and log emission earlier in this same behaviour, and the
+    behaviour-side prune in the next cycle depends on
+    ``shared_state[DONE_TASKS]`` reflecting only tasks that were not
+    settled — mutating the consensus field here breaks that contract.
     """
 
     payload_class = PostTxSettlementPayload
@@ -286,7 +302,30 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
         """Process the end of the block."""
         if self.threshold_reached:
-            return self.synchronized_data, Event.DONE
+            # Extract the id list from this period's done_tasks and
+            # carry it via ``submitted_request_ids`` for the next
+            # cycle's prune. ``str``-normalise for parity with the
+            # ``str``-keyed dedup rule in
+            # ``TaskPoolingRound.end_block``; downstream match sites
+            # normalise the same way.
+            done_tasks = cast(
+                List[Dict[str, Any]],
+                cast(SynchronizedData, self.synchronized_data).done_tasks,
+            )
+            submitted_ids = [
+                str(task["request_id"])
+                for task in done_tasks
+                if task.get("request_id") is not None and task.get("request_id") != ""
+            ]
+            return (
+                self.synchronized_data.update(
+                    synchronized_data_class=SynchronizedData,
+                    **{
+                        get_name(SynchronizedData.submitted_request_ids): submitted_ids,
+                    },
+                ),
+                Event.DONE,
+            )
         if not self.is_majority_possible(
             self.collection, self.synchronized_data.nb_participants
         ):
@@ -376,16 +415,21 @@ class TaskSubmissionAbciApp(AbciApp[Event]):
     }
     cross_period_persisted_keys: FrozenSet[str] = frozenset(
         [
-            get_name(SynchronizedData.done_tasks),
+            # Hand-off signal only. ``done_tasks`` is intentionally
+            # not cross-period-persisted because its per-entry payload
+            # data is large enough to inflate DB serialization on the
+            # next registration.
+            get_name(SynchronizedData.submitted_request_ids),
             get_name(SynchronizedData.final_tx_hash),
         ]
     )
     db_pre_conditions: Dict[AppState, Set[str]] = {
         TaskPoolingRound: set(),
-        # Entered from composition after settlement; relies on done_tasks
-        # being on synchronized_data from the prior TaskPoolingRound cycle
-        # (cross_period_persisted_keys above keeps it alive). No additional
-        # pre-condition fields beyond what the FSM already carries.
+        # Entered from composition after settlement. Reads
+        # ``done_tasks`` from the same FSM cycle's earlier
+        # ``TaskPoolingRound`` (present in the current period's DB
+        # slot). end_block writes the id-only
+        # ``submitted_request_ids`` for the next cycle's prune.
         PostTxSettlementRound: set(),
     }
     db_post_conditions: Dict[AppState, Set[str]] = {

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -41,6 +41,24 @@ from packages.valory.skills.task_submission_abci.payloads import (
 )
 
 
+def extract_request_ids(tasks: List[Dict[str, Any]]) -> List[str]:
+    """Return ``str``-normalised request ids from a task list.
+
+    Falsy ids (missing key, ``None``, empty string) are dropped so
+    they don't collide in downstream match sets. Legit ``0`` (int)
+    is kept via the explicit ``is None or == ""`` check rather than
+    a ``not`` truthiness test.
+
+    :param tasks: task dicts (each expected to carry ``"request_id"``).
+    :return: the ``str``-normalised id list, in input order.
+    """
+    return [
+        str(task["request_id"])
+        for task in tasks
+        if task.get("request_id") is not None and task.get("request_id") != ""
+    ]
+
+
 class Event(Enum):
     """TaskSubmissionAbciApp Events"""
 
@@ -287,11 +305,12 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     period it was set and is not carried across; the ID hand-off is
     what rides consensus between cycles.
 
-    Do NOT mutate ``done_tasks`` here. It is still read by predict-api
-    write and log emission earlier in this same behaviour, and the
-    behaviour-side prune in the next cycle depends on
-    ``shared_state[DONE_TASKS]`` reflecting only tasks that were not
-    settled — mutating the consensus field here breaks that contract.
+    Do NOT mutate ``done_tasks`` here. It is still read by
+    :class:`PostTxSettlementBehaviour` earlier in the same period for
+    the predict-api write and log emission, and the behaviour-side
+    prune in the next cycle depends on ``shared_state[DONE_TASKS]``
+    reflecting only tasks that were not settled — mutating the
+    consensus field here breaks that contract.
     """
 
     payload_class = PostTxSettlementPayload
@@ -302,21 +321,8 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
         """Process the end of the block."""
         if self.threshold_reached:
-            # Extract the id list from this period's done_tasks and
-            # carry it via ``submitted_request_ids`` for the next
-            # cycle's prune. ``str``-normalise for parity with the
-            # ``str``-keyed dedup rule in
-            # ``TaskPoolingRound.end_block``; downstream match sites
-            # normalise the same way.
-            done_tasks = cast(
-                List[Dict[str, Any]],
-                cast(SynchronizedData, self.synchronized_data).done_tasks,
-            )
-            submitted_ids = [
-                str(task["request_id"])
-                for task in done_tasks
-                if task.get("request_id") is not None and task.get("request_id") != ""
-            ]
+            done_tasks = cast(SynchronizedData, self.synchronized_data).done_tasks
+            submitted_ids = extract_request_ids(done_tasks)
             return (
                 self.synchronized_data.update(
                     synchronized_data_class=SynchronizedData,

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -45,10 +45,11 @@ from packages.valory.skills.task_submission_abci.payloads import (
 def extract_request_ids(tasks: List[Dict[str, Any]]) -> List[str]:
     """Return ``str``-normalised request ids from a task list.
 
-    Falsy ids (missing key, ``None``, empty string) are dropped so
-    they don't collide in downstream match sets. Legit ``0`` (int)
-    is kept via the explicit ``is None or == ""`` check rather than
-    a ``not`` truthiness test.
+    Only two shapes are treated as absent and dropped: the key
+    resolves to ``None``, or to the empty string. Any other value
+    (including ``0`` and ``False``) is kept and stringified — a
+    ``not`` truthiness test would drop those and let a legitimate
+    id disappear silently.
 
     :param tasks: task dicts (each expected to carry ``"request_id"``).
     :return: the ``str``-normalised id list, in input order.
@@ -325,24 +326,8 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
     the server scales naturally across agents.
 
     The round always transitions DONE on threshold: a failed predict-api
-    write does NOT block the FSM (the settlement already landed on-chain,
-    the analytics row just arrives later via the replay buffer). The
-    NO_MAJORITY arm only fires if the agents can't agree on having reached
-    this round at all, which is the same shape as every consensus round.
-
-    On DONE the round writes ``submitted_request_ids`` — the id-only
-    hand-off used by the next cycle's
-    :meth:`TaskPoolingBehaviour.handle_submitted_tasks` to prune
-    ``shared_state[DONE_TASKS]``. ``done_tasks`` itself stays in the
-    period it was set and is not carried across; the ID hand-off is
-    what rides consensus between cycles.
-
-    Do NOT mutate ``done_tasks`` here. It is still read by
-    :class:`PostTxSettlementBehaviour` earlier in the same period for
-    the predict-api write and log emission, and the behaviour-side
-    prune in the next cycle depends on ``shared_state[DONE_TASKS]``
-    reflecting only tasks that were not settled — mutating the
-    consensus field here breaks that contract.
+    write does NOT block the FSM. NO_MAJORITY fires only if the agents
+    can't agree on having reached this round at all.
     """
 
     payload_class = PostTxSettlementPayload
@@ -467,21 +452,12 @@ class TaskSubmissionAbciApp(AbciApp[Event]):
     }
     cross_period_persisted_keys: FrozenSet[str] = frozenset(
         [
-            # Hand-off signal only. ``done_tasks`` is intentionally
-            # not cross-period-persisted because its per-entry payload
-            # data is large enough to inflate DB serialization on the
-            # next registration.
             get_name(SynchronizedData.submitted_request_ids),
             get_name(SynchronizedData.final_tx_hash),
         ]
     )
     db_pre_conditions: Dict[AppState, Set[str]] = {
         TaskPoolingRound: set(),
-        # Entered from composition after settlement. Reads
-        # ``done_tasks`` from the same FSM cycle's earlier
-        # ``TaskPoolingRound`` (present in the current period's DB
-        # slot). end_block writes the id-only
-        # ``submitted_request_ids`` for the next cycle's prune.
         PostTxSettlementRound: set(),
     }
     db_post_conditions: Dict[AppState, Set[str]] = {

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -20,6 +20,7 @@
 """This package contains the rounds of TaskSubmissionAbciApp."""
 
 import json
+import logging
 from enum import Enum
 from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple, cast
 
@@ -99,23 +100,30 @@ class SynchronizedData(BaseSynchronizedData):
         across periods because it holds per-event request/response
         payload data that would inflate DB serialization.
 
-        The value is validated on read: writers must go through
-        :func:`extract_request_ids` so that only ``str`` ids land in
-        the DB. A future writer that bypasses the helper and stores a
-        non-list or non-``str`` entries surfaces as ``TypeError`` here
-        rather than as silent type drift at the consumer.
+        Writers must go through :func:`extract_request_ids` so that
+        only ``str`` ids land in the DB. A future writer that bypasses
+        the helper and stores a non-list or non-``str`` entries logs
+        an error and yields ``[]`` here: raising would crash-loop
+        every participant on the same consensus block (the value is
+        byte-identical across the fleet and cross-period-persisted,
+        so ``db.create`` copies it forward across resets), with no
+        in-band recovery. Returning ``[]`` degrades to "prune nothing
+        this cycle", which is the same shape as a period with no
+        settlement to consume.
 
         :return: the list of request ids from the most recent settlement.
-        :raises TypeError: if the persisted value is not ``list[str]``.
         """
         value = self.db.get("submitted_request_ids", [])
         if not isinstance(value, list) or not all(
             isinstance(item, str) for item in value
         ):
-            raise TypeError(
-                "submitted_request_ids must be a list[str]; got "
-                f"{type(value).__name__}={value!r}"
+            logging.getLogger(__name__).error(
+                "submitted_request_ids invariant broken: expected list[str], "
+                "got %s=%r; degrading to [] for this cycle",
+                type(value).__name__,
+                value,
             )
+            return []
         return value
 
     @property

--- a/packages/valory/skills/task_submission_abci/rounds.py
+++ b/packages/valory/skills/task_submission_abci/rounds.py
@@ -219,10 +219,19 @@ class TaskPoolingRound(CollectionRound):
             unique_done_tasks = sorted(
                 unique_objects, key=lambda x: str(x.get("request_id", ""))
             )
+            # Consume the hand-off from the previous cycle. ``handle_submitted_tasks``
+            # ran in every participant's ``TaskPoolingBehaviour.async_act`` before
+            # this round accepted quorum, so the ids have been read and pruned
+            # everywhere by now. Clearing here in consensus makes the field
+            # one-shot per settlement: the next cycle sees ``[]`` and returns
+            # early rather than re-executing the "already submitted" block on
+            # stale data every period (which would silently re-prune re-swept
+            # requests before they can be pooled).
             synchronized_data = self.synchronized_data.update(
                 synchronized_data_class=SynchronizedData,
                 **{
                     get_name(SynchronizedData.done_tasks): unique_done_tasks,
+                    get_name(SynchronizedData.submitted_request_ids): [],
                 },
             )
             if len(unique_done_tasks) > 0:
@@ -337,6 +346,20 @@ class PostTxSettlementRound(CollectSameUntilThresholdRound):
         """Process the end of the block."""
         if self.threshold_reached:
             done_tasks = cast(SynchronizedData, self.synchronized_data).done_tasks
+            if not done_tasks:
+                # ``PostTxSettlementRound`` is also reached from paths
+                # that carry no task batch: the delivery-rate settlement
+                # (``composition.py`` wires ``FinishedTransactionSubmissionRound``
+                # here for every settlement, not just task delivery) and
+                # a settlement-internal ``ResetRound`` retry (which
+                # drops ``done_tasks`` from the DB via ``db.create``'s
+                # allow-list). Writing ``submitted_request_ids = []``
+                # in those cases would clobber a still-pending hand-off
+                # from a prior real settlement, and the delivered batch
+                # would be re-pooled and re-submitted on-chain next
+                # cycle. When we have no task batch to record, leave
+                # any pending hand-off in place.
+                return self.synchronized_data, Event.DONE
             submitted_ids = extract_request_ids(done_tasks)
             return (
                 self.synchronized_data.update(

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,18 +8,18 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeieetnponid4kir2e5mtuihtbuk6qlaconf522ovpfjhhvlrq5hp6e
+  behaviours.py: bafybeietlxjecs4czaxbin63wvmwxn5moto2ho5dszgowk6xpmwoytrbjy
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeidpqruiwzm62pwobwg7wuxfywkdo6ypq2z6v7zlyce65ruty4kdsm
+  rounds.py: bafybeigjhv6n4wh4eiqhegqxcgpr2rzntqvexzf5tmbi2rmq26ijhjp2um
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeiggxis45rii5wjryqvcfayfmmznn6olxumfet7mq6m5uqrblbamzq
+  tests/test_behaviours.py: bafybeifnbbbicmtyhmb6twbhqd6bttz7ooxuefitovqzcsjqqyarlthil4
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,25 +8,25 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeibuakf3zsqz2hdtmlnlmbjflefr4g2hyky5hvwkoujjblt7sku574
+  behaviours.py: bafybeiep7dhdvoaplfjhqdn2f34ygmslvfaw7n3l7rk6knezsbaocqwhr4
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeicx52a7eud5qcwoba4rlffb27brbx7gmir4bibn7ico4wvdju22fa
+  rounds.py: bafybeifzl7ogcp3jeq45szysz6tmovc6nxvyydf6zeoajqgbbmp7jxicxm
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeiaczsllwrenucnt5fyxeiv5dq5e2lyyiqw4r5o47butw2cd57dnqe
+  tests/test_behaviours.py: bafybeid55ccjl4pj3u7y6dr7ckh2bkoc65dbb66r4bkzbzbusfasiofja4
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
   tests/test_onchain_write_path.py: bafybeiercklygtxznuqo47xevl2ox4yefbi35maom4iivlbkyiq2elut4y
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
-  tests/test_rounds.py: bafybeifhsnakzmpboekozkl6pajhfet2j6xujdh2p6p47jeinzh7juineq
+  tests/test_rounds.py: bafybeidszrxy3wz2iailyc5xdbxvyamufdr6o646plmc3ad2cwe2skpc74
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,14 +8,14 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeifdpeqefa2rwh3bcxpadfscnf3rntbhau5toks3ljri2w7u2zcfu4
+  behaviours.py: bafybeieetnponid4kir2e5mtuihtbuk6qlaconf522ovpfjhhvlrq5hp6e
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeifzl7ogcp3jeq45szysz6tmovc6nxvyydf6zeoajqgbbmp7jxicxm
+  rounds.py: bafybeidpqruiwzm62pwobwg7wuxfywkdo6ypq2z6v7zlyce65ruty4kdsm
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -26,7 +26,7 @@ fingerprint:
   tests/test_onchain_write_path.py: bafybeiercklygtxznuqo47xevl2ox4yefbi35maom4iivlbkyiq2elut4y
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
-  tests/test_rounds.py: bafybeidszrxy3wz2iailyc5xdbxvyamufdr6o646plmc3ad2cwe2skpc74
+  tests/test_rounds.py: bafybeid3ncxzxxqkegh256cgz2vqsz3dfrq7cilvm6qhnfqx6a7waaim7m
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiep7dhdvoaplfjhqdn2f34ygmslvfaw7n3l7rk6knezsbaocqwhr4
+  behaviours.py: bafybeifdpeqefa2rwh3bcxpadfscnf3rntbhau5toks3ljri2w7u2zcfu4
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -19,7 +19,7 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeid55ccjl4pj3u7y6dr7ckh2bkoc65dbb66r4bkzbzbusfasiofja4
+  tests/test_behaviours.py: bafybeibij4xoqpd6gz2mxydgcdlfxf5wewveerb75y4u2t422fteypxnba
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,18 +8,18 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeieufec2vs4jxo3f6qaqacts2roitzcr62ju2ii3ehbdkc7o6wgxnq
+  behaviours.py: bafybeibuakf3zsqz2hdtmlnlmbjflefr4g2hyky5hvwkoujjblt7sku574
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeihdwkonnhqk5aixazrjob3hqfitjiuw44is4slaftat2do7p7kr3u
+  rounds.py: bafybeia64ymolcchh42ghcv2epmbgfqr54hnzuezpsi4h4bvxv76lvcwka
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeieusidfbahmf3g6jw6xipccv27xdlnepjs2jvza4qdpyalbnmoz3i
+  tests/test_behaviours.py: bafybeiaczsllwrenucnt5fyxeiv5dq5e2lyyiqw4r5o47butw2cd57dnqe
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeia64ymolcchh42ghcv2epmbgfqr54hnzuezpsi4h4bvxv76lvcwka
+  rounds.py: bafybeicx52a7eud5qcwoba4rlffb27brbx7gmir4bibn7ico4wvdju22fa
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
@@ -26,7 +26,7 @@ fingerprint:
   tests/test_onchain_write_path.py: bafybeiercklygtxznuqo47xevl2ox4yefbi35maom4iivlbkyiq2elut4y
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
-  tests/test_rounds.py: bafybeidp3qdieapj5yccpvt3tkc7rt46zay6fl2jkgclinyjmyxpmqtdoa
+  tests/test_rounds.py: bafybeifhsnakzmpboekozkl6pajhfet2j6xujdh2p6p47jeinzh7juineq
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,25 +8,25 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiawsfiwup4g6akxkxubzf3izttlfeb32hrhe5jid2tspxytl4axfa
+  behaviours.py: bafybeigfb63rkqvvh7y5nnuufa6lcfricn7bk7vqmuw6372erheecttqti
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeidt43y5ohj4so67dvs57w7hotnezlc22kvixquvkqeumtzivwd74y
+  rounds.py: bafybeidss3suugcpdawrwg5i5jzi26bguk4hh54us4ctxgsj3ntb3iozim
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeihcxzh3drnwdxjbjxw5owqqyqq7cihbqqjzgfzrdzng3sp5mvahem
+  tests/test_behaviours.py: bafybeic3qeh5u5tukru2deiuml4i6nopouowdzpo2t37ynbkga4wvbkmga
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
   tests/test_onchain_write_path.py: bafybeiercklygtxznuqo47xevl2ox4yefbi35maom4iivlbkyiq2elut4y
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
-  tests/test_rounds.py: bafybeigzbclqwozy2itqi4bs3tr6w2xghw3wb7ie3zyrteytptd5jtsywu
+  tests/test_rounds.py: bafybeidp3qdieapj5yccpvt3tkc7rt46zay6fl2jkgclinyjmyxpmqtdoa
   tests/test_tasks.py: bafybeifdnscfudthqjadvnigxiqgy74xzefrn6f3xiowhhwcc5ujztodym
 fingerprint_ignore_patterns: []
 connections: []

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -19,7 +19,7 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeibij4xoqpd6gz2mxydgcdlfxf5wewveerb75y4u2t422fteypxnba
+  tests/test_behaviours.py: bafybeiggxis45rii5wjryqvcfayfmmznn6olxumfet7mq6m5uqrblbamzq
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,18 +8,18 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeigfb63rkqvvh7y5nnuufa6lcfricn7bk7vqmuw6372erheecttqti
+  behaviours.py: bafybeieufec2vs4jxo3f6qaqacts2roitzcr62ju2ii3ehbdkc7o6wgxnq
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
   models.py: bafybeihi4udsewau7p73t4vqnasywm5kicydrrggxcdz4skxoulfykvl5i
   payloads.py: bafybeiaaelmpfuv6pvuesj7iy2nnxvgxjketigrppurto2pbsoaqjum2ba
   predict_api_events_client.py: bafybeie7yu4ygy4gnpc6yekhnhbtdgtferzzaoyzj4nhenyune7hnhswvm
-  rounds.py: bafybeidss3suugcpdawrwg5i5jzi26bguk4hh54us4ctxgsj3ntb3iozim
+  rounds.py: bafybeihdwkonnhqk5aixazrjob3hqfitjiuw44is4slaftat2do7p7kr3u
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeic3qeh5u5tukru2deiuml4i6nopouowdzpo2t37ynbkga4wvbkmga
+  tests/test_behaviours.py: bafybeieusidfbahmf3g6jw6xipccv27xdlnepjs2jvza4qdpyalbnmoz3i
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -877,6 +877,89 @@ class TestHandleSubmittedTasks:
         # Prune still ran end-to-end despite the metric skip.
         assert b.context.shared_state[DONE_TASKS] == []
 
+    def test_prune_acquires_done_tasks_lock(self) -> None:
+        """The live prune path MUST hold ``done_tasks_lock``.
+
+        Without this, dropping the ``with`` around the prune would
+        pass every other test in the suite silently — the background
+        executor's concurrent append could then torn-read the metrics
+        loop's snapshot. Directly assert the lock is entered.
+        """
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [
+            {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()},
+        ]
+        mock_lock = MagicMock()
+        mock_lock.__enter__ = MagicMock(return_value=None)
+        mock_lock.__exit__ = MagicMock(return_value=None)
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, submitted_ids=["r1"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram"),
+            patch.object(b, "done_tasks_lock", return_value=mock_lock),
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        mock_lock.__enter__.assert_called_once()
+        mock_lock.__exit__.assert_called_once()
+
+    def test_str_normalisation_matches_legacy_int_on_live_path(self) -> None:
+        """Live prune path str-normalises the shared_state side of the match.
+
+        The reviewer flagged that ``0518c00e`` moved the prune inline
+        and the only test guarding the ``str()`` normalisation lived
+        on ``remove_tasks_by_id`` (which the live path used to
+        bypass). After the consolidation the live path calls
+        ``remove_tasks_by_id`` again, but pin it end-to-end here so a
+        future re-inlining that drops the normalisation surfaces.
+        """
+        b = self._make_b()
+        # Shared state carries the legacy ``int`` shape; the incoming
+        # id list is ``List[str]`` per the type contract.
+        b.context.shared_state[DONE_TASKS] = [
+            {"request_id": 5, "tool": "t1", "start_time": time.perf_counter()},
+        ]
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, submitted_ids=["5"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram"),
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        assert b.context.shared_state[DONE_TASKS] == []
+
+    def test_prune_runs_before_block_number_fetch(self) -> None:
+        """The prune completes before the ``_fetch_tx_block_number`` yield.
+
+        A cancellation at the yield must not leave the delivered
+        batch un-pruned. Sending ``GeneratorExit`` at the first yield
+        would mid-execute the metrics block and prune only if either
+        happens after the yield. Pin the invariant by asserting that
+        with the yield replaced by a raise, ``shared_state`` is
+        already pruned.
+        """
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [
+            {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()},
+        ]
+
+        def _raising_yield(_tx_hash: str) -> Generator[None, None, None]:
+            if False:
+                yield  # pragma: no cover - satisfy typing
+            raise RuntimeError("simulated yield failure")
+
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, submitted_ids=["r1"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_raising_yield),
+            patch.object(b, "observe_histogram"),
+        ):
+            with pytest.raises(RuntimeError, match="simulated yield failure"):
+                _run_gen(b.handle_submitted_tasks())
+        # If the prune had been moved below the yield, this would
+        # still be ``[{'request_id': 'r1', ...}]``.
+        assert b.context.shared_state[DONE_TASKS] == []
+
 
 # ---------------------------------------------------------------------------
 # End-to-end hand-off contract (round-side write ↔ behaviour-side read)

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -832,17 +832,36 @@ class TestHandleSubmittedTasks:
         # metric is dropped.
         mock_remove.assert_called_once_with(["r1"])
 
-    def test_histogram_skipped_when_task_missing_tool_or_start_time(self) -> None:
+    @pytest.mark.parametrize(
+        "task",
+        [
+            pytest.param(
+                {"request_id": "r1", "start_time": 0.0},
+                id="tool-missing",
+            ),
+            pytest.param(
+                {"request_id": "r1", "tool": "t1"},
+                id="start_time-missing",
+            ),
+        ],
+    )
+    def test_histogram_skipped_when_task_missing_tool_or_start_time(
+        self, task: Dict[str, Any]
+    ) -> None:
         """Skip the histogram when ``tool`` or ``start_time`` is absent.
 
-        Task-execution failures produce entries without ``tool``;
-        emitting a histogram sample against ``tool=None`` would push
-        a nonsense label into the metric.
+        Task-execution failures produce entries without ``tool``, and
+        early-abort paths can produce entries without ``start_time``.
+        Emitting a histogram sample against either as ``None`` would
+        push a nonsense label / negative duration into the metric.
+        Both halves of the guard are exercised so a mutation that
+        weakens either half surfaces here.
+
+        :param task: parametrised done-task shape (missing ``tool``
+            in one case, missing ``start_time`` in the other).
         """
-        # Task present in shared_state but missing ``tool``.
-        task_missing_tool = {"request_id": "r1", "start_time": time.perf_counter()}
         b = self._make_b()
-        b.context.shared_state[DONE_TASKS] = [task_missing_tool]
+        b.context.shared_state[DONE_TASKS] = [task]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
             self._patch_sd(b, submitted_ids=["r1"]),

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -220,20 +220,12 @@ class TestRemoveTasks:
     def test_remove_submitted_task_mixed_types(self) -> None:
         """``remove_tasks`` matches across the ``str`` / ``int`` split.
 
-        Post the ingress coercion in :mod:`task_execution.handlers`,
-        off-chain ``done_tasks`` carry ``request_id`` as ``int``. But a
-        mech resuming with pre-fix off-chain rows in shared state at
-        redeploy time would have ``str`` there, while the newly-emitted
-        ``submitted_tasks`` for the same round carry ``int``. Without
-        the ``str()`` normalization added to the equality check in
-        :meth:`TaskExecutionBaseBehaviour.remove_tasks`, the pre-fix
-        ``str`` row would silently escape removal and be re-emitted next
-        round — the same class of silent-double-delivery bug the dedup
-        normalization in :mod:`task_submission_abci.rounds` prevents.
+        Mixed ``request_id`` types (``str`` vs ``int``) can survive
+        an in-place restart. Both sides are ``str``-normalised on the
+        equality check so a delivered task doesn't silently escape
+        removal and get re-emitted.
         """
-        # Pre-fix ``str`` row survives from an old boot; new
-        # ``submitted_tasks`` for the same request_id comes back as
-        # ``int``.
+        # ``str`` in shared_state; ``int`` in submitted.
         done_tasks_str: List[Dict[str, Any]] = [{"request_id": "5"}]
         ctx = _make_ctx(done_tasks=done_tasks_str)
         b = _DummyBase(name="b", skill_context=ctx)
@@ -246,6 +238,69 @@ class TestRemoveTasks:
         b = _DummyBase(name="b", skill_context=ctx)
         b.remove_tasks([{"request_id": "5"}])
         assert ctx.shared_state[DONE_TASKS] == []
+
+
+class TestRemoveTasksById:
+    """Tests for :meth:`TaskExecutionBaseBehaviour.remove_tasks_by_id`."""
+
+    def test_removes_matching_task(self) -> None:
+        """Passing an id list prunes matching tasks and leaves the rest."""
+        tasks = [{"request_id": "r1"}, {"request_id": "r2"}]
+        ctx = _make_ctx(done_tasks=tasks)
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id(["r1"])
+        remaining = ctx.shared_state[DONE_TASKS]
+        assert len(remaining) == 1
+        assert remaining[0]["request_id"] == "r2"
+
+    def test_empty_id_list_is_noop(self) -> None:
+        """An empty id list leaves shared_state untouched."""
+        tasks = [{"request_id": "r1"}]
+        ctx = _make_ctx(done_tasks=tasks)
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id([])
+        assert ctx.shared_state[DONE_TASKS] == tasks
+
+    def test_all_ids_leaves_empty(self) -> None:
+        """Passing every id present clears shared_state."""
+        tasks = [{"request_id": "r1"}, {"request_id": "r2"}]
+        ctx = _make_ctx(done_tasks=tasks)
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id(["r1", "r2"])
+        assert ctx.shared_state[DONE_TASKS] == []
+
+    def test_mixed_type_ids_match_normalised(self) -> None:
+        """``str`` / ``int`` id mismatch across boot boundaries still matches.
+
+        A shared_state row carrying ``int`` and an incoming id list of
+        ``str`` (or vice versa) both normalise to ``str`` on the
+        equality check.
+        """
+        # str shared_state / int id list
+        ctx = _make_ctx(done_tasks=[{"request_id": "5"}])
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id([5])  # type: ignore[list-item]
+        assert ctx.shared_state[DONE_TASKS] == []
+
+        # int shared_state / str id list
+        ctx = _make_ctx(done_tasks=[{"request_id": 5}])
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id(["5"])
+        assert ctx.shared_state[DONE_TASKS] == []
+
+    def test_id_not_in_shared_state_is_noop(self) -> None:
+        """An id absent from shared_state doesn't affect other entries.
+
+        Guards the case where the executor lost state (restart or
+        prune-race) between the on-chain settle and the next prune.
+        The id is still valid for the marketplace side; we just skip
+        the pop safely.
+        """
+        tasks = [{"request_id": "r1"}]
+        ctx = _make_ctx(done_tasks=tasks)
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id(["r-missing"])
+        assert ctx.shared_state[DONE_TASKS] == tasks
 
 
 class TestSetGauge:
@@ -659,9 +714,32 @@ class TestHandleSubmittedTasks:
         b = _DummyPooling(name="b", skill_context=ctx)
         return b
 
-    def _patch_sd(self, b: Any, done_tasks: Any) -> Any:
+    def _patch_sd(
+        self,
+        b: Any,
+        done_tasks: Any,
+        submitted_ids: Any = None,
+    ) -> Any:
+        """Wire the mocked synchronized_data.
+
+        ``submitted_ids=None`` exercises the fallback path (the DB key
+        isn't set, prune reads ``done_tasks`` instead). Passing a list
+        exercises the primary path where the id hand-off is available.
+
+        :param b: the behaviour under test to attach the mock onto.
+        :param done_tasks: value to expose as ``synchronized_data.done_tasks``.
+        :param submitted_ids: value the mocked ``db.get`` returns for
+            ``"submitted_request_ids"``; ``None`` triggers the fallback.
+        :return: a no-op context manager so the caller's ``with`` block stays uniform.
+        """
         mock_sd = MagicMock()
         mock_sd.done_tasks = done_tasks
+        # ``db.get(key, default)`` returns the second arg when key is
+        # missing. Configure the mock to mimic that shape so the code
+        # under test hits the intended branch.
+        mock_sd.db.get.side_effect = lambda key, default=None: (
+            submitted_ids if key == "submitted_request_ids" else default
+        )
         b._synchronized_data = mock_sd
         return contextlib.nullcontext()
 
@@ -677,7 +755,7 @@ class TestHandleSubmittedTasks:
         b = self._make_b()
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, []),
+            self._patch_sd(b, [], submitted_ids=[]),
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
@@ -686,9 +764,10 @@ class TestHandleSubmittedTasks:
         """Test status true with tasks no block number."""
         task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
         b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [task]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, [task]),
+            self._patch_sd(b, [task], submitted_ids=["r1"]),
             patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
             patch.object(b, "observe_histogram"),
         ):
@@ -699,9 +778,10 @@ class TestHandleSubmittedTasks:
         """Test status true with tasks and block number."""
         task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
         b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [task]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, [task]),
+            self._patch_sd(b, [task], submitted_ids=["r1"]),
             patch.object(
                 b, "_fetch_tx_block_number", side_effect=_gen_returning(12345)
             ),
@@ -710,6 +790,62 @@ class TestHandleSubmittedTasks:
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
+
+    def test_reads_submitted_request_ids_when_present(self) -> None:
+        """Primary path: id list from the DB drives the prune.
+
+        Once ``PostTxSettlementRound`` has written the id list,
+        subsequent cycles use it directly rather than parsing full
+        ``done_tasks`` dicts.
+        """
+        task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [task]
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            # done_tasks intentionally EMPTY to prove the code doesn't
+            # fall back to it when submitted_ids is provided.
+            self._patch_sd(b, done_tasks=[], submitted_ids=["r1"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram"),
+            patch.object(b, "remove_tasks_by_id") as mock_remove,
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        mock_remove.assert_called_once_with(["r1"])
+
+    def test_falls_back_to_done_tasks_when_ids_missing(self) -> None:
+        """Fallback path: no id list yet → read from done_tasks.
+
+        Applies for the first cycle on a mech whose persisted state
+        predates ``submitted_request_ids`` being written. After this
+        cycle, ``PostTxSettlementRound`` writes the id list and
+        subsequent cycles take the primary path.
+        """
+        task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [task]
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            # submitted_ids=None triggers the fallback branch; the
+            # code should derive the id list from done_tasks.
+            self._patch_sd(b, done_tasks=[task], submitted_ids=None),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram"),
+            patch.object(b, "remove_tasks_by_id") as mock_remove,
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        mock_remove.assert_called_once_with(["r1"])
+
+    def test_empty_submitted_ids_is_noop(self) -> None:
+        """An empty id list → early return, no prune call."""
+        b = self._make_b()
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, done_tasks=[], submitted_ids=[]),
+            patch.object(b, "remove_tasks_by_id") as mock_remove,
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        mock_remove.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -723,11 +723,14 @@ class TestHandleSubmittedTasks:
         return contextlib.nullcontext()
 
     def test_status_false_removes_nothing(self) -> None:
-        """Test status false removes nothing."""
+        """A failed prior-tx status leaves ``shared_state[DONE_TASKS]`` untouched."""
         b = self._make_b()
+        seeded = [{"request_id": "r1", "tool": "t1"}]
+        b.context.shared_state[DONE_TASKS] = list(seeded)
         with patch.object(b, "check_last_tx_status", return_value=(False, "")):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
+        assert b.context.shared_state[DONE_TASKS] == seeded
 
     def test_status_true_empty_tasks(self) -> None:
         """Test status true empty tasks."""
@@ -740,7 +743,7 @@ class TestHandleSubmittedTasks:
         assert result is None
 
     def test_status_true_with_tasks_no_block_number(self) -> None:
-        """Test status true with tasks no block number."""
+        """The task is pruned from shared_state and its histogram fires."""
         task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
         b = self._make_b()
         b.context.shared_state[DONE_TASKS] = [task]
@@ -752,6 +755,8 @@ class TestHandleSubmittedTasks:
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
+        # End-to-end contract: the submitted id is gone from shared_state.
+        assert b.context.shared_state[DONE_TASKS] == []
         # Histogram MUST fire for the task in shared_state; a regression
         # that flips the ``if task is None`` guard would silently skip
         # the emit without this assertion.
@@ -760,7 +765,7 @@ class TestHandleSubmittedTasks:
         assert kwargs["tool"] == "t1"
 
     def test_status_true_with_tasks_and_block_number(self) -> None:
-        """Test status true with tasks and block number."""
+        """Same as above but with a block number → gauge fires too."""
         task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
         b = self._make_b()
         b.context.shared_state[DONE_TASKS] = [task]
@@ -771,46 +776,51 @@ class TestHandleSubmittedTasks:
                 b, "_fetch_tx_block_number", side_effect=_gen_returning(12345)
             ),
             patch.object(b, "observe_histogram") as mock_hist,
-            patch.object(b, "set_gauge"),
+            patch.object(b, "set_gauge") as mock_gauge,
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
+        assert b.context.shared_state[DONE_TASKS] == []
         mock_hist.assert_called_once()
         _, kwargs = mock_hist.call_args
         assert kwargs["tool"] == "t1"
+        mock_gauge.assert_called_once()
 
     def test_reads_submitted_request_ids_when_present(self) -> None:
-        """Primary path: the id list drives the prune call."""
+        """Primary path: the id list drives the shared_state prune."""
         task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
+        other = {"request_id": "r2", "tool": "t2", "start_time": time.perf_counter()}
         b = self._make_b()
-        b.context.shared_state[DONE_TASKS] = [task]
+        b.context.shared_state[DONE_TASKS] = [task, other]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
             self._patch_sd(b, submitted_ids=["r1"]),
             patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
             patch.object(b, "observe_histogram"),
-            patch.object(b, "remove_tasks_by_id") as mock_remove,
         ):
             _run_gen(b.handle_submitted_tasks())
-        mock_remove.assert_called_once_with(["r1"])
+        # r1 pruned, r2 kept.
+        assert b.context.shared_state[DONE_TASKS] == [other]
 
     def test_empty_submitted_ids_is_noop(self) -> None:
-        """An empty id list → early return, no prune call."""
+        """An empty id list → early return, shared_state untouched."""
         b = self._make_b()
+        seeded = [{"request_id": "r1", "tool": "t1"}]
+        b.context.shared_state[DONE_TASKS] = list(seeded)
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
             self._patch_sd(b, submitted_ids=[]),
-            patch.object(b, "remove_tasks_by_id") as mock_remove,
         ):
             _run_gen(b.handle_submitted_tasks())
-        mock_remove.assert_not_called()
+        assert b.context.shared_state[DONE_TASKS] == seeded
 
     def test_histogram_skipped_when_task_absent_from_shared_state(self) -> None:
         """Skip the histogram when the task is absent from shared state.
 
-        The prune still fires because the delivery landed on-chain.
-        Guards the ``if task is None`` continue branch so a regression
-        that flips the guard would surface here instead of silently
+        The prune loop still runs (the delivery landed on-chain);
+        only the timing metric is dropped for that entry. Guards the
+        ``if task is None`` continue branch so a regression that
+        flips the guard would surface here instead of silently
         emitting garbage timings.
         """
         b = self._make_b()
@@ -820,13 +830,11 @@ class TestHandleSubmittedTasks:
             self._patch_sd(b, submitted_ids=["r1"]),
             patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
             patch.object(b, "observe_histogram") as mock_hist,
-            patch.object(b, "remove_tasks_by_id") as mock_remove,
         ):
             _run_gen(b.handle_submitted_tasks())
         mock_hist.assert_not_called()
-        # Prune still runs — delivery landed on-chain, only the timing
-        # metric is dropped.
-        mock_remove.assert_called_once_with(["r1"])
+        # Prune still ran (no-op here since shared_state was empty).
+        assert b.context.shared_state[DONE_TASKS] == []
 
     @pytest.mark.parametrize(
         "task",
@@ -863,11 +871,11 @@ class TestHandleSubmittedTasks:
             self._patch_sd(b, submitted_ids=["r1"]),
             patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
             patch.object(b, "observe_histogram") as mock_hist,
-            patch.object(b, "remove_tasks_by_id") as mock_remove,
         ):
             _run_gen(b.handle_submitted_tasks())
         mock_hist.assert_not_called()
-        mock_remove.assert_called_once_with(["r1"])
+        # Prune still ran end-to-end despite the metric skip.
+        assert b.context.shared_state[DONE_TASKS] == []
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -269,20 +269,16 @@ class TestRemoveTasksById:
         b.remove_tasks_by_id(["r1", "r2"])
         assert ctx.shared_state[DONE_TASKS] == []
 
-    def test_mixed_type_ids_match_normalised(self) -> None:
-        """``str`` / ``int`` id mismatch across boot boundaries still matches.
+    def test_int_shared_state_matches_str_id(self) -> None:
+        """A legacy ``int`` in shared_state is matched by a ``str`` id.
 
-        A shared_state row carrying ``int`` and an incoming id list of
-        ``str`` (or vice versa) both normalise to ``str`` on the
-        equality check.
+        The id list side is typed ``List[str]``; callers must go
+        through :func:`extract_request_ids` which normalises to
+        ``str`` at the write site. The shared_state side, in
+        contrast, may still carry legacy ``int`` request_ids from a
+        pre-fix boot, so this direction of the equality is normalised
+        via ``str(done_task.get("request_id"))`` on lookup.
         """
-        # str shared_state / int id list
-        ctx = _make_ctx(done_tasks=[{"request_id": "5"}])
-        b = _DummyBase(name="b", skill_context=ctx)
-        b.remove_tasks_by_id([5])
-        assert ctx.shared_state[DONE_TASKS] == []
-
-        # int shared_state / str id list
         ctx = _make_ctx(done_tasks=[{"request_id": 5}])
         b = _DummyBase(name="b", skill_context=ctx)
         b.remove_tasks_by_id(["5"])

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -279,7 +279,7 @@ class TestRemoveTasksById:
         # str shared_state / int id list
         ctx = _make_ctx(done_tasks=[{"request_id": "5"}])
         b = _DummyBase(name="b", skill_context=ctx)
-        b.remove_tasks_by_id([5])  # type: ignore[list-item]
+        b.remove_tasks_by_id([5])
         assert ctx.shared_state[DONE_TASKS] == []
 
         # int shared_state / str id list
@@ -714,32 +714,15 @@ class TestHandleSubmittedTasks:
         b = _DummyPooling(name="b", skill_context=ctx)
         return b
 
-    def _patch_sd(
-        self,
-        b: Any,
-        done_tasks: Any,
-        submitted_ids: Any = None,
-    ) -> Any:
-        """Wire the mocked synchronized_data.
-
-        ``submitted_ids=None`` exercises the fallback path (the DB key
-        isn't set, prune reads ``done_tasks`` instead). Passing a list
-        exercises the primary path where the id hand-off is available.
+    def _patch_sd(self, b: Any, submitted_ids: List[str]) -> Any:
+        """Wire the mocked synchronized_data with a fixed id list.
 
         :param b: the behaviour under test to attach the mock onto.
-        :param done_tasks: value to expose as ``synchronized_data.done_tasks``.
-        :param submitted_ids: value the mocked ``db.get`` returns for
-            ``"submitted_request_ids"``; ``None`` triggers the fallback.
+        :param submitted_ids: value the property returns.
         :return: a no-op context manager so the caller's ``with`` block stays uniform.
         """
         mock_sd = MagicMock()
-        mock_sd.done_tasks = done_tasks
-        # ``db.get(key, default)`` returns the second arg when key is
-        # missing. Configure the mock to mimic that shape so the code
-        # under test hits the intended branch.
-        mock_sd.db.get.side_effect = lambda key, default=None: (
-            submitted_ids if key == "submitted_request_ids" else default
-        )
+        mock_sd.submitted_request_ids = submitted_ids
         b._synchronized_data = mock_sd
         return contextlib.nullcontext()
 
@@ -755,7 +738,7 @@ class TestHandleSubmittedTasks:
         b = self._make_b()
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, [], submitted_ids=[]),
+            self._patch_sd(b, submitted_ids=[]),
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
@@ -767,12 +750,18 @@ class TestHandleSubmittedTasks:
         b.context.shared_state[DONE_TASKS] = [task]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, [task], submitted_ids=["r1"]),
+            self._patch_sd(b, submitted_ids=["r1"]),
             patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
-            patch.object(b, "observe_histogram"),
+            patch.object(b, "observe_histogram") as mock_hist,
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
+        # Histogram MUST fire for the task in shared_state; a regression
+        # that flips the ``if task is None`` guard would silently skip
+        # the emit without this assertion.
+        mock_hist.assert_called_once()
+        _, kwargs = mock_hist.call_args
+        assert kwargs["tool"] == "t1"
 
     def test_status_true_with_tasks_and_block_number(self) -> None:
         """Test status true with tasks and block number."""
@@ -781,54 +770,27 @@ class TestHandleSubmittedTasks:
         b.context.shared_state[DONE_TASKS] = [task]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, [task], submitted_ids=["r1"]),
+            self._patch_sd(b, submitted_ids=["r1"]),
             patch.object(
                 b, "_fetch_tx_block_number", side_effect=_gen_returning(12345)
             ),
-            patch.object(b, "observe_histogram"),
+            patch.object(b, "observe_histogram") as mock_hist,
             patch.object(b, "set_gauge"),
         ):
             result = _run_gen(b.handle_submitted_tasks())
         assert result is None
+        mock_hist.assert_called_once()
+        _, kwargs = mock_hist.call_args
+        assert kwargs["tool"] == "t1"
 
     def test_reads_submitted_request_ids_when_present(self) -> None:
-        """Primary path: id list from the DB drives the prune.
-
-        Once ``PostTxSettlementRound`` has written the id list,
-        subsequent cycles use it directly rather than parsing full
-        ``done_tasks`` dicts.
-        """
+        """Primary path: the id list drives the prune call."""
         task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
         b = self._make_b()
         b.context.shared_state[DONE_TASKS] = [task]
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            # done_tasks intentionally EMPTY to prove the code doesn't
-            # fall back to it when submitted_ids is provided.
-            self._patch_sd(b, done_tasks=[], submitted_ids=["r1"]),
-            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
-            patch.object(b, "observe_histogram"),
-            patch.object(b, "remove_tasks_by_id") as mock_remove,
-        ):
-            _run_gen(b.handle_submitted_tasks())
-        mock_remove.assert_called_once_with(["r1"])
-
-    def test_falls_back_to_done_tasks_when_ids_missing(self) -> None:
-        """Fallback path: no id list yet → read from done_tasks.
-
-        Applies for the first cycle on a mech whose persisted state
-        predates ``submitted_request_ids`` being written. After this
-        cycle, ``PostTxSettlementRound`` writes the id list and
-        subsequent cycles take the primary path.
-        """
-        task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
-        b = self._make_b()
-        b.context.shared_state[DONE_TASKS] = [task]
-        with (
-            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            # submitted_ids=None triggers the fallback branch; the
-            # code should derive the id list from done_tasks.
-            self._patch_sd(b, done_tasks=[task], submitted_ids=None),
+            self._patch_sd(b, submitted_ids=["r1"]),
             patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
             patch.object(b, "observe_histogram"),
             patch.object(b, "remove_tasks_by_id") as mock_remove,
@@ -841,11 +803,56 @@ class TestHandleSubmittedTasks:
         b = self._make_b()
         with (
             patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
-            self._patch_sd(b, done_tasks=[], submitted_ids=[]),
+            self._patch_sd(b, submitted_ids=[]),
             patch.object(b, "remove_tasks_by_id") as mock_remove,
         ):
             _run_gen(b.handle_submitted_tasks())
         mock_remove.assert_not_called()
+
+    def test_histogram_skipped_when_task_absent_from_shared_state(self) -> None:
+        """Skip the histogram when the task is absent from shared state.
+
+        The prune still fires because the delivery landed on-chain.
+        Guards the ``if task is None`` continue branch so a regression
+        that flips the guard would surface here instead of silently
+        emitting garbage timings.
+        """
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = []  # id present in ids, absent here
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, submitted_ids=["r1"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram") as mock_hist,
+            patch.object(b, "remove_tasks_by_id") as mock_remove,
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        mock_hist.assert_not_called()
+        # Prune still runs — delivery landed on-chain, only the timing
+        # metric is dropped.
+        mock_remove.assert_called_once_with(["r1"])
+
+    def test_histogram_skipped_when_task_missing_tool_or_start_time(self) -> None:
+        """Skip the histogram when ``tool`` or ``start_time`` is absent.
+
+        Task-execution failures produce entries without ``tool``;
+        emitting a histogram sample against ``tool=None`` would push
+        a nonsense label into the metric.
+        """
+        # Task present in shared_state but missing ``tool``.
+        task_missing_tool = {"request_id": "r1", "start_time": time.perf_counter()}
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [task_missing_tool]
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, submitted_ids=["r1"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram") as mock_hist,
+            patch.object(b, "remove_tasks_by_id") as mock_remove,
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        mock_hist.assert_not_called()
+        mock_remove.assert_called_once_with(["r1"])
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -879,6 +879,70 @@ class TestHandleSubmittedTasks:
 
 
 # ---------------------------------------------------------------------------
+# End-to-end hand-off contract (round-side write ↔ behaviour-side read)
+# ---------------------------------------------------------------------------
+
+
+class TestSubmittedRequestIdsRoundTrip:
+    """Pins the write→read hand-off using real ``SynchronizedData``.
+
+    The other behaviour-side tests replace ``synchronized_data`` with
+    a ``MagicMock``; that leaves the real property (including its
+    ``list[str]`` validation) unexercised on the behaviour path, so a
+    rename or deletion of the property would pass silently. This
+    class exercises the actual round writer, feeds the resulting
+    synced data to the behaviour, and asserts the prune reaches
+    ``shared_state[DONE_TASKS]``.
+    """
+
+    def _make_sync_data_with_ids(self, ids: List[str]) -> Any:
+        """Build a real ``SynchronizedData`` carrying ``submitted_request_ids``."""
+        from packages.valory.skills.abstract_round_abci.base import (
+            AbciAppDB,
+            get_name,
+        )
+        from packages.valory.skills.task_submission_abci.rounds import (
+            SynchronizedData,
+        )
+
+        data: dict = {
+            "participants": [["agent-0", "agent-1", "agent-2"]],
+            "consensus_threshold": [3],
+            "all_participants": [["agent-0", "agent-1", "agent-2"]],
+            get_name(SynchronizedData.final_tx_hash): ["0xhash"],
+            get_name(SynchronizedData.submitted_request_ids): [ids],
+        }
+        return SynchronizedData(AbciAppDB(data))
+
+    def test_end_to_end_prune_using_real_synchronized_data(self) -> None:
+        """A real ``SynchronizedData`` drives the prune to shared_state.
+
+        Round writer → behaviour reader → shared_state prune. If the
+        property name or ``list[str]`` validation changes, this test
+        catches the drift.
+        """
+        ctx = _make_full_ctx()
+        ctx.shared_state["mech_delivery_last_block_number"] = MagicMock()
+        b = _DummyPooling(name="b", skill_context=ctx)
+        b._synchronized_data = self._make_sync_data_with_ids(["req-a", "req-b"])
+        b.context.shared_state[DONE_TASKS] = [
+            {"request_id": "req-a", "tool": "t1", "start_time": time.perf_counter()},
+            {"request_id": "req-b", "tool": "t2", "start_time": time.perf_counter()},
+            {"request_id": "req-keep", "tool": "t3"},
+        ]
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram"),
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        remaining_ids = [
+            task["request_id"] for task in b.context.shared_state[DONE_TASKS]
+        ]
+        assert remaining_ids == ["req-keep"]
+
+
+# ---------------------------------------------------------------------------
 # DeliverBehaviour._get_current_delivery_report
 # ---------------------------------------------------------------------------
 

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from packages.valory.skills.abstract_round_abci.base import AbciAppDB
+from packages.valory.skills.abstract_round_abci.base import AbciAppDB, get_name
 from packages.valory.skills.task_submission_abci.payloads import (
     PostTxSettlementPayload,
     TaskPoolingPayload,
@@ -195,6 +195,65 @@ class TestTaskPoolingRound:
         assert result is not None
         data, event = result
         assert event == Event.NO_TASKS
+
+    def test_submitted_request_ids_cleared_on_done(self) -> None:
+        """DONE clears the hand-off from the previous cycle.
+
+        By the time ``end_block`` fires here, every participant's
+        ``TaskPoolingBehaviour.async_act`` has already run
+        ``handle_submitted_tasks`` and pruned its local
+        ``shared_state[DONE_TASKS]``. Clearing the consensus field
+        makes the hand-off one-shot: without this, the next cycle
+        re-runs the "already submitted" block on stale ids every
+        period, and re-swept requests get pruned before they can be
+        pooled.
+        """
+        task = _make_task("req-new")
+        payloads = {
+            "agent-0": _payload_for("agent-0", [task]),
+            "agent-1": _payload_for("agent-1", [task]),
+            "agent-2": _payload_for("agent-2", [task]),
+        }
+        round_ = _make_pooling_round(
+            payloads,
+            **{
+                get_name(SynchronizedData.submitted_request_ids): [
+                    "stale-a",
+                    "stale-b",
+                ]
+            },
+        )
+        result = round_.end_block()
+        assert result is not None
+        data, event = result
+        assert event == Event.DONE
+        assert cast(SynchronizedData, data).submitted_request_ids == []
+
+    def test_submitted_request_ids_cleared_on_no_tasks(self) -> None:
+        """NO_TASKS also clears the hand-off.
+
+        A cycle that produced no new tasks still needs to consume the
+        prior settlement's ids so the next cycle doesn't loop on them.
+        """
+        payloads = {
+            "agent-0": _payload_for("agent-0", []),
+            "agent-1": _payload_for("agent-1", []),
+            "agent-2": _payload_for("agent-2", []),
+        }
+        round_ = _make_pooling_round(
+            payloads,
+            **{
+                get_name(SynchronizedData.submitted_request_ids): [
+                    "stale-a",
+                    "stale-b",
+                ]
+            },
+        )
+        result = round_.end_block()
+        assert result is not None
+        data, event = result
+        assert event == Event.NO_TASKS
+        assert cast(SynchronizedData, data).submitted_request_ids == []
 
     def test_deduplication_by_request_id(self) -> None:
         """Same request_id from multiple agents → deduplicated to one."""
@@ -689,15 +748,30 @@ class TestPostTxSettlementRound:
             "req-b",
         ]
 
-    def test_submitted_request_ids_empty_when_no_done_tasks(self) -> None:
-        """DONE with no done_tasks writes an empty id list, not a missing key."""
+    def test_no_write_when_done_tasks_empty(self) -> None:
+        """DONE with no ``done_tasks`` leaves the hand-off untouched.
+
+        ``PostTxSettlementRound`` is reachable via the delivery-rate
+        settlement path and the settlement-internal ``ResetRound``
+        retry; both arrive with ``done_tasks == []``. Overwriting a
+        still-pending ``submitted_request_ids`` from a prior real
+        settlement in those cases silently loses the prune and the
+        delivered batch is re-pooled next cycle.
+        """
         payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
-        round_ = _make_post_tx_round(payloads)
+        pending_handoff = ["still-pending-a", "still-pending-b"]
+        round_ = _make_post_tx_round(
+            payloads,
+            **{get_name(SynchronizedData.submitted_request_ids): pending_handoff},
+        )
         result = round_.end_block()
         assert result is not None
         new_sync_data, event = result
         assert event == Event.DONE
-        assert cast(SynchronizedData, new_sync_data).submitted_request_ids == []
+        assert (
+            cast(SynchronizedData, new_sync_data).submitted_request_ids
+            == pending_handoff
+        )
 
     def test_submitted_request_ids_normalised_to_str(self) -> None:
         """Ids are ``str``-normalised to match the prune-site lookup key.

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -138,6 +138,17 @@ class TestSynchronizedData:
         with pytest.raises(ValueError):
             _ = sd.final_tx_hash
 
+    def test_submitted_request_ids_defaults_to_empty_list(self) -> None:
+        """``submitted_request_ids`` reads ``[]`` when the key is unset."""
+        sd = _make_sync_data()
+        assert sd.submitted_request_ids == []
+
+    def test_submitted_request_ids_returns_stored_value(self) -> None:
+        """``submitted_request_ids`` reads back the stored list."""
+        ids = ["req-1", "req-2"]
+        sd = _make_sync_data(submitted_request_ids=ids)
+        assert sd.submitted_request_ids == ids
+
 
 # ---------------------------------------------------------------------------
 # TaskPoolingRound tests
@@ -452,8 +463,14 @@ class TestTaskSubmissionAbciApp:
             == 60.0
         )
         assert TaskSubmissionAbciApp.event_to_timeout[Event.ROUND_TIMEOUT] == 60.0
-        assert "done_tasks" in TaskSubmissionAbciApp.cross_period_persisted_keys
+        # ``done_tasks`` is intentionally NOT cross-period-persisted;
+        # the id hand-off rides ``submitted_request_ids`` instead. See
+        # :class:`TestCrossPeriodPersistedKeys` for the schema invariant.
+        assert (
+            "submitted_request_ids" in TaskSubmissionAbciApp.cross_period_persisted_keys
+        )
         assert "final_tx_hash" in TaskSubmissionAbciApp.cross_period_persisted_keys
+        assert "done_tasks" not in TaskSubmissionAbciApp.cross_period_persisted_keys
 
     def test_fsm_transitions(self) -> None:
         """All FSM transitions route to expected destination rounds."""
@@ -633,18 +650,13 @@ class TestPostTxSettlementRound:
         assert event == Event.NO_MAJORITY
 
     def test_done_tasks_preserved_on_done(self) -> None:
-        """Regression pin: ``done_tasks`` MUST survive DONE untouched.
+        """``done_tasks`` MUST survive DONE untouched within the same period.
 
-        ``TaskPoolingBehaviour.handle_submitted_tasks`` reads
-        ``synchronized_data.done_tasks`` at the START of the next cycle to
-        know which ``request_id``s to prune from
-        ``shared_state[DONE_TASKS]``. If this round clears the field on
-        DONE, the next cycle sees an empty list, ``remove_tasks`` is a
-        no-op, and the same batch is re-delivered on every settlement
-        cycle — the Safe tx succeeds but ``mech.deliverMulti`` reverts on
-        the already-delivered ids, burning gas without emitting new
-        Deliver events. Any predict-api re-fire concern on self-loop must be
-        guarded inside the behaviour, not by mutating this field.
+        The behaviour side still reads ``done_tasks`` for predict-api
+        writes and log emission during this round; clearing it here
+        breaks those reads. The id hand-off to the next cycle rides
+        ``submitted_request_ids`` (see the sibling regression test),
+        so ``done_tasks`` doesn't need to leave this period.
         """
         tasks = [_make_task("req-1"), _make_task("req-2")]
         payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
@@ -654,3 +666,114 @@ class TestPostTxSettlementRound:
         new_sync_data, event = result
         assert event == Event.DONE
         assert cast(SynchronizedData, new_sync_data).done_tasks == tasks
+
+    def test_submitted_request_ids_written_on_done(self) -> None:
+        """DONE writes the id list from ``done_tasks`` for the next cycle to prune.
+
+        Ids are extracted from this period's ``done_tasks`` and
+        exposed via
+        :attr:`SynchronizedData.submitted_request_ids`, which
+        the next cycle's
+        :meth:`TaskPoolingBehaviour.handle_submitted_tasks` reads to
+        prune ``shared_state[DONE_TASKS]`` by request_id.
+        """
+        tasks = [_make_task("req-a"), _make_task("req-b")]
+        payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
+        round_ = _make_post_tx_round(payloads, done_tasks=tasks)
+        result = round_.end_block()
+        assert result is not None
+        new_sync_data, event = result
+        assert event == Event.DONE
+        assert cast(SynchronizedData, new_sync_data).submitted_request_ids == [
+            "req-a",
+            "req-b",
+        ]
+
+    def test_submitted_request_ids_empty_when_no_done_tasks(self) -> None:
+        """DONE with no done_tasks writes an empty id list, not a missing key."""
+        payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
+        round_ = _make_post_tx_round(payloads)
+        result = round_.end_block()
+        assert result is not None
+        new_sync_data, event = result
+        assert event == Event.DONE
+        assert cast(SynchronizedData, new_sync_data).submitted_request_ids == []
+
+    def test_submitted_request_ids_normalised_to_str(self) -> None:
+        """Ids are ``str``-normalised to match the prune-site lookup key.
+
+        Mixed ``int`` / ``str`` request_id shapes can survive an
+        in-place restart. Normalising to ``str`` here keeps parity
+        with the downstream match in
+        :meth:`TaskExecutionBaseBehaviour.remove_tasks_by_id`.
+        """
+        tasks = [_make_task(42), _make_task("req-x")]
+        payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
+        round_ = _make_post_tx_round(payloads, done_tasks=tasks)
+        result = round_.end_block()
+        assert result is not None
+        new_sync_data, event = result
+        assert event == Event.DONE
+        assert cast(SynchronizedData, new_sync_data).submitted_request_ids == [
+            "42",
+            "req-x",
+        ]
+
+    def test_submitted_request_ids_skips_falsy_ids(self) -> None:
+        """A missing / empty ``request_id`` is dropped from the id list.
+
+        Mirrors the falsy-id skip in
+        :meth:`TaskPoolingRound.end_block`. Legit ``0`` (int) is
+        deliberately kept via the explicit ``is None or == ""``
+        check rather than a ``not`` truthiness test.
+        """
+        tasks = [
+            {"request_id": 0, "tool": "t0"},  # legit id, keep
+            {"request_id": None, "tool": "t-drop"},  # missing, skip
+            {"request_id": "", "tool": "t-drop2"},  # empty, skip
+            _make_task("req-keep"),
+        ]
+        payloads = {p: _post_tx_payload_for(p) for p in _PARTICIPANTS}
+        round_ = _make_post_tx_round(payloads, done_tasks=tasks)
+        result = round_.end_block()
+        assert result is not None
+        new_sync_data, event = result
+        assert event == Event.DONE
+        assert cast(SynchronizedData, new_sync_data).submitted_request_ids == [
+            "0",
+            "req-keep",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# TaskSubmissionAbciApp — schema-level invariants
+# ---------------------------------------------------------------------------
+
+
+class TestCrossPeriodPersistedKeys:
+    """Schema invariants on which fields ride cross-period consensus carry."""
+
+    def test_submitted_request_ids_is_cross_period_persisted(self) -> None:
+        """``submitted_request_ids`` MUST be cross-period-persisted.
+
+        The next cycle's
+        :meth:`TaskPoolingBehaviour.handle_submitted_tasks` reads it
+        via the framework's cross-period carry to prune
+        ``shared_state[DONE_TASKS]``. Removing it from
+        ``cross_period_persisted_keys`` would silently drop the id
+        hand-off and let already-delivered tasks re-enter the next
+        pooling round.
+        """
+        keys = TaskSubmissionAbciApp.cross_period_persisted_keys
+        assert "submitted_request_ids" in keys
+
+    def test_done_tasks_is_not_cross_period_persisted(self) -> None:
+        """``done_tasks`` MUST NOT be cross-period-persisted.
+
+        ``done_tasks`` carries per-event request/response payload data.
+        Persisting it across periods would inflate DB serialization on
+        the next :class:`RegistrationRound` entry. The id hand-off
+        rides ``submitted_request_ids`` instead.
+        """
+        keys = TaskSubmissionAbciApp.cross_period_persisted_keys
+        assert "done_tasks" not in keys

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -19,6 +19,7 @@
 """Tests for task_submission_abci.rounds."""
 
 import json
+import logging
 from typing import Any, Union, cast
 from unittest.mock import MagicMock
 
@@ -148,6 +149,36 @@ class TestSynchronizedData:
         ids = ["req-1", "req-2"]
         sd = _make_sync_data(submitted_request_ids=ids)
         assert sd.submitted_request_ids == ids
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            pytest.param("not-a-list", id="non-list"),
+            pytest.param([1, 2, 3], id="non-str-entries"),
+            pytest.param(["ok", 42], id="mixed-str-and-int"),
+        ],
+    )
+    def test_submitted_request_ids_degrades_to_empty_on_bad_shape(
+        self,
+        bad_value: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A malformed value logs an error and yields ``[]``.
+
+        The property is read at the top of every FSM cycle across
+        every participant on the same consensus block. Raising would
+        crash-loop the whole fleet with no in-band recovery because
+        the value is cross-period-persisted (``db.create`` copies it
+        forward). Degrading to ``[]`` keeps the drift detectable via
+        the ``error`` log while the FSM continues.
+        """
+        sd = _make_sync_data(submitted_request_ids=bad_value)
+        with caplog.at_level(logging.ERROR):
+            assert sd.submitted_request_ids == []
+        assert any(
+            "submitted_request_ids invariant broken" in rec.message
+            for rec in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_submission_abci/tests/test_rounds.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_rounds.py
@@ -171,6 +171,11 @@ class TestSynchronizedData:
         the value is cross-period-persisted (``db.create`` copies it
         forward). Degrading to ``[]`` keeps the drift detectable via
         the ``error`` log while the FSM continues.
+
+        :param bad_value: parametrised invalid ``submitted_request_ids``
+            shape (non-list, non-str entries, mixed).
+        :param caplog: captured log records used to assert the error
+            log is emitted.
         """
         sd = _make_sync_data(submitted_request_ids=bad_value)
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
## Summary

Splits the cross-period hand-off between `TaskPoolingRound` and `TaskPoolingBehaviour.handle_submitted_tasks` out of the fat `done_tasks` field into a new id-only `submitted_request_ids` field. Reduces the serialized `synchronized_data.db` size by the one carried copy per period that `AbciAppDB.create()` used to seed. Under typical single-event batches a `RegistrationPayload.encode()` that used to reject at the 1 MiB cap now fits.

Does not fully bound the serialized size: a batch with two max-size predict-api events in the same period still rejects. Bounding it in the strict sense requires keeping `predict_api_event` out of consensus entirely (follow-up).

## Why

`done_tasks` carries the full request/response payload per event and is in `cross_period_persisted_keys`. On period boundary `AbciAppDB.create()` seeds the new period with the previous latest value, and `AbciAppDB.update()` then appends the new period's own write; both remain in the retained period's per-key value history because `mech_abci/skill.yaml` sets `cleanup_history_depth_current: null`. So a period ends up holding two fat blobs (carried + fresh).

`serialize()` walks every retained period. `RegistrationPayload.encode()` calls it. Once the per-event payload grew (predict-api rollout on Jul 8), the two-blobs-per-period pattern was enough to push a single-event batch over `MAX_READ_IN_BYTES = 2**20`. The failure is silent until a mech restarts (or takes the reset-error → Registration path), at which point the payload is rejected and the FSM stalls. TM replay reconstructs the same fat DB.

Removing `done_tasks` from `cross_period_persisted_keys` halves the retained size per period (only the fresh write, no carry). The id-only `submitted_request_ids` carries the ~50 bytes needed for the next cycle's prune.

## Measured

Against real `AbciAppDB` with 500 KB events on the reset-error path (no `create()` / `cleanup()`):

| events in batch | pre-PR | post-PR |
|---|---|---|
| 1 | 1465 KB — exceeds | 977 KB — fits |
| 2 | 2930 KB — exceeds | 1954 KB — still exceeds |

## Changes

- `SynchronizedData.submitted_request_ids`: new property. Reads `[]` when unset. Fail-soft on invariant drift: a non-`list[str]` value logs via `self.db.logger.error` (which is the configured AEA logger, so it lands in `log.txt`) and yields `[]` rather than raising. The field is cross-period-persisted and read on every FSM cycle across all participants — a raise would crash-loop the whole fleet with no in-band recovery.
- `PostTxSettlementRound.end_block`: writes `submitted_request_ids` only when `done_tasks` is non-empty. `composition.py` wires `FinishedTransactionSubmissionRound` here for every settlement, so the delivery-rate settlement path arrives with `done_tasks == []`; overwriting a still-pending hand-off in that case would clobber a prior real settlement's ids. Emits a `warning` naming the pending id list so this benign case is distinguishable from an actual bug landing on the same branch.
- `TaskPoolingRound.end_block`: consumes the hand-off (`submitted_request_ids = []`) on both DONE and NO_TASKS. Every participant's `handle_submitted_tasks` has already read and pruned by the time the round accepts quorum, so clearing here makes the field one-shot per settlement. Without this, the "already submitted" block re-runs on stale ids every period, silently re-pruning re-swept requests before they can be pooled.
- `cross_period_persisted_keys`: swap `done_tasks` → `submitted_request_ids`.
- `TaskPoolingBehaviour.handle_submitted_tasks`: `remove_tasks_by_id` now returns the pre-prune snapshot; the caller drives its metrics loop from that snapshot. One lock acquisition, one tested surface. Prune runs before the `_fetch_tx_block_number` yield so a cancellation there can't leave shared state un-pruned. Prune log fires next to the prune, past tense.
- `remove_tasks_by_id(submitted_ids: List[str])`: tightened from `Sequence[Any]`. `str` satisfies `Sequence[str]`, so the old annotation type-checked a bare `str` and character-split it.
- Per-task `tool_delivery_time` histogram reads from local `shared_state[DONE_TASKS]`. `start_time` is `time.perf_counter()` (process-relative), so pre-PR subtracting another agent's counter produced meaningless durations; this is arguably a correctness fix. Any dashboard threshold keyed on this histogram's rate will shift on deploy (sample count drops by roughly N in an N-agent service).

## What's preserved

- On-chain requests: source of truth is the marketplace contract; re-fetched and re-executed on restart as before.
- Offchain in-memory requests: unchanged.
- Predict-api POST: reads `done_tasks` in the same period as it was set, unchanged.
- Multi-agent idempotency: server dedups on `request_id`.

## Tests

Round side:
- `SynchronizedData.submitted_request_ids` property (default, stored value, invariant-broken → `[]` with `error` log)
- `PostTxSettlementRound.end_block` writes ids on DONE, does not write when `done_tasks` empty (pending hand-off preserved), str-normalises mixed-type ids, skips falsy ids
- `TaskPoolingRound.end_block` clears `submitted_request_ids` on both DONE and NO_TASKS
- `cross_period_persisted_keys` schema invariant (contains `submitted_request_ids`, excludes `done_tasks`)

Behaviour side:
- `remove_tasks_by_id` (removes, missing ids no-op, legacy `int` in shared_state matches `str` id, returns pre-prune snapshot)
- `handle_submitted_tasks` primary path (id list drives shared_state prune), empty-ids no-op, `status=False` leaves shared_state untouched, histogram + shared_state assertions on the with-tasks path
- Skip-branch coverage: task absent from shared_state, task missing `tool` / `start_time`

Mutation-catching:
- `test_prune_acquires_done_tasks_lock` — dropping the `with` around the prune fails.
- `test_str_normalisation_matches_legacy_int_on_live_path` — dropping the `str()` on the shared_state side of the match fails on the hot path.
- `test_prune_runs_before_block_number_fetch` — moving the prune below the `_fetch_tx_block_number` yield fails.

End-to-end:
- `TestSubmittedRequestIdsRoundTrip` uses a real `SynchronizedData` (not `MagicMock`) so the property is actually exercised on the behaviour path; asserts the prune reaches `shared_state[DONE_TASKS]`.

## Follow-ups (out of scope)

- Keep `predict_api_event` out of consensus entirely, to truly bound the serialized payload regardless of event count per batch.
- Extract a shared `normalise_request_id(task)` helper for the three sites in `rounds.py` (extract_request_ids filter, dedup loop, sort key).
- Extract the metrics loop in `handle_submitted_tasks` to a plain helper.
- Labelled counter to separate "task not in shared_state (executed by another agent)" from "malformed skip".

## Test plan

- [x] Unit tests pass locally (`pytest packages/valory/skills/task_submission_abci/tests packages/valory/skills/task_execution/tests packages/valory/skills/mech_abci/tests`, 903 tests)
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e darglint -e mypy` clean
- [x] `tomte tox -e check-abci-docstrings -e check-abciapp-specs` OK
- [x] `autonomy packages lock --check` OK
- [x] `tomte tox -e check-hash` OK
- [ ] CI: full pipeline
- [ ] Post-merge: canary on a Gnosis mech; confirm DB serialization stays under 1 MiB through many periods and reset-error cycles