### PR TITLE
fix(task_submission): recognise FixedPriceTokenUSDC paymentType

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiehxuzywr7ld3bosooqvhewyrpbagmz2kljep6i3mls43jmtnktie",
+        "skill/valory/mech_abci/0.1.0": "bafybeid53ko6e7f2iqieve4t7cky4w7qpbztbf6pdlee3vnry2mjrnszra",
         "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidxzddmqxhovneuxtplkdcmlbf7xlm3h75jhps7eddrwuuqnozeee",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiarzinfeymv6kiymkdsfvreivod7sf5hkudfilamsrl5a5eeqvkci",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeighyndmb65rgptrifklfuimhvotz27dciemqyrnh2xbehovq6t5hm",
-        "service/valory/mech/0.1.0": "bafybeietnx4ctnxqswbtrcw7z6qrdncsiimf7xsbgp7pyw7mr7rblvxuhi"
+        "agent/valory/mech/0.1.0": "bafybeigsq263pcxuxisq47kk2yasl4o3xzdb2dputd4yqzpi6efeyepnvi",
+        "service/valory/mech/0.1.0": "bafybeiazchfmdlyc32hypspvg4zpydxjubkvuggvjzsbzq3t7g4lhkqyii"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeid53ko6e7f2iqieve4t7cky4w7qpbztbf6pdlee3vnry2mjrnszra",
-        "skill/valory/task_execution/0.1.0": "bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiarzinfeymv6kiymkdsfvreivod7sf5hkudfilamsrl5a5eeqvkci",
+        "skill/valory/mech_abci/0.1.0": "bafybeialhw2p6dqyjtjuwzboizswh2wtpimwf556aje2e3sczzxkq7yzgi",
+        "skill/valory/task_execution/0.1.0": "bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiabk5sffb4i2doypwjbznr6zw6kwr3pnjttwm4onrydfbfyavrzce",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeigsq263pcxuxisq47kk2yasl4o3xzdb2dputd4yqzpi6efeyepnvi",
-        "service/valory/mech/0.1.0": "bafybeiazchfmdlyc32hypspvg4zpydxjubkvuggvjzsbzq3t7g4lhkqyii"
+        "agent/valory/mech/0.1.0": "bafybeicgbuajc22iy47fgaulxi2b5alfyhxq3z6znqgyumxaxgqqc2iruu",
+        "service/valory/mech/0.1.0": "bafybeihltyh5umxwagb2kqrlic7sezyex7osiosuvw4w6um7242wzs43ny"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeialhw2p6dqyjtjuwzboizswh2wtpimwf556aje2e3sczzxkq7yzgi",
+        "skill/valory/mech_abci/0.1.0": "bafybeifuuif7ctpas6u7j75qkhda6zpm5uzrnotetzoux4uujvjyflk5pi",
         "skill/valory/task_execution/0.1.0": "bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiabk5sffb4i2doypwjbznr6zw6kwr3pnjttwm4onrydfbfyavrzce",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeic6lgc2xk57zd6nhxq4fvmpkithkwukwoompebioms2ggr35gp43a",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeicgbuajc22iy47fgaulxi2b5alfyhxq3z6znqgyumxaxgqqc2iruu",
-        "service/valory/mech/0.1.0": "bafybeihltyh5umxwagb2kqrlic7sezyex7osiosuvw4w6um7242wzs43ny"
+        "agent/valory/mech/0.1.0": "bafybeihh7457c7kjkyat4zqh44tihzgup2jiilgfoufefhun3i5tvsyvaa",
+        "service/valory/mech/0.1.0": "bafybeicfblue2fsikhlqvw52viwyszbracowbdf5loelir73pjrbnxwatq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeiehxuzywr7ld3bosooqvhewyrpbagmz2kljep6i3mls43jmtnktie
+- valory/mech_abci:0.1.0:bafybeid53ko6e7f2iqieve4t7cky4w7qpbztbf6pdlee3vnry2mjrnszra
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeidxzddmqxhovneuxtplkdcmlbf7xlm3h75jhps7eddrwuuqnozeee
+- valory/task_submission_abci:0.1.0:bafybeiarzinfeymv6kiymkdsfvreivod7sf5hkudfilamsrl5a5eeqvkci
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeid53ko6e7f2iqieve4t7cky4w7qpbztbf6pdlee3vnry2mjrnszra
+- valory/mech_abci:0.1.0:bafybeialhw2p6dqyjtjuwzboizswh2wtpimwf556aje2e3sczzxkq7yzgi
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeiarzinfeymv6kiymkdsfvreivod7sf5hkudfilamsrl5a5eeqvkci
+- valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
+- valory/task_submission_abci:0.1.0:bafybeiabk5sffb4i2doypwjbznr6zw6kwr3pnjttwm4onrydfbfyavrzce
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeialhw2p6dqyjtjuwzboizswh2wtpimwf556aje2e3sczzxkq7yzgi
+- valory/mech_abci:0.1.0:bafybeifuuif7ctpas6u7j75qkhda6zpm5uzrnotetzoux4uujvjyflk5pi
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
-- valory/task_submission_abci:0.1.0:bafybeiabk5sffb4i2doypwjbznr6zw6kwr3pnjttwm4onrydfbfyavrzce
+- valory/task_submission_abci:0.1.0:bafybeic6lgc2xk57zd6nhxq4fvmpkithkwukwoompebioms2ggr35gp43a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeighyndmb65rgptrifklfuimhvotz27dciemqyrnh2xbehovq6t5hm
+agent: valory/mech:0.1.0:bafybeigsq263pcxuxisq47kk2yasl4o3xzdb2dputd4yqzpi6efeyepnvi
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeigsq263pcxuxisq47kk2yasl4o3xzdb2dputd4yqzpi6efeyepnvi
+agent: valory/mech:0.1.0:bafybeicgbuajc22iy47fgaulxi2b5alfyhxq3z6znqgyumxaxgqqc2iruu
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeicgbuajc22iy47fgaulxi2b5alfyhxq3z6znqgyumxaxgqqc2iruu
+agent: valory/mech:0.1.0:bafybeihh7457c7kjkyat4zqh44tihzgup2jiilgfoufefhun3i5tvsyvaa
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
-- valory/task_submission_abci:0.1.0:bafybeiabk5sffb4i2doypwjbznr6zw6kwr3pnjttwm4onrydfbfyavrzce
+- valory/task_submission_abci:0.1.0:bafybeic6lgc2xk57zd6nhxq4fvmpkithkwukwoompebioms2ggr35gp43a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeiarzinfeymv6kiymkdsfvreivod7sf5hkudfilamsrl5a5eeqvkci
+- valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
+- valory/task_submission_abci:0.1.0:bafybeiabk5sffb4i2doypwjbznr6zw6kwr3pnjttwm4onrydfbfyavrzce
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -32,7 +32,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
-- valory/task_submission_abci:0.1.0:bafybeidxzddmqxhovneuxtplkdcmlbf7xlm3h75jhps7eddrwuuqnozeee
+- valory/task_submission_abci:0.1.0:bafybeiarzinfeymv6kiymkdsfvreivod7sf5hkudfilamsrl5a5eeqvkci
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -2112,7 +2112,9 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                     executing_task.get("priority_mech") or delivery_mech
                 ),
                 "delivery_mech": delivery_mech,
-                "payment_type": str(executing_task.get("payment_type") or "") or None,
+                "payment_type": (
+                    self.payment_model.hex() if self.payment_model else None
+                ),
                 "delivery_rate": delivery_rate_str,
                 "nonce": nonce_int,
                 "content_cid": executing_task.get("request_cid") or cid,

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeia2iuzx36edygd7ldiigtxpita2itbr3rfgwl2kyog3stjpkuo76u
+  behaviours.py: bafybeidj2rmgxfmnuk65mraezlcpcv2w3g2hzzzchumfl36jribabhdvcu
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeihrkgawzcxuv2jkfqmhoivzenakobybcdkjyxs6jk7vrx5oensnzy
+  tests/test_behaviours.py: bafybeiehhymwtrv23cqxaaz6ncld3c5xd7t7ffptupufigl6qd4utbepqm
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -3984,6 +3984,119 @@ def test_build_predict_api_event_omits_request_tx_hash_on_offchain_task(
     assert event["request"]["request_tx_hash"] is None
 
 
+def test_build_predict_api_event_writes_hex_payment_type_from_shared_state(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """The event's ``payment_type`` is the bytes32 hex of the cached payment_model.
+
+    Predict-api's ``mech_requests.payment_type`` was blank for 100% of
+    rows because upstream contract-event readers did not attach a
+    payment-type key to the task dict, and this build fell back to
+    ``executing_task.get('payment_type')`` which was always absent.
+    Reading from ``shared_state[PAYMENT_MODEL]`` — populated once at
+    startup by the mech-type handler from the ``paymentType()`` view —
+    puts the authoritative on-chain value on the event without a
+    per-event contract call. Consumers (marketplace FE) map the hash to
+    a human label; the pipeline carries the hash unchanged.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
+    """
+    # 32-byte payment-model hash — the shape returned by the mech
+    # contract's ``paymentType()`` view. Value is arbitrary here; the
+    # invariant is that whatever is in shared_state ends up hex-encoded
+    # on the event.
+    payment_model_bytes = bytes.fromhex("ab" * 32)
+    shared_state[beh_mod.PAYMENT_MODEL] = payment_model_bytes
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    # ``bytes.hex()`` returns lowercase hex with no ``0x`` prefix,
+    # matching how the constants in
+    # ``packages/valory/contracts/olas_mech/contract.py`` are declared.
+    assert event["request"]["payment_type"] == "ab" * 32
+
+
+def test_build_predict_api_event_writes_none_payment_type_when_shared_state_empty(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """Startup race: PAYMENT_MODEL not yet cached → ``payment_type`` is None.
+
+    Defensive fallback for the window between agent start and the first
+    ``get_mech_type`` handler response. ``_ensure_payment_model`` gates
+    the ``act`` step on this cache being populated, so in the ordinary
+    flow ``self.payment_model`` is bytes by the time an event is built,
+    but this test pins the None-safe accessor so a regression that
+    dropped the guard would not raise ``AttributeError`` on ``.hex()``.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
+    """
+    shared_state.pop(beh_mod.PAYMENT_MODEL, None)
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["payment_type"] is None
+
+
+def test_build_predict_api_event_payment_type_ignores_executing_task_key(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+) -> None:
+    """A bogus ``executing_task['payment_type']`` does not shadow shared_state.
+
+    The prior shape read ``executing_task.get('payment_type')`` and
+    coerced through ``str(x or '') or None``. Nothing in the mech's
+    contract readers ever populated that key in production, so the
+    fallback was always None — but the coupling meant any future writer
+    that put a value there would silently override the authoritative
+    cache. Now the cache wins; ``executing_task`` is not consulted for
+    this field.
+
+    :param behaviour: Behaviour under test.
+    :param params_stub: Params-like namespace.
+    :param shared_state: Shared-state mapping the behaviour reads from.
+    """
+    shared_state[beh_mod.PAYMENT_MODEL] = bytes.fromhex("cd" * 32)
+    request_data = {
+        "prompt": "p",
+        "tool": "prediction-offline",
+        "requested_at": "2026-06-25T13:19:06.651013Z",
+    }
+    done_task, executing_task = _predict_api_event_setup(
+        behaviour, shared_state, request_data
+    )
+    # Bogus stray key on the task — must be ignored.
+    executing_task["payment_type"] = "hijacked_value"
+    event = behaviour._build_predict_api_event(
+        done_task=done_task, cid="bafy", executing_task=executing_task
+    )
+    assert event["request"]["payment_type"] == "cd" * 32
+
+
 def test_build_predict_api_event_response_delivery_tx_hash_placeholder(
     behaviour: Any,
     params_stub: Any,

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -120,6 +120,20 @@ PAYMENT_TYPE_TOKEN_USDC = (
     "6406bb5f31a732f898e1ce9fdd988a80a808d36ab5d9a4a4805a8be8d197d5e3"  # nosec
 )
 
+# Payment types that settle via ERC20 transfer. A new token rail must
+# be added here alongside its ``PAYMENT_TYPE_*`` constant, otherwise
+# the withdraw path falls through to the native branch and reverts
+# on-chain with GS013 (the exact regression this list gates against).
+TOKEN_PAYMENT_TYPES = frozenset(
+    {PAYMENT_TYPE_TOKEN, PAYMENT_TYPE_TOKEN_NVM, PAYMENT_TYPE_TOKEN_USDC}
+)
+# Payment types that legitimately settle via a native transfer.
+# Anything outside both sets is an unrecognised rail — the withdraw
+# path still falls back to native but logs a warning so a new
+# ``PAYMENT_TYPE_*`` constant added without a matching update to
+# ``TOKEN_PAYMENT_TYPES`` surfaces before it reverts on-chain.
+KNOWN_NATIVE_PAYMENT_TYPES = frozenset({PAYMENT_TYPE_NATIVE, PAYMENT_TYPE_NATIVE_NVM})
+
 IS_MARKETPLACE_MECH_KEY = "is_marketplace_mech"
 
 IS_OFFCHAIN = "is_offchain"
@@ -680,11 +694,7 @@ class FundsSplittingBehaviour(DeliverBehaviour, ABC):
                 if amount == 0:
                     continue
 
-                if mech_type.hex() in [
-                    PAYMENT_TYPE_TOKEN_NVM,
-                    PAYMENT_TYPE_TOKEN,
-                    PAYMENT_TYPE_TOKEN_USDC,
-                ]:
+                if mech_type.hex() in TOKEN_PAYMENT_TYPES:
                     self.context.logger.info(
                         f"Token type mech detected {mech_address}. Preparing token transfer tx"
                     )
@@ -705,6 +715,12 @@ class FundsSplittingBehaviour(DeliverBehaviour, ABC):
                         mech_address, token_address, receiver_address, amount
                     )
                 else:
+                    if mech_type.hex() not in KNOWN_NATIVE_PAYMENT_TYPES:
+                        self.context.logger.warning(
+                            f"Unrecognised mech_type {mech_type.hex()} for {mech_address}; "
+                            f"falling back to native transfer. If this is a new token rail, "
+                            f"add it to TOKEN_PAYMENT_TYPES to avoid a GS013 revert on-chain."
+                        )
                     tx = yield from self._get_transfer_tx(
                         mech_address, receiver_address, amount
                     )

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -116,6 +116,9 @@ PAYMENT_TYPE_NATIVE_NVM = (
 PAYMENT_TYPE_TOKEN_NVM = (
     "0d6fd99afa9c4c580fab5e341922c2a5c4b61d880da60506193d7bf88944dd14"  # nosec
 )
+PAYMENT_TYPE_TOKEN_USDC = (
+    "6406bb5f31a732f898e1ce9fdd988a80a808d36ab5d9a4a4805a8be8d197d5e3"  # nosec
+)
 
 IS_MARKETPLACE_MECH_KEY = "is_marketplace_mech"
 
@@ -677,7 +680,11 @@ class FundsSplittingBehaviour(DeliverBehaviour, ABC):
                 if amount == 0:
                     continue
 
-                if mech_type.hex() in [PAYMENT_TYPE_TOKEN_NVM, PAYMENT_TYPE_TOKEN]:
+                if mech_type.hex() in [
+                    PAYMENT_TYPE_TOKEN_NVM,
+                    PAYMENT_TYPE_TOKEN,
+                    PAYMENT_TYPE_TOKEN_USDC,
+                ]:
                     self.context.logger.info(
                         f"Token type mech detected {mech_address}. Preparing token transfer tx"
                     )

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeieh4fveplgwaayfnmtn4dk5ye5vcaocbg5dacl4mwp725txgn5o7q
+  behaviours.py: bafybeia32tc4sfqnjq33aj3jpla74tni3b7qiifw4k2yp747r2fxqrvl2u
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -19,7 +19,7 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeidb2mazhtnnyw2olysl5o443ukmv2qtm26ynvppnybekjgxdtqdkm
+  tests/test_behaviours.py: bafybeibfmlv6gfkwbb5opk4bqol746eyx7zmfg6ii7s743bdke3j2wmadq
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeietlxjecs4czaxbin63wvmwxn5moto2ho5dszgowk6xpmwoytrbjy
+  behaviours.py: bafybeieh4fveplgwaayfnmtn4dk5ye5vcaocbg5dacl4mwp725txgn5o7q
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -19,7 +19,7 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeifnbbbicmtyhmb6twbhqd6bttz7ooxuefitovqzcsjqqyarlthil4
+  tests/test_behaviours.py: bafybeidb2mazhtnnyw2olysl5o443ukmv2qtm26ynvppnybekjgxdtqdkm
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeifbqbo5fmgxxrs4gpkuqrukg4qvt6q2l2sd4pgpqsvlmcz2zbo3fy
+- valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -2986,6 +2986,59 @@ class TestGetSplitProfitTxsTokenMech:
         assert result is not None
         assert len(result) == 2  # process_tx + token_transfer_tx
 
+    def test_fixed_price_token_usdc_routes_to_erc20_branch(self) -> None:
+        """USDC mech (FixedPriceTokenUSDC paymentType) must take the ERC20 branch.
+
+        Guards against the regression where an unrecognised token-payment
+        paymentType falls through to _get_transfer_tx and encodes a native
+        transfer, which reverts on-chain because the mech contract holds the
+        token but no native balance.
+        """
+        b = self._make_b()
+        from packages.valory.skills.task_submission_abci.behaviours import (
+            PAYMENT_TYPE_TOKEN_USDC,
+        )
+
+        usdc_type = bytes.fromhex(PAYMENT_TYPE_TOKEN_USDC)
+        mech_info = (usdc_type, "0xTRACK", 1000)
+        process_tx = {
+            "to": "0xTRACK",
+            "value": 0,
+            "data": b"\x00",
+            "simulation_ok": True,
+        }
+        split_funds = {"0xSERVICE_OWNER": 900}
+        token_transfer_tx = {"to": "0xMECH", "value": 0, "data": b"\x02"}
+        native_transfer_sentinel = MagicMock(
+            side_effect=AssertionError(
+                "USDC paymentType must not take the native _get_transfer_tx branch"
+            )
+        )
+        with (
+            patch.object(b, "_should_split_profits", side_effect=_gen_returning(True)),
+            patch.object(b, "_get_mech_info", side_effect=_gen_returning(mech_info)),
+            patch.object(b, "_calculate_mech_profits", side_effect=_gen_returning(900)),
+            patch.object(
+                b,
+                "_get_process_payment_tx",
+                side_effect=_gen_returning(dict(process_tx)),
+            ),
+            patch.object(b, "_split_funds", side_effect=_gen_returning(split_funds)),
+            patch.object(
+                b, "_get_token_address", side_effect=_gen_returning("0xTOKEN")
+            ),
+            patch.object(
+                b,
+                "_get_token_transfer_tx",
+                side_effect=_gen_returning(token_transfer_tx),
+            ),
+            patch.object(b, "_get_transfer_tx", native_transfer_sentinel),
+        ):
+            result = _run_gen(b.get_split_profit_txs())
+        assert result is not None
+        assert len(result) == 2  # process_tx + token_transfer_tx (not native)
+        native_transfer_sentinel.assert_not_called()
+
 
 class TestMarketplaceNvmMechPath:
     """Test Marketplace Nvm Mech Path."""

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -3009,11 +3009,7 @@ class TestGetSplitProfitTxsTokenMech:
         }
         split_funds = {"0xSERVICE_OWNER": 900}
         token_transfer_tx = {"to": "0xMECH", "value": 0, "data": b"\x02"}
-        native_transfer_sentinel = MagicMock(
-            side_effect=AssertionError(
-                "USDC paymentType must not take the native _get_transfer_tx branch"
-            )
-        )
+        native_transfer_sentinel = MagicMock()
         with (
             patch.object(b, "_should_split_profits", side_effect=_gen_returning(True)),
             patch.object(b, "_get_mech_info", side_effect=_gen_returning(mech_info)),
@@ -3038,6 +3034,94 @@ class TestGetSplitProfitTxsTokenMech:
         assert result is not None
         assert len(result) == 2  # process_tx + token_transfer_tx (not native)
         native_transfer_sentinel.assert_not_called()
+
+    def test_unrecognised_payment_type_warns_before_native_fallback(self) -> None:
+        """Unknown paymentType falls back to native transfer AND logs a warning.
+
+        Guards against the regression where a new token rail is added to
+        the ``PAYMENT_TYPE_*`` constants but forgotten in
+        ``TOKEN_PAYMENT_TYPES`` — the withdraw path silently reverts
+        on-chain with GS013. The warning surfaces the misconfiguration
+        in agent logs before the on-chain revert lands.
+        """
+        b = self._make_b()
+        unknown_type = bytes.fromhex(
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        )
+        mech_info = (unknown_type, "0xTRACK", 1000)
+        process_tx = {
+            "to": "0xTRACK",
+            "value": 0,
+            "data": b"\x00",
+            "simulation_ok": True,
+        }
+        split_funds = {"0xSERVICE_OWNER": 900}
+        native_transfer_tx = {"to": "0xSERVICE_OWNER", "value": 900, "data": b""}
+        warn_spy = MagicMock()
+        b.context.logger.warning = warn_spy  # type: ignore[assignment]
+        with (
+            patch.object(b, "_should_split_profits", side_effect=_gen_returning(True)),
+            patch.object(b, "_get_mech_info", side_effect=_gen_returning(mech_info)),
+            patch.object(b, "_calculate_mech_profits", side_effect=_gen_returning(900)),
+            patch.object(
+                b,
+                "_get_process_payment_tx",
+                side_effect=_gen_returning(dict(process_tx)),
+            ),
+            patch.object(b, "_split_funds", side_effect=_gen_returning(split_funds)),
+            patch.object(
+                b, "_get_transfer_tx", side_effect=_gen_returning(native_transfer_tx)
+            ),
+        ):
+            result = _run_gen(b.get_split_profit_txs())
+        assert result is not None
+        warn_spy.assert_called_once()
+        warn_msg = warn_spy.call_args[0][0]
+        assert "Unrecognised mech_type" in warn_msg
+        assert unknown_type.hex() in warn_msg
+        assert "TOKEN_PAYMENT_TYPES" in warn_msg
+
+    def test_known_native_payment_type_does_not_warn(self) -> None:
+        """Legitimate ``PAYMENT_TYPE_NATIVE`` mechs must not trip the warning.
+
+        The unrecognised-mech-type warning is scoped to hashes outside
+        both ``TOKEN_PAYMENT_TYPES`` and ``KNOWN_NATIVE_PAYMENT_TYPES``;
+        a plain native rail is the intended path.
+        """
+        b = self._make_b()
+        from packages.valory.skills.task_submission_abci.behaviours import (
+            PAYMENT_TYPE_NATIVE,
+        )
+
+        native_type = bytes.fromhex(PAYMENT_TYPE_NATIVE)
+        mech_info = (native_type, "0xTRACK", 1000)
+        process_tx = {
+            "to": "0xTRACK",
+            "value": 0,
+            "data": b"\x00",
+            "simulation_ok": True,
+        }
+        split_funds = {"0xSERVICE_OWNER": 900}
+        native_transfer_tx = {"to": "0xSERVICE_OWNER", "value": 900, "data": b""}
+        warn_spy = MagicMock()
+        b.context.logger.warning = warn_spy  # type: ignore[assignment]
+        with (
+            patch.object(b, "_should_split_profits", side_effect=_gen_returning(True)),
+            patch.object(b, "_get_mech_info", side_effect=_gen_returning(mech_info)),
+            patch.object(b, "_calculate_mech_profits", side_effect=_gen_returning(900)),
+            patch.object(
+                b,
+                "_get_process_payment_tx",
+                side_effect=_gen_returning(dict(process_tx)),
+            ),
+            patch.object(b, "_split_funds", side_effect=_gen_returning(split_funds)),
+            patch.object(
+                b, "_get_transfer_tx", side_effect=_gen_returning(native_transfer_tx)
+            ),
+        ):
+            result = _run_gen(b.get_split_profit_txs())
+        assert result is not None
+        warn_spy.assert_not_called()
 
 
 class TestMarketplaceNvmMechPath:


### PR DESCRIPTION
## Summary

Two independent fixes on the same `task_submission` / `task_execution` surface, bundled because they landed against the same open PR:

1. **Recognise `FixedPriceTokenUSDC` paymentType** so USDC-denominated mechs route their withdraw through the ERC20 branch instead of the native-transfer fallback. Fixes the polygon-21 GS013 loop.
2. **Write the mech's paymentType hash on every predict-api event** so `mech_requests.payment_type` stops being NULL on 100% of rows. Closes the downstream marketplace-app "Payment cell blank on off-chain rows" gap Tanya flagged on autonolas-frontend-mono#446.

Each fix stands alone; either can be dropped without affecting the other.

---

## Fix 1 — Recognise `FixedPriceTokenUSDC` paymentType

### Background — the on-chain failure this fixes

The polygon 21 mech at `0x76A9A29441c7ACd072b03e63911F0E177DE56Ab7` is a `MechFixedPriceTokenUSDC` (`autonolas-marketplace/contracts/mechs/token/usdc/MechFixedPriceTokenUSDC.sol`). Its `paymentType()` returns `keccak256("FixedPriceTokenUSDC") = 0x6406bb5f31a732f898e1ce9fdd988a80a808d36ab5d9a4a4805a8be8d197d5e3`.

Before this fix, that value wasn't in `behaviours.py:107-118`, so the withdraw branch at line 680 (`if mech_type.hex() in [PAYMENT_TYPE_TOKEN_NVM, PAYMENT_TYPE_TOKEN]`) evaluated False and fell through to `_get_transfer_tx` at line 701 — the NATIVE-transfer path. That encoded `mech.exec(to=service_owner, value=<usdc_amount>, data=0x, operation=CALL)`, attempting to send `<usdc_amount>` wei of POL from the mech contract.

The mech contract had just received USDC from `processPaymentByMultisig` inside the same Safe multisend, but zero POL. The native transfer reverted, the atomic multisend rolled back with `GS013`, and the FSM entered a settlement retry loop rebuilding the same failing multisend every ~90s. Symptom in agent logs: `Payload is invalid for 0x...! Cannot continue. Received: ContractLogicError('execution reverted: GS013', ...)`.

Confirmed live on polygon 21 on 2026-09-02 after agent-deployments PR #336 rolled out the withdraw trigger; rolled back via agent-deployments PR #338.

### What changed

- `packages/valory/skills/task_submission_abci/behaviours.py`
  - Add `PAYMENT_TYPE_TOKEN_USDC = "6406bb5f..."` constant next to the existing four
  - Include it in the ERC20-branch list at line 680 alongside `PAYMENT_TYPE_TOKEN` and `PAYMENT_TYPE_TOKEN_NVM`
- `packages/valory/skills/task_submission_abci/tests/test_behaviours.py`
  - New regression test `test_fixed_price_token_usdc_routes_to_erc20_branch` that pins the routing: asserts `_get_token_transfer_tx` is called AND `_get_transfer_tx` (native) is NOT called for a USDC paymentType

### What deliberately did NOT change

- `behaviours.py:619` (NVM `_adjust_mech_balance` branch) — USDC does not use `tokenCreditRatio`. The USDC contract at `autonolas-marketplace/contracts/mechs/token/usdc/` reuses `BalanceTrackerFixedPriceToken.sol` (no dedicated `BalanceTrackerFixedPriceTokenUSDC.sol` exists), so no ratio adjustment applies.
- Existing misleading constant `PAYMENT_TYPE_TOKEN_NVM` — its actual hash matches `NvmSubscriptionTokenUSDC`, not `NvmSubscriptionToken`. Not renaming to avoid churn on working code.

### Round-3 review pickups (all on Fix 1)

- **Warn on unrecognised paymentType.** The withdraw-path else-branch used to silently fall through to `_get_transfer_tx` for any hash outside the token-payment list — the exact regression this PR fixes per-type. Split the token check from a new `KNOWN_NATIVE_PAYMENT_TYPES` set; the else-branch warns when the paymentType is in neither set, with the observed hash + mech address + remediation string (`add it to TOKEN_PAYMENT_TYPES to avoid a GS013 revert on-chain`). Legitimate native rails stay silent.
- **`TOKEN_PAYMENT_TYPES` frozenset.** Inline `[PAYMENT_TYPE_TOKEN_NVM, PAYMENT_TYPE_TOKEN, PAYMENT_TYPE_TOKEN_USDC]` at the check site was two-place maintenance; extracted to a module-level `frozenset` alongside the constants.
- **Sentinel test cleanup.** Dropped the belt-and-suspenders `MagicMock(side_effect=AssertionError(...))` on `_get_transfer_tx` in the USDC routing test; rely on `.assert_not_called()` alone for a clean pytest failure message.
- **New regression tests.** `test_unrecognised_payment_type_warns_before_native_fallback` and `test_known_native_payment_type_does_not_warn` pin the warning fires on unknown hashes and doesn't fire on legitimate native rails.

---

## Fix 2 — Write the mech's paymentType hash on every predict-api event

### The gap this fixes

Predict-api's `mech_requests.payment_type` was NULL on **100% of rows** — measured directly against prod on 2026-09-02: 0 of 11,326,264 rows populated, including all 14,813 rows written since the mech-analytics v0.0.19 deploy went live. The NULL propagates through mech-analytics' ETL projection into `per_request_scores.payment_type`, and on the marketplace FE that means:

- `mapPaymentToFee` cannot pick correct decimals for `delivery_rate` (the same `"1000000"` reads as 1 USDC at 6-decimal or 0.000000000001 xDAI at 18-decimal depending on the rail)
- On-chain rows fall back to the marketplace-subgraph twin's `feeUnit` / `feeRaw`, so they render OK
- **Off-chain rows have no twin**, so their Payment cell is always blank — the exact failure mode Tanya flagged on autonolas-frontend-mono#446 as the caveat blocking the default-ON flip

### Root cause

`_build_predict_api_event` in `task_execution/behaviours.py` read `executing_task.get("payment_type")` and coerced through `str(x or "") or None`. No code path in the marketplace-contract readers (`get_marketplace_undelivered_reqs` / `get_marketplace_request_events` in `packages/valory/contracts/mech_marketplace/contract.py`) or in the off-chain request handler ever populated `payment_type` on the task dict, so the fallback was always None. The mech was faithfully sending `payment_type=None` on every event; the schema was NULL because upstream never wrote anything.

### What changed

- `packages/valory/skills/task_execution/behaviours.py` (`_build_predict_api_event`, line 2115)
  - Read `self.payment_model.hex()` instead of `executing_task.get("payment_type")`. `self.payment_model` is the process-wide cache in `shared_state[PAYMENT_MODEL]`, populated once at startup by `task_execution.handlers._handle_get_undelivered_reqs` from the mech contract's `paymentType()` view. Zero contract calls per event.
  - Bytes32 hash is emitted as lowercase hex without the `0x` prefix (matching how the constants are declared in `packages/valory/contracts/olas_mech/contract.py:49-54`). No human-name conversion in the pipeline — the marketplace FE (`apps/marketplace/common-util/mechAnalytics/service-activity.ts`) does the hash → `native` / `usdc` / `nvm_subscription` label mapping at render time in a follow-up autonolas-frontend-mono PR.
- `packages/valory/skills/task_execution/tests/test_behaviours.py`
  - `test_build_predict_api_event_writes_hex_payment_type_from_shared_state` — cache set to bytes → event carries lowercase hex without `0x`.
  - `test_build_predict_api_event_writes_none_payment_type_when_shared_state_empty` — startup-race guard: `self.payment_model` is None → event's `payment_type` is None (no `AttributeError` on `.hex()`).
  - `test_build_predict_api_event_payment_type_ignores_executing_task_key` — a bogus `executing_task['payment_type']` does not shadow the cache. Prior shape was coupled to that key; the new authoritative read is not.

### What deliberately did NOT change

- `task_submission_abci/behaviours.py:2691` (`_build_request_only_event`) keeps `"payment_type": None`. The sweep's `priority_mech` may be another mech whose payment model we don't authoritatively cache, and the delivery event's `ON CONFLICT UPDATE` fills the row's `payment_type` when the actual deliverer writes. Emitting a possibly-wrong hash from the sweep would risk shadowing the correct value under race conditions.
- Pipeline-side conversion of hash → human name. The mech carries only bytes32; every downstream layer (predict-api storage, mech-analytics projection, mech-analytics API) forwards the hash unchanged. This makes new payment rails additive — a new marketplace rail flows end-to-end without any pipeline code change; only display consumers need to map the new hash.

### Why zero contract calls per event

`self.payment_model` is populated once at agent start via the `get_mech_type` handler path. `_get_mech_payment_type` in `task_submission_abci/behaviours.py:797` explicitly returns the cache without a contract call when the address is the mech's own (line 800-801). For step-in flows, `_filter_out_incompatible_reqs` guarantees the mech only processes tasks whose priority mech shares the mech's own payment model, so `self.payment_model` is the authoritative value for every delivered row regardless of whether the delivery originated as own-mech-priority or step-in.

---

## Local checks passed

- `tomte tox -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` — all OK
- `tomte tox -e check-abci-docstrings -e check-abciapp-specs -e check-handlers` — all OK
- `tomte tox -e check-doc-hashes` — all OK
- `autonomy packages lock --check` — verification successful
- `pytest packages/valory/skills/task_submission_abci/tests/test_behaviours.py packages/valory/skills/task_execution/tests/test_behaviours.py` — 357 passed (Fix 1 regression tests + round-3 warn tests + 3 new tests for Fix 2)

Packages relocked via `autonomy packages lock`; `autonomy push-all` still needed before the branch is pushed for review — the IPFS registry entries under the new hashes have to exist before Propel can pull them.

## Rollout after merge

1. Merge this PR
2. Bump the service hash on `single_polygon_mech_mm_predict_21` in the agent-deployments repo to pick up the new mech-service package: `bafybeicfblue2fsikhlqvw52viwyszbracowbdf5loelir73pjrbnxwatq` (relocked and pushed to IPFS by `autonomy push-all` after both fixes + round-3 review pickups landed on the branch)
3. Re-open the lower-`PROFIT_SPLIT_BALANCE` config change (was in agent-deployments PR #336, rolled back in PR #338) alongside the service-hash bump
4. Redeploy `single_polygon_mech_mm_predict_21` on Propel
5. Watch agent logs for **Fix 1**: expect `Splitting profits` → `Split ... into {service_owner: N}` → Safe multisend lands on-chain → `Total mechs balances: 0` on the next split-check
6. Watch **Fix 2** rollout by querying `predict-api-db` after the redeploy: `SELECT count(*), count(payment_type) FROM mech_requests WHERE created_at > '<redeploy timestamp>'`. Expect `count(payment_type)` to grow with `count(*)` on rows written by the redeployed mech. The autonolas-frontend-mono follow-up PR that maps hex → label needs to land + deploy before the FE Payment cell renders correctly for those rows.
7. If Fix 1 is clean, extend the same treatment to `polygon_mech_mm_predict_25` and `polygon_mech_mm_predict_44`. Fix 2 benefits from any mech redeploy identically — the more mechs on the new package, the faster the tail of NULL payment_type shrinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
