### PR TITLE
fix(task_submission): move predict_api_event out of consensus

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeib4v4lwuwku2q2wq6fsqxtwgwg6ysurddcpggl4d3ryrdd5bk3p34",
-        "skill/valory/task_execution/0.1.0": "bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeig5sfn3lfydrycnlfe4h6bqlwnt5l3vptkhi3fdkmiqxdahfgwnq4",
+        "skill/valory/mech_abci/0.1.0": "bafybeie3mxvlutr6iu4vqpwrnchhuwomdkn2jr6axmp3nhnplwddb2ku7m",
+        "skill/valory/task_execution/0.1.0": "bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifbfmfvlxn3hjqtgimbrpwwkzrxox3f76ty25wppdtshnkbj5raam",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiboguuhzpcekem4hfj24zdgypgrzgqjpoekj4zaktcpgmbz4ue5ta",
-        "service/valory/mech/0.1.0": "bafybeibp3z7zzo4tadpyjzvluyly4dce7p7jmwyqhvbqje7rowpiowxgwe"
+        "agent/valory/mech/0.1.0": "bafybeihcezrl4nsdhrp2rxzzqyfhl4awk4g2lm3l45l3razews7jl7c76y",
+        "service/valory/mech/0.1.0": "bafybeigwmdbx4d6h6btdouf6abtdzyarif6vg75eod3qu3xx4qbnjh3sva"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeie3mxvlutr6iu4vqpwrnchhuwomdkn2jr6axmp3nhnplwddb2ku7m",
-        "skill/valory/task_execution/0.1.0": "bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifbfmfvlxn3hjqtgimbrpwwkzrxox3f76ty25wppdtshnkbj5raam",
+        "skill/valory/mech_abci/0.1.0": "bafybeiexqf73mv5eztaj2fftro6lcdcnh74nh6ofynhltqzwzrihy535bi",
+        "skill/valory/task_execution/0.1.0": "bafybeiaf6p36ftx6tustdlkhygewmr2vfhfn7q6qr2jwzxgxgnh3ztjnue",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeiff5t5d7itgnc7v63cxdrbob5fmfxxwn2g4gsj4mmdxicrcqnpwfe",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihcezrl4nsdhrp2rxzzqyfhl4awk4g2lm3l45l3razews7jl7c76y",
-        "service/valory/mech/0.1.0": "bafybeigwmdbx4d6h6btdouf6abtdzyarif6vg75eod3qu3xx4qbnjh3sva"
+        "agent/valory/mech/0.1.0": "bafybeici6fpzuspmstejpsdt6ducg222o24laaju4xc6x5iolbfengqziq",
+        "service/valory/mech/0.1.0": "bafybeicwkbsux4aqw2ksw5boaas4wyjr2d52bhyl7cbhn7gbkmw57w3xn4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeihpodhq2ispskxmza35y7q6xmc6qitfn6tl55h7oin3jz25ghtk6u",
-        "skill/valory/task_execution/0.1.0": "bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihlnid342gh6wzo3mcgi5rlqvit5w3wdhah6ekqi566gkftvkf6au",
+        "skill/valory/mech_abci/0.1.0": "bafybeib4v4lwuwku2q2wq6fsqxtwgwg6ysurddcpggl4d3ryrdd5bk3p34",
+        "skill/valory/task_execution/0.1.0": "bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeig5sfn3lfydrycnlfe4h6bqlwnt5l3vptkhi3fdkmiqxdahfgwnq4",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeiaet6wsg4mfxrkiorutylummbfcczluy4gktg3fomsc5j34av2abq",
-        "service/valory/mech/0.1.0": "bafybeifnmhte22tux5fkbz6dg2mi4nvyxplyczn4aap35sbkygdew3d2v4"
+        "agent/valory/mech/0.1.0": "bafybeiboguuhzpcekem4hfj24zdgypgrzgqjpoekj4zaktcpgmbz4ue5ta",
+        "service/valory/mech/0.1.0": "bafybeibp3z7zzo4tadpyjzvluyly4dce7p7jmwyqhvbqje7rowpiowxgwe"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -9,12 +9,12 @@
         "connection/valory/websocket_client/0.1.0": "bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea",
         "skill/valory/contract_subscription/0.1.0": "bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeifuuif7ctpas6u7j75qkhda6zpm5uzrnotetzoux4uujvjyflk5pi",
-        "skill/valory/task_execution/0.1.0": "bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeic6lgc2xk57zd6nhxq4fvmpkithkwukwoompebioms2ggr35gp43a",
+        "skill/valory/mech_abci/0.1.0": "bafybeihpodhq2ispskxmza35y7q6xmc6qitfn6tl55h7oin3jz25ghtk6u",
+        "skill/valory/task_execution/0.1.0": "bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihlnid342gh6wzo3mcgi5rlqvit5w3wdhah6ekqi566gkftvkf6au",
         "skill/valory/websocket_client/0.1.0": "bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m",
-        "agent/valory/mech/0.1.0": "bafybeihh7457c7kjkyat4zqh44tihzgup2jiilgfoufefhun3i5tvsyvaa",
-        "service/valory/mech/0.1.0": "bafybeicfblue2fsikhlqvw52viwyszbracowbdf5loelir73pjrbnxwatq"
+        "agent/valory/mech/0.1.0": "bafybeiaet6wsg4mfxrkiorutylummbfcczluy4gktg3fomsc5j34av2abq",
+        "service/valory/mech/0.1.0": "bafybeifnmhte22tux5fkbz6dg2mi4nvyxplyczn4aap35sbkygdew3d2v4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeie3mxvlutr6iu4vqpwrnchhuwomdkn2jr6axmp3nhnplwddb2ku7m
+- valory/mech_abci:0.1.0:bafybeiexqf73mv5eztaj2fftro6lcdcnh74nh6ofynhltqzwzrihy535bi
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q
-- valory/task_submission_abci:0.1.0:bafybeifbfmfvlxn3hjqtgimbrpwwkzrxox3f76ty25wppdtshnkbj5raam
+- valory/task_execution:0.1.0:bafybeiaf6p36ftx6tustdlkhygewmr2vfhfn7q6qr2jwzxgxgnh3ztjnue
+- valory/task_submission_abci:0.1.0:bafybeiff5t5d7itgnc7v63cxdrbob5fmfxxwn2g4gsj4mmdxicrcqnpwfe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeihpodhq2ispskxmza35y7q6xmc6qitfn6tl55h7oin3jz25ghtk6u
+- valory/mech_abci:0.1.0:bafybeib4v4lwuwku2q2wq6fsqxtwgwg6ysurddcpggl4d3ryrdd5bk3p34
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y
-- valory/task_submission_abci:0.1.0:bafybeihlnid342gh6wzo3mcgi5rlqvit5w3wdhah6ekqi566gkftvkf6au
+- valory/task_execution:0.1.0:bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq
+- valory/task_submission_abci:0.1.0:bafybeig5sfn3lfydrycnlfe4h6bqlwnt5l3vptkhi3fdkmiqxdahfgwnq4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeifuuif7ctpas6u7j75qkhda6zpm5uzrnotetzoux4uujvjyflk5pi
+- valory/mech_abci:0.1.0:bafybeihpodhq2ispskxmza35y7q6xmc6qitfn6tl55h7oin3jz25ghtk6u
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
-- valory/task_submission_abci:0.1.0:bafybeic6lgc2xk57zd6nhxq4fvmpkithkwukwoompebioms2ggr35gp43a
+- valory/task_execution:0.1.0:bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y
+- valory/task_submission_abci:0.1.0:bafybeihlnid342gh6wzo3mcgi5rlqvit5w3wdhah6ekqi566gkftvkf6au
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -41,11 +41,11 @@ skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeihaaqld7ntndyhoxu2o4jecjocclo4gsvmqdz3dpgmqeckq6j5cb4
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/mech_abci:0.1.0:bafybeib4v4lwuwku2q2wq6fsqxtwgwg6ysurddcpggl4d3ryrdd5bk3p34
+- valory/mech_abci:0.1.0:bafybeie3mxvlutr6iu4vqpwrnchhuwomdkn2jr6axmp3nhnplwddb2ku7m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq
-- valory/task_submission_abci:0.1.0:bafybeig5sfn3lfydrycnlfe4h6bqlwnt5l3vptkhi3fdkmiqxdahfgwnq4
+- valory/task_execution:0.1.0:bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q
+- valory/task_submission_abci:0.1.0:bafybeifbfmfvlxn3hjqtgimbrpwwkzrxox3f76ty25wppdtshnkbj5raam
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiaet6wsg4mfxrkiorutylummbfcczluy4gktg3fomsc5j34av2abq
+agent: valory/mech:0.1.0:bafybeiboguuhzpcekem4hfj24zdgypgrzgqjpoekj4zaktcpgmbz4ue5ta
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihh7457c7kjkyat4zqh44tihzgup2jiilgfoufefhun3i5tvsyvaa
+agent: valory/mech:0.1.0:bafybeiaet6wsg4mfxrkiorutylummbfcczluy4gktg3fomsc5j34av2abq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiboguuhzpcekem4hfj24zdgypgrzgqjpoekj4zaktcpgmbz4ue5ta
+agent: valory/mech:0.1.0:bafybeihcezrl4nsdhrp2rxzzqyfhl4awk4g2lm3l45l3razews7jl7c76y
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeihppqns2lwn5vehtqh2wu4tjyf76dbzxc26nlfws4sc5hcbjbalma
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeihcezrl4nsdhrp2rxzzqyfhl4awk4g2lm3l45l3razews7jl7c76y
+agent: valory/mech:0.1.0:bafybeici6fpzuspmstejpsdt6ducg222o24laaju4xc6x5iolbfengqziq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q
-- valory/task_submission_abci:0.1.0:bafybeifbfmfvlxn3hjqtgimbrpwwkzrxox3f76ty25wppdtshnkbj5raam
+- valory/task_execution:0.1.0:bafybeiaf6p36ftx6tustdlkhygewmr2vfhfn7q6qr2jwzxgxgnh3ztjnue
+- valory/task_submission_abci:0.1.0:bafybeiff5t5d7itgnc7v63cxdrbob5fmfxxwn2g4gsj4mmdxicrcqnpwfe
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
-- valory/task_submission_abci:0.1.0:bafybeic6lgc2xk57zd6nhxq4fvmpkithkwukwoompebioms2ggr35gp43a
+- valory/task_execution:0.1.0:bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y
+- valory/task_submission_abci:0.1.0:bafybeihlnid342gh6wzo3mcgi5rlqvit5w3wdhah6ekqi566gkftvkf6au
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y
-- valory/task_submission_abci:0.1.0:bafybeihlnid342gh6wzo3mcgi5rlqvit5w3wdhah6ekqi566gkftvkf6au
+- valory/task_execution:0.1.0:bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq
+- valory/task_submission_abci:0.1.0:bafybeig5sfn3lfydrycnlfe4h6bqlwnt5l3vptkhi3fdkmiqxdahfgwnq4
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/mech_abci/skill.yaml
+++ b/packages/valory/skills/mech_abci/skill.yaml
@@ -31,8 +31,8 @@ skills:
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/task_execution:0.1.0:bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq
-- valory/task_submission_abci:0.1.0:bafybeig5sfn3lfydrycnlfe4h6bqlwnt5l3vptkhi3fdkmiqxdahfgwnq4
+- valory/task_execution:0.1.0:bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q
+- valory/task_submission_abci:0.1.0:bafybeifbfmfvlxn3hjqtgimbrpwwkzrxox3f76ty25wppdtshnkbj5raam
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -87,6 +87,7 @@ LAST_SUCCESSFUL_EXECUTED_TASK = "last_successful_executed_task"
 LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
+PREDICT_API_EVENTS = "predict_api_events"
 # Shared-state keys owned by the MechHttpHandler (handlers.py); mirrored here
 # because the off-chain finalize path writes the response envelope for the
 # ``/fetch_offchain_info`` polling endpoint and clears the buffered request
@@ -1773,40 +1774,18 @@ class TaskExecutionBehaviour(SimpleBehaviour):
         # pop the data key value as it's bytes which causes issues
         # with json dumps and not required anywhere
         done_task.pop("data", None)
-        # Attach the offchain predict-api event payload before the
-        # IN_MEMORY_REQUESTS pop below; the post-settlement behaviour in
-        # task_submission_abci reads it off ``synchronized_data.done_tasks``
-        # (i.e. after consensus replication) and posts it to the predict-api
-        # data lake, but the buffered request metadata it needs is local
-        # to this agent's shared_state and goes away at the pop.
-        #
-        # Gate the whole event build on ``use_offchain``. When the flag
-        # is off, no payload is built and nothing rides Tendermint
-        # consensus replication — so the ingress-side consensus cost
-        # matches the egress-side HTTP write cost (nothing on either
-        # side). The paired gate in
-        # :py:meth:`task_submission_abci.behaviours.PostTxSettlementBehaviour._do_predict_api_write_best_effort`
-        # additionally warns if it receives events under a locally-off
-        # flag, so a config drift between the two skill copies of
-        # ``use_offchain`` is alertable rather than silent.
-        # Build the event for both off-chain HTTP deliveries
-        # (``is_offchain=True``) and on-chain marketplace deliveries
-        # (``is_offchain=False`` AND ``is_marketplace_delivery=True``).
-        # The ``source`` field on the event (set by
-        # ``_build_predict_api_event``) disambiguates the two paths on
-        # the predict-api side: ``mech_offchain`` for the paid HTTP path,
-        # ``mech_onchain`` for the on-chain rails. See
-        # ``autonolas-marketplace/docs/onchain_write_path_scope.md`` for
-        # the agreed shape.
         predict_api_mode_enabled = self.params.use_offchain
         is_marketplace_delivery = bool(done_task.get("is_marketplace_mech"))
         if predict_api_mode_enabled and (is_offchain or is_marketplace_delivery):
-            done_task["predict_api_event"] = self._build_predict_api_event(
+            event = self._build_predict_api_event(
                 done_task=done_task,
                 cid=cid,
                 executing_task=cast(Dict[str, Any], executing_task),
                 response=response,
             )
+            self.context.shared_state.setdefault(PREDICT_API_EVENTS, {})[
+                str(req_id)
+            ] = event
         # add to done tasks, in thread safe way
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -88,6 +88,7 @@ LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
 PREDICT_API_EVENTS = "predict_api_events"
+PREDICT_API_EVENT_TTL_SECONDS = 24 * 60 * 60
 # Shared-state keys owned by the MechHttpHandler (handlers.py); mirrored here
 # because the off-chain finalize path writes the response envelope for the
 # ``/fetch_offchain_info`` polling endpoint and clears the buffered request
@@ -1785,7 +1786,7 @@ class TaskExecutionBehaviour(SimpleBehaviour):
             )
             self.context.shared_state.setdefault(PREDICT_API_EVENTS, {})[
                 str(req_id)
-            ] = event
+            ] = {"event": event, "written_at": time.time()}
         # add to done tasks, in thread safe way
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)

--- a/packages/valory/skills/task_execution/behaviours.py
+++ b/packages/valory/skills/task_execution/behaviours.py
@@ -1784,9 +1784,23 @@ class TaskExecutionBehaviour(SimpleBehaviour):
                 executing_task=cast(Dict[str, Any], executing_task),
                 response=response,
             )
-            self.context.shared_state.setdefault(PREDICT_API_EVENTS, {})[
-                str(req_id)
-            ] = {"event": event, "written_at": time.time()}
+            events_by_id = self.context.shared_state.setdefault(PREDICT_API_EVENTS, {})
+            # TTL sweep on write bounds cache growth even if settlement
+            # is stuck and no post-settlement prune ever fires.
+            cutoff = time.time() - PREDICT_API_EVENT_TTL_SECONDS
+            stale = [
+                rid
+                for rid, entry in events_by_id.items()
+                if not isinstance(entry, dict)
+                or not isinstance(entry.get("written_at"), (int, float))
+                or float(entry["written_at"]) < cutoff
+            ]
+            for rid in stale:
+                events_by_id.pop(rid, None)
+            events_by_id[str(req_id)] = {
+                "event": event,
+                "written_at": time.time(),
+            }
         # add to done tasks, in thread safe way
         with self.done_tasks_lock:
             self.done_tasks.append(done_task)

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -61,6 +61,7 @@ from packages.valory.protocols.ipfs import IpfsMessage
 from packages.valory.protocols.kv_store.message import KvStoreMessage
 from packages.valory.protocols.ledger_api import LedgerApiMessage
 from packages.valory.skills.abstract_round_abci.handlers import AbstractResponseHandler
+from packages.valory.skills.task_execution.behaviours import PREDICT_API_EVENTS
 from packages.valory.skills.task_execution.dialogues import HttpDialogue
 from packages.valory.skills.task_execution.models import Params
 from packages.valory.skills.task_execution.utils import preimage as preimage_buffer
@@ -88,7 +89,6 @@ LAST_SUCCESSFUL_READ = "last_successful_read"
 LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
-PREDICT_API_EVENTS = "predict_api_events"
 WAS_LAST_READ_SUCCESSFUL = "was_last_read_successful"
 PAYMENT_MODEL = "payment_model"
 PAYMENT_INFO = "payment_info"

--- a/packages/valory/skills/task_execution/handlers.py
+++ b/packages/valory/skills/task_execution/handlers.py
@@ -88,6 +88,7 @@ LAST_SUCCESSFUL_READ = "last_successful_read"
 LAST_READ_ATTEMPT_TS = "last_read_attempt_ts"
 INFLIGHT_READ_TS = "inflight_read_ts"
 REQUEST_ID_TO_DELIVERY_RATE_INFO = "request_id_to_delivery_rate_info"
+PREDICT_API_EVENTS = "predict_api_events"
 WAS_LAST_READ_SUCCESSFUL = "was_last_read_successful"
 PAYMENT_MODEL = "payment_model"
 PAYMENT_INFO = "payment_info"
@@ -608,6 +609,7 @@ class ContractHandler(BaseHandler):
         self.context.shared_state[DONE_TASKS] = []
         self.context.shared_state[DONE_TASKS_LOCK] = threading.Lock()
         self.context.shared_state[REQUEST_ID_TO_DELIVERY_RATE_INFO] = {}
+        self.context.shared_state[PREDICT_API_EVENTS] = {}
         super().setup()
 
     def set_last_successful_read(self, block_number: Optional[int]) -> None:

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeihdgoskohgjm4sr7wrgpkvezycabumxbgwl55plriagqs4jw2eqsm
+  behaviours.py: bafybeibip44j3jqggn4bs2qltcs3ijnrs7sd27gzw33glmqdejubqq3q5e
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeiff6qadx3fnvgyp2uyqabt5ys4tbkhxokiklhmzg7527jrqxnnziq
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeigvcbnbn3a6r2phgadhtqd5t4hirqd75kyrsm7e2tev4e5tzkuyou
+  tests/test_behaviours.py: bafybeicsp55g4brex7zcgaiajeflxaarc5irk4g7sf5jbtnk5wafnmj5ea
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeid7wjw2lfuxgsnqpaojvy57e6k2dtedalupb2dqjr45setir5gk6u
+  behaviours.py: bafybeihdgoskohgjm4sr7wrgpkvezycabumxbgwl55plriagqs4jw2eqsm
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
   handlers.py: bafybeifwln3rpe4rd67tozq6htnzbi4itfamzbh4se4nbd365tuseiqpya
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeifn7oyptgpd7tmmvcqkgfbwj34jhjpsuadwpf6okfpualnml4jfxy
+  tests/test_behaviours.py: bafybeigvcbnbn3a6r2phgadhtqd5t4hirqd75kyrsm7e2tev4e5tzkuyou
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
   behaviours.py: bafybeihdgoskohgjm4sr7wrgpkvezycabumxbgwl55plriagqs4jw2eqsm
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeifwln3rpe4rd67tozq6htnzbi4itfamzbh4se4nbd365tuseiqpya
+  handlers.py: bafybeiff6qadx3fnvgyp2uyqabt5ys4tbkhxokiklhmzg7527jrqxnnziq
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq

--- a/packages/valory/skills/task_execution/skill.yaml
+++ b/packages/valory/skills/task_execution/skill.yaml
@@ -7,13 +7,13 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiddgrfcoxgz6syq5kyhf2k4dor4ewhr3xiyqrpro4c5idhfqjifsu
-  behaviours.py: bafybeidj2rmgxfmnuk65mraezlcpcv2w3g2hzzzchumfl36jribabhdvcu
+  behaviours.py: bafybeid7wjw2lfuxgsnqpaojvy57e6k2dtedalupb2dqjr45setir5gk6u
   dialogues.py: bafybeid7bbtq3thsazuheoxwnli2lkpaiwgoeps7pwrw63apqg5dizuomm
-  handlers.py: bafybeietoccc5xvbcghp3grsh44xh34bzy7pctdez3374kz24oec5ipab4
+  handlers.py: bafybeifwln3rpe4rd67tozq6htnzbi4itfamzbh4se4nbd365tuseiqpya
   models.py: bafybeibf6crcay7rqwwcmwx2eyl4knxikr6rtfjszx4ndfhmltmhxowb6i
   tests/__init__.py: bafybeieqltdoxt2ipgn7owrfyceylzqug3fpdy6pk6mxhdxyn2mujz4v7q
   tests/conftest.py: bafybeiahjndbwygeufbb72aud765lg554dltrmvwc5yc42nyfm5gxeuhmq
-  tests/test_behaviours.py: bafybeiehhymwtrv23cqxaaz6ncld3c5xd7t7ffptupufigl6qd4utbepqm
+  tests/test_behaviours.py: bafybeifn7oyptgpd7tmmvcqkgfbwj34jhjpsuadwpf6okfpualnml4jfxy
   tests/test_dialogues.py: bafybeig2phgjrv7ugdx4olviuclaxegvyzkcw7t2ztzrp3xcj2ygqs4344
   tests/test_handlers.py: bafybeifxtcvsc6ggb3pzwsdzmh2bpad7qcvkhsawjcj5anaci6xbj4hq54
   tests/test_models.py: bafybeidyzmub74c3m6zopwgxy43o2mx5tvig4wmahgyhoiur4qz55jgwaq

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1865,11 +1865,13 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     # the writer stores under ``str(req_id)``, so every successful off-chain
     # delivery landed in the lake as ``status="failed"``, ``result=None``.
     # Silent failure: the poller still saw the right answer.
-    done_event = done.get("predict_api_event")
-    assert isinstance(done_event, dict), done
+    events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
+    done_event = events.get(str(done["request_id"]))
+    assert isinstance(done_event, dict), events
     inner = done_event.get("response", {})
     assert inner.get("status") == "complete", done_event
     assert inner.get("result") == "prediction: yes", done_event
+    assert "predict_api_event" not in done
 
 
 def test_handle_done_task_offchain_invalid_request_recorded_as_failure(
@@ -2026,7 +2028,9 @@ def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
 
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
-    event = done_tasks[0]["predict_api_event"]
+    assert "predict_api_event" not in done_tasks[0]
+    events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
+    event = events[str(done_tasks[0]["request_id"])]
     assert event["response"]["result"] == expected_event_result
     assert event["response"]["status"] == expected_event_status
     assert event["response"]["error"] == expected_event_error
@@ -4431,8 +4435,10 @@ def test_finalize_done_task_attaches_predict_api_event_when_use_offchain_on(
     behaviour._finalize_done_task("bafycid")
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
-    assert isinstance(done_tasks[0].get("predict_api_event"), dict)
-    assert done_tasks[0]["predict_api_event"].get("source") == "mech_offchain"
+    assert "predict_api_event" not in done_tasks[0]
+    events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
+    event = events[str(done_tasks[0]["request_id"])]
+    assert event.get("source") == "mech_offchain"
 
 
 def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
@@ -4465,8 +4471,10 @@ def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
     behaviour._finalize_done_task("bafycid")
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
-    assert isinstance(done_tasks[0].get("predict_api_event"), dict)
-    assert done_tasks[0]["predict_api_event"].get("source") == "mech_onchain"
+    assert "predict_api_event" not in done_tasks[0]
+    events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
+    event = events[str(done_tasks[0]["request_id"])]
+    assert event.get("source") == "mech_onchain"
 
 
 def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(
@@ -4499,6 +4507,7 @@ def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(
     done_tasks = shared_state[beh_mod.DONE_TASKS]
     assert len(done_tasks) == 1
     assert "predict_api_event" not in done_tasks[0]
+    assert not shared_state.get(beh_mod.PREDICT_API_EVENTS)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -1866,8 +1866,10 @@ def test_handle_done_task_offchain_skips_ipfs_and_finalizes_locally(
     # delivery landed in the lake as ``status="failed"``, ``result=None``.
     # Silent failure: the poller still saw the right answer.
     events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
-    done_event = events.get(str(done["request_id"]))
-    assert isinstance(done_event, dict), events
+    entry = events.get(str(done["request_id"]))
+    assert isinstance(entry, dict) and "written_at" in entry, events
+    done_event = entry["event"]
+    assert isinstance(done_event, dict), entry
     inner = done_event.get("response", {})
     assert inner.get("status") == "complete", done_event
     assert inner.get("result") == "prediction: yes", done_event
@@ -2030,7 +2032,9 @@ def test_handle_done_task_onchain_end_to_end_predict_api_event(  # noqa: PLR0913
     assert len(done_tasks) == 1
     assert "predict_api_event" not in done_tasks[0]
     events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
-    event = events[str(done_tasks[0]["request_id"])]
+    entry = events[str(done_tasks[0]["request_id"])]
+    assert "written_at" in entry
+    event = entry["event"]
     assert event["response"]["result"] == expected_event_result
     assert event["response"]["status"] == expected_event_status
     assert event["response"]["error"] == expected_event_error
@@ -4437,8 +4441,9 @@ def test_finalize_done_task_attaches_predict_api_event_when_use_offchain_on(
     assert len(done_tasks) == 1
     assert "predict_api_event" not in done_tasks[0]
     events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
-    event = events[str(done_tasks[0]["request_id"])]
-    assert event.get("source") == "mech_offchain"
+    entry = events[str(done_tasks[0]["request_id"])]
+    assert "written_at" in entry
+    assert entry["event"].get("source") == "mech_offchain"
 
 
 def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
@@ -4473,8 +4478,9 @@ def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
     assert len(done_tasks) == 1
     assert "predict_api_event" not in done_tasks[0]
     events = shared_state.get(beh_mod.PREDICT_API_EVENTS, {})
-    event = events[str(done_tasks[0]["request_id"])]
-    assert event.get("source") == "mech_onchain"
+    entry = events[str(done_tasks[0]["request_id"])]
+    assert "written_at" in entry
+    assert entry["event"].get("source") == "mech_onchain"
 
 
 def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(

--- a/packages/valory/skills/task_execution/tests/test_behaviours.py
+++ b/packages/valory/skills/task_execution/tests/test_behaviours.py
@@ -4483,6 +4483,53 @@ def test_finalize_done_task_attaches_predict_api_event_on_marketplace_delivery(
     assert entry["event"].get("source") == "mech_onchain"
 
 
+def test_finalize_done_task_sweeps_stale_predict_api_events_on_write(
+    behaviour: Any,
+    params_stub: Any,
+    shared_state: Dict[str, Any],
+    monkeypatch: Any,
+) -> None:
+    """A write drops entries older than the TTL and preserves fresh ones.
+
+    Bounds cache growth on agents whose settlement is stuck: the
+    on-write sweep runs regardless of whether a post-settlement
+    prune ever fires. ``malformed`` and ``bad-written-at`` cover
+    the guard branches (F4).
+
+    :param behaviour: TaskExecutionBehaviour fixture.
+    :param params_stub: params fixture with ``use_offchain=True``.
+    :param shared_state: shared_state fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    params_stub.use_offchain = True
+    now = time.time()
+    shared_state[beh_mod.PREDICT_API_EVENTS] = {
+        "fresh": {"event": {"src": "off"}, "written_at": now - 60},
+        "stale": {
+            "event": {"src": "off"},
+            "written_at": now - beh_mod.PREDICT_API_EVENT_TTL_SECONDS - 60,
+        },
+        "malformed": "not-a-dict",
+        "bad-written-at": {"event": {"src": "off"}, "written_at": "yesterday"},
+    }
+    _finalize_gate_setup(
+        behaviour,
+        shared_state,
+        params_stub,
+        monkeypatch,
+        is_offchain=True,
+        is_marketplace_mech=True,
+    )
+    fresh_req_id = str(behaviour._done_task["request_id"])
+    behaviour._finalize_done_task("bafycid")
+    events = shared_state[beh_mod.PREDICT_API_EVENTS]
+    assert "fresh" in events
+    assert "stale" not in events
+    assert "malformed" not in events
+    assert "bad-written-at" not in events
+    assert fresh_req_id in events
+
+
 def test_finalize_done_task_omits_predict_api_event_when_use_offchain_off(
     behaviour: Any,
     params_stub: Any,

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -67,6 +67,7 @@ from packages.valory.skills.abstract_round_abci.behaviours import (
     BaseBehaviour,
 )
 from packages.valory.skills.abstract_round_abci.io_.store import SupportedFiletype
+from packages.valory.skills.task_execution.behaviours import PREDICT_API_EVENTS
 from packages.valory.skills.task_execution.utils.ipfs import to_multihash
 from packages.valory.skills.task_submission_abci.models import Params
 from packages.valory.skills.task_submission_abci.payloads import (
@@ -278,6 +279,10 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
                 for task in snapshot
                 if str(task.get("request_id")) not in submitted_id_set
             ]
+        events_by_id = self.context.shared_state.get(PREDICT_API_EVENTS)
+        if isinstance(events_by_id, dict):
+            for rid in submitted_id_set:
+                events_by_id.pop(rid, None)
         return snapshot
 
     @property
@@ -1990,21 +1995,11 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             ``return`` anything.
         """
         if not self.params.use_offchain:
-            # Divergence safety net. ``use_offchain`` is a duplicated
-            # param (declared on both this skill and ``task_execution``);
-            # if an operator flips ``task_execution.use_offchain=true`` but
-            # forgets this one, the ingress side builds
-            # ``predict_api_event`` entries and rides Tendermint
-            # consensus replication for them — and then the egress side
-            # here silently drops the entire batch. Warn loudly when we
-            # can see that has happened so the divergence is alertable
-            # rather than invisible.
-            if any(
-                isinstance(t, dict) and t.get("predict_api_event")
-                for t in cast(List[Dict[str, Any]], self.synchronized_data.done_tasks)
-            ):
+            # Divergence safety net: the ingress side wrote events into
+            # local shared_state but the egress side has the flag off.
+            if self.context.shared_state.get(PREDICT_API_EVENTS):
                 self.context.logger.warning(
-                    "predict_api_event entries present in done_tasks but "
+                    "predict_api_event entries present in shared_state but "
                     "task_submission_abci.use_offchain is False — the "
                     "ingress-side (task_execution) and egress-side "
                     "(task_submission_abci) use_offchain flags are "
@@ -2447,30 +2442,29 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         ).inc()
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
-        """Return the ``predict_api_event`` payload from every done_task that carries one.
+        """Return the ``predict_api_event`` payload for every done_task that has one.
 
-        Both off-chain HTTP deliveries (``source = 'mech_offchain'``) and
-        on-chain marketplace deliveries (``source = 'mech_onchain'``) now
-        ride the same predict-api write path; the per-event ``source`` field
-        set inside :py:meth:`task_execution.behaviours._build_predict_api_event`
-        is what disambiguates the two on the predict-api side. The filter
-        here keys on the presence of a ``predict_api_event`` field, which
-        :py:meth:`task_execution.behaviours._finalize_done_task` sets only
-        when ``use_offchain`` is on AND the task is either an off-chain
-        HTTP delivery (``is_offchain=True``) or an on-chain marketplace
-        delivery (``is_marketplace_delivery=True``). On-chain
-        non-marketplace tasks on a legacy mech contract stay out of the
-        lake by construction.
+        Looks each event up in agent-local
+        ``shared_state[PREDICT_API_EVENTS]`` keyed by ``str(request_id)``.
+        Only the agent that executed a task locally has its event; a
+        task another agent executed is skipped here and posted by that
+        agent instead. Predict-api dedups on ``request_id`` so a single
+        POST per task is sufficient.
 
         :return: an ordered list of ``MechEvent``-shaped dicts.
         """
         done_tasks = cast(List[Dict[str, Any]], self.synchronized_data.done_tasks)
+        events_by_id: Dict[str, Dict[str, Any]] = self.context.shared_state.get(
+            PREDICT_API_EVENTS, {}
+        )
         events: List[Dict[str, Any]] = []
         for task in done_tasks:
-            event = task.get("predict_api_event")
-            if not isinstance(event, dict):
+            req_id = task.get("request_id")
+            if req_id is None:
                 continue
-            events.append(event)
+            event = events_by_id.get(str(req_id))
+            if isinstance(event, dict):
+                events.append(event)
         return events
 
     def _sweep_pending_undelivered(

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -67,7 +67,10 @@ from packages.valory.skills.abstract_round_abci.behaviours import (
     BaseBehaviour,
 )
 from packages.valory.skills.abstract_round_abci.io_.store import SupportedFiletype
-from packages.valory.skills.task_execution.behaviours import PREDICT_API_EVENTS
+from packages.valory.skills.task_execution.behaviours import (
+    PREDICT_API_EVENTS,
+    PREDICT_API_EVENT_TTL_SECONDS,
+)
 from packages.valory.skills.task_execution.utils.ipfs import to_multihash
 from packages.valory.skills.task_submission_abci.models import Params
 from packages.valory.skills.task_submission_abci.payloads import (
@@ -282,6 +285,15 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
         events_by_id = self.context.shared_state.get(PREDICT_API_EVENTS)
         if isinstance(events_by_id, dict):
             for rid in submitted_id_set:
+                events_by_id.pop(rid, None)
+            cutoff = time.time() - PREDICT_API_EVENT_TTL_SECONDS
+            stale = [
+                rid
+                for rid, entry in events_by_id.items()
+                if not isinstance(entry, dict)
+                or float(entry.get("written_at", 0)) < cutoff
+            ]
+            for rid in stale:
                 events_by_id.pop(rid, None)
         return snapshot
 
@@ -2462,7 +2474,10 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             req_id = task.get("request_id")
             if req_id is None:
                 continue
-            event = events_by_id.get(str(req_id))
+            entry = events_by_id.get(str(req_id))
+            if not isinstance(entry, dict):
+                continue
+            event = entry.get("event")
             if isinstance(event, dict):
                 events.append(event)
         return events

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -67,10 +67,7 @@ from packages.valory.skills.abstract_round_abci.behaviours import (
     BaseBehaviour,
 )
 from packages.valory.skills.abstract_round_abci.io_.store import SupportedFiletype
-from packages.valory.skills.task_execution.behaviours import (
-    PREDICT_API_EVENTS,
-    PREDICT_API_EVENT_TTL_SECONDS,
-)
+from packages.valory.skills.task_execution.behaviours import PREDICT_API_EVENTS
 from packages.valory.skills.task_execution.utils.ipfs import to_multihash
 from packages.valory.skills.task_submission_abci.models import Params
 from packages.valory.skills.task_submission_abci.payloads import (
@@ -282,19 +279,6 @@ class TaskExecutionBaseBehaviour(BaseBehaviour, ABC):
                 for task in snapshot
                 if str(task.get("request_id")) not in submitted_id_set
             ]
-        events_by_id = self.context.shared_state.get(PREDICT_API_EVENTS)
-        if isinstance(events_by_id, dict):
-            for rid in submitted_id_set:
-                events_by_id.pop(rid, None)
-            cutoff = time.time() - PREDICT_API_EVENT_TTL_SECONDS
-            stale = [
-                rid
-                for rid, entry in events_by_id.items()
-                if not isinstance(entry, dict)
-                or float(entry.get("written_at", 0)) < cutoff
-            ]
-            for rid in stale:
-                events_by_id.pop(rid, None)
         return snapshot
 
     @property
@@ -391,6 +375,13 @@ class TaskPoolingBehaviour(TaskExecutionBaseBehaviour, ABC):
         # ``shared_state[DONE_TASKS]`` under the same lock) and keeps
         # both paths on the single tested prune surface.
         shared_snapshot = self.remove_tasks_by_id(submitted_ids)
+        # Prune must fire only after ``PostTxSettlementBehaviour`` has
+        # POSTed. Do not move into ``remove_tasks_by_id``: its
+        # pre-settlement caller strands the row otherwise.
+        events_by_id = self.context.shared_state.get(PREDICT_API_EVENTS)
+        if isinstance(events_by_id, dict):
+            for rid in submitted_ids:
+                events_by_id.pop(rid, None)
         self.context.logger.info(
             f"Pruned tasks with ids {submitted_ids} from shared state; "
             f"tx_hash={tx_hash}."
@@ -1951,14 +1942,15 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     agent-local ``shared_state[PREDICT_API_EVENTS]`` (keyed by
     ``str(request_id)``, populated on the offchain path inside
     :py:meth:`task_execution.behaviours._build_predict_api_event`).
-    Each cache entry is a ``{event, written_at}`` wrapper so the sibling
-    TTL sweep in :py:meth:`TaskExecutionBaseBehaviour.remove_tasks_by_id`
-    can drop stale entries. Only the agent that executed a task
-    locally has its event; other agents skip and rely on the executor
-    to POST. The predict-api server is idempotent on ``request_id``,
-    so a single POST per task is sufficient — each agent posts its own
-    events under its own EOA signature; the per-EOA rate limiter on the
-    server keeps the co-owners in separate budgets.
+    Each cache entry is a ``{event, written_at}`` wrapper so the TTL
+    sweep on write in
+    :py:meth:`task_execution.behaviours.TaskExecutionBehaviour._finalize_done_task`
+    can drop stale entries. Only the agent that executed a task locally
+    has its event; other agents skip and rely on the executor to POST.
+    The predict-api server is idempotent on ``request_id``, so a single
+    POST per task is sufficient — each agent posts only the subset it
+    executed, under its own EOA signature; the per-EOA rate limiter on
+    the server keeps the co-owners in separate budgets.
 
     The behaviour is fail-soft by construction. A predict-api outage / 5xx
     / network drop does NOT stop the FSM — the settlement already landed
@@ -2462,14 +2454,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         ).inc()
 
     def _extract_offchain_events(self) -> List[Dict[str, Any]]:
-        """Return the ``predict_api_event`` payload for every done_task that has one.
-
-        Looks each event up in agent-local
-        ``shared_state[PREDICT_API_EVENTS]`` keyed by ``str(request_id)``.
-        Only the agent that executed a task locally has its event; a
-        task another agent executed is skipped here and posted by that
-        agent instead. Predict-api dedups on ``request_id`` so a single
-        POST per task is sufficient.
+        """Return every locally-cached ``predict_api_event`` for the round's done_tasks.
 
         :return: an ordered list of ``MechEvent``-shaped dicts.
         """
@@ -2477,6 +2462,7 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         events_by_id: Dict[str, Dict[str, Any]] = self.context.shared_state.get(
             PREDICT_API_EVENTS, {}
         )
+        agent_address = self.context.agent_address
         events: List[Dict[str, Any]] = []
         for task in done_tasks:
             req_id = task.get("request_id")
@@ -2486,10 +2472,17 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             event = entry.get("event") if isinstance(entry, dict) else None
             if isinstance(event, dict):
                 events.append(event)
+                continue
+            if task.get("task_executor_address") == agent_address:
+                self.context.logger.warning(
+                    "no local predict_api_event for request_id=%s but this "
+                    "agent executed it — event dropped before POST",
+                    req_id,
+                )
             else:
                 self.context.logger.debug(
                     "no local predict_api_event for request_id=%s; "
-                    "assuming executed by another agent",
+                    "executed by another agent",
                     req_id,
                 )
         return events

--- a/packages/valory/skills/task_submission_abci/behaviours.py
+++ b/packages/valory/skills/task_submission_abci/behaviours.py
@@ -1946,15 +1946,19 @@ class TransactionPreparationBehaviour(
 class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
     """Runs once on-chain settlement of the round's tx confirms.
 
-    Reads ``synchronized_data.done_tasks`` for the just-settled cycle,
-    extracts every entry's pre-built ``predict_api_event`` payload (set on
-    the offchain path inside :py:meth:`task_execution.behaviours._build_predict_api_event`),
-    bundles them into one EIP-712-signed batch, and POSTs the batch to
-    the predict-api data lake at ``params.predict_api_events_url``. The predict-api
-    server is idempotent on ``request_id``, so multi-agent services don't
-    need a keeper pattern: each agent posts its own copy under its own
-    EOA signature; the per-EOA rate limiter on the server keeps the
-    co-owners in separate budgets.
+    Iterates ``synchronized_data.done_tasks`` for the just-settled cycle
+    and, for each entry, looks up its ``predict_api_event`` in
+    agent-local ``shared_state[PREDICT_API_EVENTS]`` (keyed by
+    ``str(request_id)``, populated on the offchain path inside
+    :py:meth:`task_execution.behaviours._build_predict_api_event`).
+    Each cache entry is a ``{event, written_at}`` wrapper so the sibling
+    TTL sweep in :py:meth:`TaskExecutionBaseBehaviour.remove_tasks_by_id`
+    can drop stale entries. Only the agent that executed a task
+    locally has its event; other agents skip and rely on the executor
+    to POST. The predict-api server is idempotent on ``request_id``,
+    so a single POST per task is sufficient — each agent posts its own
+    events under its own EOA signature; the per-EOA rate limiter on the
+    server keeps the co-owners in separate budgets.
 
     The behaviour is fail-soft by construction. A predict-api outage / 5xx
     / network drop does NOT stop the FSM — the settlement already landed
@@ -1998,9 +2002,11 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
 
             1. The feature flag is off (the default during Phase 1).
             2. The skill has no predict-api URL configured.
-            3. The round's done_tasks carry no offchain predict_api_event
-               entries and the pending-task sweep produced no
-               request-only events (a truly quiet round).
+            3. No local ``shared_state[PREDICT_API_EVENTS]`` entries
+               match the round's ``done_tasks`` (this agent didn't
+               execute any of them; other agents will POST their own)
+               and the pending-task sweep produced no request-only
+               events (a truly quiet round).
 
         :yield: AEA protocol messages (signing dialogue, HTTP request) via
             the underlying generator-based helpers; this method does not
@@ -2039,9 +2045,11 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
         request_only_events, swept_request_ids = self._sweep_pending_undelivered()
         if not delivered_events and not request_only_events:
             self.context.logger.debug(
-                "No predict_api_event entries in done_tasks and no swept "
-                "pending tasks; post-tx predict-api write is a no-op for "
-                "this round."
+                "No local predict_api_event entries in "
+                "shared_state[PREDICT_API_EVENTS] matched this round's "
+                "done_tasks (executed by other agents or absent) and no "
+                "swept pending tasks; post-tx predict-api write is a "
+                "no-op for this round."
             )
             return
 
@@ -2475,11 +2483,15 @@ class PostTxSettlementBehaviour(TaskExecutionBaseBehaviour):
             if req_id is None:
                 continue
             entry = events_by_id.get(str(req_id))
-            if not isinstance(entry, dict):
-                continue
-            event = entry.get("event")
+            event = entry.get("event") if isinstance(entry, dict) else None
             if isinstance(event, dict):
                 events.append(event)
+            else:
+                self.context.logger.debug(
+                    "no local predict_api_event for request_id=%s; "
+                    "assuming executed by another agent",
+                    req_id,
+                )
         return events
 
     def _sweep_pending_undelivered(

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiggh2tn6qmkqqnasssaswbvoj7lqmakmv2il3hfqctb2yrjlgg3ni
+  behaviours.py: bafybeig6qy6mnpqqspjpc3e2sgtspxquqnbuim2bab4stsrrpfxwg3nn24
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -19,11 +19,11 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeibfmlv6gfkwbb5opk4bqol746eyx7zmfg6ii7s743bdke3j2wmadq
+  tests/test_behaviours.py: bafybeiciexlaz2l45xygjwvjfg3esvkwc67dcd4ggq3632kxmjq7zrhyze
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeicsjleffdofd5hvejfbk4ebbw4aukx6xrq7yyrmc3veqntzdfa3r4
+  tests/test_onchain_write_path.py: bafybeidr7utdstzu7jy3il3rau5sjupexpvsaxatauqrcdih7y2t4et5j4
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeid3ncxzxxqkegh256cgz2vqsz3dfrq7cilvm6qhnfqx6a7waaim7m
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y
+- valory/task_execution:0.1.0:bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeig6qy6mnpqqspjpc3e2sgtspxquqnbuim2bab4stsrrpfxwg3nn24
+  behaviours.py: bafybeiavt6vtcnp4niepygykp65cmtkajyik25d6jpoqpzxhmh6sulxkdu
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -19,11 +19,11 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeiciexlaz2l45xygjwvjfg3esvkwc67dcd4ggq3632kxmjq7zrhyze
+  tests/test_behaviours.py: bafybeibiqwarazoph34kco4rysojb7cg22g5bgdpaeeq46y4zsc5772hje
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeidr7utdstzu7jy3il3rau5sjupexpvsaxatauqrcdih7y2t4et5j4
+  tests/test_onchain_write_path.py: bafybeigyl427hrcg76yvcqqj5leqxbpse5u33si7fycxrepdsn4rxu4pqy
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeid3ncxzxxqkegh256cgz2vqsz3dfrq7cilvm6qhnfqx6a7waaim7m
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeifribws23ccysd5rakrdjm5nqpxhy2i7xujuoudkvauyviein2ehq
+- valory/task_execution:0.1.0:bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeiavt6vtcnp4niepygykp65cmtkajyik25d6jpoqpzxhmh6sulxkdu
+  behaviours.py: bafybeiar54cdh357t246o3oodjhz565kfwvewkhuxkvjwtdr3xctcvri7q
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -19,11 +19,11 @@ fingerprint:
   tasks.py: bafybeicu5t5cvfhbndgpxbbtmp4vbmtyb6fba6vsnlewftvuderxp5lwcy
   tests/__init__.py: bafybeicra66y4yt2jcbj35imsfdq3c33xqnbvzfyzn5v3x533nuiidjhpu
   tests/conftest.py: bafybeihxi2j5lkdlq3rwydag2bzrv67exegutggxmgku3mq5pmrdth3pjq
-  tests/test_behaviours.py: bafybeibiqwarazoph34kco4rysojb7cg22g5bgdpaeeq46y4zsc5772hje
+  tests/test_behaviours.py: bafybeigcr5tbqfdism7ymfxbcl32wi65lecixwavk4n5f3bh5ytijwofuq
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeigyl427hrcg76yvcqqj5leqxbpse5u33si7fycxrepdsn4rxu4pqy
+  tests/test_onchain_write_path.py: bafybeih76ywmb4r4hmguuygtsc7wql3klr5bx777pzyni2wygggrt5rpsm
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeid3ncxzxxqkegh256cgz2vqsz3dfrq7cilvm6qhnfqx6a7waaim7m
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeiac2qswkfk4p43bjivswbbyutuysjojv3qqmcp6mj52vpkdhqax5q
+- valory/task_execution:0.1.0:bafybeiaf6p36ftx6tustdlkhygewmr2vfhfn7q6qr2jwzxgxgnh3ztjnue
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/skill.yaml
+++ b/packages/valory/skills/task_submission_abci/skill.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeiexga3pxus3tar5ouib4oq26jp3rcbujepj2scflvdu6holtfjmxi
-  behaviours.py: bafybeia32tc4sfqnjq33aj3jpla74tni3b7qiifw4k2yp747r2fxqrvl2u
+  behaviours.py: bafybeiggh2tn6qmkqqnasssaswbvoj7lqmakmv2il3hfqctb2yrjlgg3ni
   dialogues.py: bafybeicvqbqqviqhjkj4hfyqepanqzv6oa3nknpjaczs6yjpyxx5ilcbcq
   fsm_specification.yaml: bafybeicswghmdg7xsfhlgznsyr7zhydtunb2575qucxkxmeks6gcos3ut4
   handlers.py: bafybeieikfkrjtnlod35ldqf3veoe3oqha6fnnpqpkxwibi5jyobsnvd4a
@@ -23,7 +23,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeiajjre5yenpy4hdhrsil5vejufk4w444jzqnnxg56l2teegqcfovq
   tests/test_handlers.py: bafybeig74brnwb56rhreqmbkbmblpmbt2xlttavl4xt2anag5dwima7cpm
   tests/test_models.py: bafybeifm6u3a7wf5u4srn6wjnduqpynlker3t2xmtwlyyehivcbbtlalry
-  tests/test_onchain_write_path.py: bafybeiercklygtxznuqo47xevl2ox4yefbi35maom4iivlbkyiq2elut4y
+  tests/test_onchain_write_path.py: bafybeicsjleffdofd5hvejfbk4ebbw4aukx6xrq7yyrmc3veqntzdfa3r4
   tests/test_payloads.py: bafybeiasoekzsmrqp4m6w6c35inb54qhrwhe5zixsb7oxmkrnw54uynjpe
   tests/test_predict_api_events_client.py: bafybeicw2x4bblwf7biuww2b5ddyihpmdpsedcrimbvg4wcqzfyqspq6zm
   tests/test_rounds.py: bafybeid3ncxzxxqkegh256cgz2vqsz3dfrq7cilvm6qhnfqx6a7waaim7m
@@ -46,7 +46,7 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/task_execution:0.1.0:bafybeihgusy4jnab5zak6ouikblzmffbwttzeag6xkjpdzrbx4rtscibwu
+- valory/task_execution:0.1.0:bafybeihiubvh6luy35z4mlf2q552otltuoddmlza6gyrsbz5xwgr4qed6y
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -302,6 +302,26 @@ class TestRemoveTasksById:
         b.remove_tasks_by_id(["r-missing"])
         assert ctx.shared_state[DONE_TASKS] == tasks
 
+    def test_submitted_ids_pruned_from_predict_api_event_cache(self) -> None:
+        """Ids in ``submitted_ids`` are dropped from the event cache too.
+
+        Primary cleanup path on every settlement. Guards against a
+        regression that removes the pop loop but leaves the TTL
+        sweep, silently leaking one 30-60 KB event per delivered
+        task until the 24h TTL fires.
+        """
+        now = time.time()
+        ctx = _make_ctx(done_tasks=[{"request_id": "r1"}, {"request_id": "r2"}])
+        ctx.shared_state[PREDICT_API_EVENTS] = {
+            "r1": {"event": {"src": "off"}, "written_at": now},
+            "r2": {"event": {"src": "off"}, "written_at": now},
+        }
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id(["r1"])
+        surviving = ctx.shared_state[PREDICT_API_EVENTS]
+        assert "r1" not in surviving
+        assert "r2" in surviving
+
     def test_stale_predict_api_events_pruned_by_ttl(self) -> None:
         """Cache entries older than the TTL are dropped on the next prune.
 

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -33,10 +33,7 @@ from packages.valory.contracts.complementary_service_metadata.contract import (
 )
 from packages.valory.contracts.hash_checkpoint.contract import HashCheckpointContract
 from packages.valory.skills.abstract_round_abci.base import AbstractRound
-from packages.valory.skills.task_execution.behaviours import (
-    PREDICT_API_EVENTS,
-    PREDICT_API_EVENT_TTL_SECONDS,
-)
+from packages.valory.skills.task_execution.behaviours import PREDICT_API_EVENTS
 from packages.valory.skills.task_submission_abci.behaviours import (
     DONE_TASKS,
     DeliverBehaviour,
@@ -302,13 +299,15 @@ class TestRemoveTasksById:
         b.remove_tasks_by_id(["r-missing"])
         assert ctx.shared_state[DONE_TASKS] == tasks
 
-    def test_submitted_ids_pruned_from_predict_api_event_cache(self) -> None:
-        """Ids in ``submitted_ids`` are dropped from the event cache too.
+    def test_pre_settlement_remove_tasks_preserves_predict_api_cache(self) -> None:
+        """``remove_tasks_by_id`` does not prune ``PREDICT_API_EVENTS``.
 
-        Primary cleanup path on every settlement. Guards against a
-        regression that removes the pop loop but leaves the TTL
-        sweep, silently leaking one 30-60 KB event per delivered
-        task until the 24h TTL fires.
+        The event cache prune belongs to ``handle_submitted_tasks``
+        (post-settlement). The pre-settlement caller
+        ``TransactionPreparationBehaviour.get_payload_content`` also
+        calls ``remove_tasks_by_id`` on the simulation-skip path;
+        popping the cache there strands the event because the task
+        row is still present in the consensus ``done_tasks``.
         """
         now = time.time()
         ctx = _make_ctx(done_tasks=[{"request_id": "r1"}, {"request_id": "r2"}])
@@ -319,32 +318,8 @@ class TestRemoveTasksById:
         b = _DummyBase(name="b", skill_context=ctx)
         b.remove_tasks_by_id(["r1"])
         surviving = ctx.shared_state[PREDICT_API_EVENTS]
-        assert "r1" not in surviving
+        assert "r1" in surviving
         assert "r2" in surviving
-
-    def test_stale_predict_api_events_pruned_by_ttl(self) -> None:
-        """Cache entries older than the TTL are dropped on the next prune.
-
-        Safety net for tasks that finalize locally but never route
-        through a primary prune (e.g. FSM branch skips remove_tasks*).
-        Without this the cache leaks 30-60 KB per stranded task.
-        """
-        now = time.time()
-        ctx = _make_ctx(done_tasks=[{"request_id": "r1"}])
-        ctx.shared_state[PREDICT_API_EVENTS] = {
-            "fresh": {"event": {"src": "off"}, "written_at": now - 60},
-            "stale": {
-                "event": {"src": "off"},
-                "written_at": now - PREDICT_API_EVENT_TTL_SECONDS - 60,
-            },
-            "malformed": "not-a-dict",
-        }
-        b = _DummyBase(name="b", skill_context=ctx)
-        b.remove_tasks_by_id(["r1"])
-        surviving = ctx.shared_state[PREDICT_API_EVENTS]
-        assert "fresh" in surviving
-        assert "stale" not in surviving
-        assert "malformed" not in surviving
 
 
 class TestSetGauge:
@@ -861,6 +836,34 @@ class TestHandleSubmittedTasks:
         ):
             _run_gen(b.handle_submitted_tasks())
         assert b.context.shared_state[DONE_TASKS] == seeded
+
+    def test_submitted_ids_pruned_from_predict_api_event_cache(self) -> None:
+        """Post-settlement path drops submitted ids from ``PREDICT_API_EVENTS``.
+
+        Anchors the prune to ``handle_submitted_tasks`` (the only
+        caller that has proof ``PostTxSettlementBehaviour`` already
+        POSTed). Guards against a regression that removes the pop
+        loop and silently leaks one 30-60 KB event per delivered
+        task until the 24h TTL fires.
+        """
+        now = time.time()
+        task = {"request_id": "r1", "tool": "t1", "start_time": time.perf_counter()}
+        b = self._make_b()
+        b.context.shared_state[DONE_TASKS] = [task]
+        b.context.shared_state[PREDICT_API_EVENTS] = {
+            "r1": {"event": {"src": "off"}, "written_at": now},
+            "r2": {"event": {"src": "off"}, "written_at": now},
+        }
+        with (
+            patch.object(b, "check_last_tx_status", return_value=(True, "0xhash")),
+            self._patch_sd(b, submitted_ids=["r1"]),
+            patch.object(b, "_fetch_tx_block_number", side_effect=_gen_returning(None)),
+            patch.object(b, "observe_histogram"),
+        ):
+            _run_gen(b.handle_submitted_tasks())
+        surviving = b.context.shared_state[PREDICT_API_EVENTS]
+        assert "r1" not in surviving
+        assert "r2" in surviving
 
     def test_histogram_skipped_when_task_absent_from_shared_state(self) -> None:
         """Skip the histogram when the task is absent from shared state.

--- a/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_behaviours.py
@@ -33,6 +33,10 @@ from packages.valory.contracts.complementary_service_metadata.contract import (
 )
 from packages.valory.contracts.hash_checkpoint.contract import HashCheckpointContract
 from packages.valory.skills.abstract_round_abci.base import AbstractRound
+from packages.valory.skills.task_execution.behaviours import (
+    PREDICT_API_EVENTS,
+    PREDICT_API_EVENT_TTL_SECONDS,
+)
 from packages.valory.skills.task_submission_abci.behaviours import (
     DONE_TASKS,
     DeliverBehaviour,
@@ -297,6 +301,30 @@ class TestRemoveTasksById:
         b = _DummyBase(name="b", skill_context=ctx)
         b.remove_tasks_by_id(["r-missing"])
         assert ctx.shared_state[DONE_TASKS] == tasks
+
+    def test_stale_predict_api_events_pruned_by_ttl(self) -> None:
+        """Cache entries older than the TTL are dropped on the next prune.
+
+        Safety net for tasks that finalize locally but never route
+        through a primary prune (e.g. FSM branch skips remove_tasks*).
+        Without this the cache leaks 30-60 KB per stranded task.
+        """
+        now = time.time()
+        ctx = _make_ctx(done_tasks=[{"request_id": "r1"}])
+        ctx.shared_state[PREDICT_API_EVENTS] = {
+            "fresh": {"event": {"src": "off"}, "written_at": now - 60},
+            "stale": {
+                "event": {"src": "off"},
+                "written_at": now - PREDICT_API_EVENT_TTL_SECONDS - 60,
+            },
+            "malformed": "not-a-dict",
+        }
+        b = _DummyBase(name="b", skill_context=ctx)
+        b.remove_tasks_by_id(["r1"])
+        surviving = ctx.shared_state[PREDICT_API_EVENTS]
+        assert "fresh" in surviving
+        assert "stale" not in surviving
+        assert "malformed" not in surviving
 
 
 class TestSetGauge:

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -50,6 +50,7 @@ import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, cast
 
+from packages.valory.skills.task_execution.behaviours import PREDICT_API_EVENTS
 from packages.valory.skills.task_submission_abci.behaviours import (
     PENDING_TASKS,
     PostTxSettlementBehaviour,
@@ -500,45 +501,42 @@ def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
 # Extract -----------------------------------------------------------------
 
 
-def test_extract_offchain_events_includes_onchain_when_predict_api_event_present() -> (
-    None
-):
-    """The extractor keys on the presence of ``predict_api_event``, not on ``is_offchain``.
-
-    An on-chain marketplace task that carried a ``predict_api_event``
-    (built by the task_execution finalize step) gets included in the
-    batch.
-    """
-    # Build a self_ that exposes synchronized_data.done_tasks; the
-    # extract method is a property-only function.
+def test_extract_offchain_events_reads_from_shared_state_by_request_id() -> None:
+    """Events are looked up from agent-local ``shared_state[PREDICT_API_EVENTS]`` by request_id."""
     self_ = cast(
         PostTxSettlementBehaviour,
         SimpleNamespace(
             synchronized_data=SimpleNamespace(
                 done_tasks=[
-                    {"is_offchain": True, "predict_api_event": {"src": "off"}},
-                    {"is_offchain": False, "predict_api_event": {"src": "on"}},
-                    {"is_offchain": False, "predict_api_event": None},  # skipped
-                    {"is_offchain": True, "predict_api_event": "not-a-dict"},  # skipped
+                    {"request_id": "r-off"},
+                    {"request_id": "r-on"},
+                    {"request_id": "r-not-local"},
+                    {"request_id": None},
                 ]
-            )
+            ),
+            context=SimpleNamespace(
+                shared_state={
+                    PREDICT_API_EVENTS: {
+                        "r-off": {"src": "off"},
+                        "r-on": {"src": "on"},
+                    }
+                }
+            ),
         ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == [{"src": "off"}, {"src": "on"}]
 
 
-def test_extract_offchain_events_skips_tasks_without_predict_api_event() -> None:
-    """Done tasks without ``predict_api_event`` (e.g. on-chain non-marketplace legacy mech tasks) stay out of the batch."""
+def test_extract_offchain_events_returns_empty_when_shared_state_unset() -> None:
+    """No local events → empty batch (other agents post their own)."""
     self_ = cast(
         PostTxSettlementBehaviour,
         SimpleNamespace(
             synchronized_data=SimpleNamespace(
-                done_tasks=[
-                    {"is_offchain": True},  # no predict_api_event at all
-                    {"is_offchain": False},
-                ]
-            )
+                done_tasks=[{"request_id": "r-off"}, {"request_id": "r-on"}]
+            ),
+            context=SimpleNamespace(shared_state={}),
         ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
@@ -559,6 +557,7 @@ def _make_egress_self(
     done_tasks: List[Dict[str, Any]] | None = None,
     warnings_sink: List[str] | None = None,
     debug_sink: List[str] | None = None,
+    predict_api_events: Dict[str, Any] | None = None,
 ) -> PostTxSettlementBehaviour:
     """Build a minimum ``self`` for a ``_do_predict_api_write_best_effort`` call.
 
@@ -577,6 +576,8 @@ def _make_egress_self(
         by the divergence-warning check.
     :param warnings_sink: list to capture WARNING-level log lines.
     :param debug_sink: list to capture DEBUG-level log lines.
+    :param predict_api_events: seed ``shared_state[PREDICT_API_EVENTS]``
+        for the divergence-warning check.
     :return: a fixture typed as :class:`PostTxSettlementBehaviour` for
         the unbound-method call pattern used by every test in this
         module.
@@ -591,8 +592,11 @@ def _make_egress_self(
         error=lambda *a, **k: None,
         debug=lambda msg, *a, **k: debug_sink.append(msg),
     )
+    shared_state: Dict[str, Any] = {}
+    if predict_api_events is not None:
+        shared_state[PREDICT_API_EVENTS] = predict_api_events
     self_ = SimpleNamespace(
-        context=SimpleNamespace(shared_state={}, logger=logger),
+        context=SimpleNamespace(shared_state=shared_state, logger=logger),
         params=SimpleNamespace(
             use_offchain=use_offchain,
             predict_api_events_url=predict_api_events_url,
@@ -666,10 +670,7 @@ def test_egress_gate_off_with_diverged_ingress_emits_divergence_warning() -> Non
     warnings_sink: List[str] = []
     self_ = _make_egress_self(
         use_offchain=False,
-        done_tasks=[
-            {"is_offchain": True, "predict_api_event": {"src": "off"}},
-            {"is_offchain": False},
-        ],
+        predict_api_events={"r1": {"src": "off"}},
         warnings_sink=warnings_sink,
     )
     _drive_generator_once(

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -503,6 +503,7 @@ def test_request_only_event_falls_back_to_now_on_bad_timestamp() -> None:
 
 def test_extract_offchain_events_reads_from_shared_state_by_request_id() -> None:
     """Events are looked up from agent-local ``shared_state[PREDICT_API_EVENTS]`` by request_id."""
+    now = time.time()
     self_ = cast(
         PostTxSettlementBehaviour,
         SimpleNamespace(
@@ -517,8 +518,8 @@ def test_extract_offchain_events_reads_from_shared_state_by_request_id() -> None
             context=SimpleNamespace(
                 shared_state={
                     PREDICT_API_EVENTS: {
-                        "r-off": {"src": "off"},
-                        "r-on": {"src": "on"},
+                        "r-off": {"event": {"src": "off"}, "written_at": now},
+                        "r-on": {"event": {"src": "on"}, "written_at": now},
                     }
                 }
             ),

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -516,6 +516,7 @@ def test_extract_offchain_events_reads_from_shared_state_by_request_id() -> None
                 ]
             ),
             context=SimpleNamespace(
+                agent_address="0xSELF",
                 shared_state={
                     PREDICT_API_EVENTS: {
                         "r-off": {"event": {"src": "off"}, "written_at": now},
@@ -530,6 +531,33 @@ def test_extract_offchain_events_reads_from_shared_state_by_request_id() -> None
     assert events == [{"src": "off"}, {"src": "on"}]
 
 
+def test_extract_offchain_events_matches_int_request_id_against_str_key() -> None:
+    """``done_task["request_id"]`` is int in production; cache key is str.
+
+    Pins the ``str(req_id)`` coercion so a regression that drops the
+    cast fails here rather than silently in production (both sides use
+    literal str keys in every other test).
+    """
+    now = time.time()
+    self_ = cast(
+        PostTxSettlementBehaviour,
+        SimpleNamespace(
+            synchronized_data=SimpleNamespace(done_tasks=[{"request_id": 42}]),
+            context=SimpleNamespace(
+                agent_address="0xSELF",
+                shared_state={
+                    PREDICT_API_EVENTS: {
+                        "42": {"event": {"src": "off"}, "written_at": now},
+                    }
+                },
+                logger=_make_logger(),
+            ),
+        ),
+    )
+    events = PostTxSettlementBehaviour._extract_offchain_events(self_)
+    assert events == [{"src": "off"}]
+
+
 def test_extract_offchain_events_returns_empty_when_shared_state_unset() -> None:
     """No local events → empty batch (other agents post their own)."""
     self_ = cast(
@@ -538,37 +566,77 @@ def test_extract_offchain_events_returns_empty_when_shared_state_unset() -> None
             synchronized_data=SimpleNamespace(
                 done_tasks=[{"request_id": "r-off"}, {"request_id": "r-on"}]
             ),
-            context=SimpleNamespace(shared_state={}, logger=_make_logger()),
+            context=SimpleNamespace(
+                agent_address="0xSELF",
+                shared_state={},
+                logger=_make_logger(),
+            ),
         ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == []
 
 
-def test_extract_offchain_events_logs_debug_when_local_miss() -> None:
-    """Each done_task without a matching local event emits a DEBUG log.
-
-    Separates the "executed by another agent" case (normal) from a
-    silent drop caused by an ingress-side bug in ``_finalize_done_task``.
-    Without the log both look identical in production.
-    """
+def test_extract_offchain_events_logs_debug_when_other_agent_executed() -> None:
+    """A missing local event for a task another agent executed → DEBUG (normal)."""
     debug_sink: List[str] = []
+    warn_sink: List[str] = []
     logger = SimpleNamespace(
         info=lambda *a, **k: None,
-        warning=lambda *a, **k: None,
+        warning=lambda msg, *a, **k: warn_sink.append(msg % a if a else msg),
         error=lambda *a, **k: None,
         debug=lambda msg, *a, **k: debug_sink.append(msg % a if a else msg),
     )
     self_ = cast(
         PostTxSettlementBehaviour,
         SimpleNamespace(
-            synchronized_data=SimpleNamespace(done_tasks=[{"request_id": "r-missing"}]),
-            context=SimpleNamespace(shared_state={}, logger=logger),
+            synchronized_data=SimpleNamespace(
+                done_tasks=[
+                    {"request_id": "r-other", "task_executor_address": "0xOTHER"}
+                ]
+            ),
+            context=SimpleNamespace(
+                agent_address="0xSELF", shared_state={}, logger=logger
+            ),
         ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == []
-    assert any("r-missing" in line for line in debug_sink), debug_sink
+    assert any("r-other" in line for line in debug_sink), debug_sink
+    assert warn_sink == []
+
+
+def test_extract_offchain_events_logs_warning_when_self_executor_has_no_cache_entry() -> (
+    None
+):
+    """A missing local event for a task THIS agent executed → WARNING (bug).
+
+    Separates the "another agent posts it" normal case from a real
+    ingress-side drop in ``_finalize_done_task``.
+    """
+    debug_sink: List[str] = []
+    warn_sink: List[str] = []
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda msg, *a, **k: warn_sink.append(msg % a if a else msg),
+        error=lambda *a, **k: None,
+        debug=lambda msg, *a, **k: debug_sink.append(msg % a if a else msg),
+    )
+    self_ = cast(
+        PostTxSettlementBehaviour,
+        SimpleNamespace(
+            synchronized_data=SimpleNamespace(
+                done_tasks=[{"request_id": "r-self", "task_executor_address": "0xSELF"}]
+            ),
+            context=SimpleNamespace(
+                agent_address="0xSELF", shared_state={}, logger=logger
+            ),
+        ),
+    )
+    events = PostTxSettlementBehaviour._extract_offchain_events(self_)
+    assert events == []
+    assert any("r-self" in line for line in warn_sink), warn_sink
+    assert debug_sink == []
 
 
 # ---------------------------------------------------------------------------
@@ -698,7 +766,9 @@ def test_egress_gate_off_with_diverged_ingress_emits_divergence_warning() -> Non
     warnings_sink: List[str] = []
     self_ = _make_egress_self(
         use_offchain=False,
-        predict_api_events={"r1": {"src": "off"}},
+        predict_api_events={
+            "r1": {"event": {"src": "off"}, "written_at": time.time()},
+        },
         warnings_sink=warnings_sink,
     )
     _drive_generator_once(
@@ -712,7 +782,7 @@ def test_egress_gate_off_with_diverged_ingress_emits_divergence_warning() -> Non
 
 
 def test_egress_gate_off_with_no_events_stays_silent() -> None:
-    """``use_offchain=False`` and empty ``done_tasks``: no warning fires.
+    """``use_offchain=False`` and empty ``shared_state[PREDICT_API_EVENTS]``: no warning.
 
     Guards against the divergence warning becoming its own boot-noise
     source on production mechs that ship dark by default (both flags

--- a/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
+++ b/packages/valory/skills/task_submission_abci/tests/test_onchain_write_path.py
@@ -521,7 +521,8 @@ def test_extract_offchain_events_reads_from_shared_state_by_request_id() -> None
                         "r-off": {"event": {"src": "off"}, "written_at": now},
                         "r-on": {"event": {"src": "on"}, "written_at": now},
                     }
-                }
+                },
+                logger=_make_logger(),
             ),
         ),
     )
@@ -537,11 +538,37 @@ def test_extract_offchain_events_returns_empty_when_shared_state_unset() -> None
             synchronized_data=SimpleNamespace(
                 done_tasks=[{"request_id": "r-off"}, {"request_id": "r-on"}]
             ),
-            context=SimpleNamespace(shared_state={}),
+            context=SimpleNamespace(shared_state={}, logger=_make_logger()),
         ),
     )
     events = PostTxSettlementBehaviour._extract_offchain_events(self_)
     assert events == []
+
+
+def test_extract_offchain_events_logs_debug_when_local_miss() -> None:
+    """Each done_task without a matching local event emits a DEBUG log.
+
+    Separates the "executed by another agent" case (normal) from a
+    silent drop caused by an ingress-side bug in ``_finalize_done_task``.
+    Without the log both look identical in production.
+    """
+    debug_sink: List[str] = []
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda msg, *a, **k: debug_sink.append(msg % a if a else msg),
+    )
+    self_ = cast(
+        PostTxSettlementBehaviour,
+        SimpleNamespace(
+            synchronized_data=SimpleNamespace(done_tasks=[{"request_id": "r-missing"}]),
+            context=SimpleNamespace(shared_state={}, logger=logger),
+        ),
+    )
+    events = PostTxSettlementBehaviour._extract_offchain_events(self_)
+    assert events == []
+    assert any("r-missing" in line for line in debug_sink), debug_sink
 
 
 # ---------------------------------------------------------------------------
@@ -657,14 +684,14 @@ def test_egress_gate_off_short_circuits_without_http_call() -> None:
 
 
 def test_egress_gate_off_with_diverged_ingress_emits_divergence_warning() -> None:
-    """``use_offchain=False`` but ``done_tasks`` carries predict_api_events: WARN and drop.
+    """``use_offchain=False`` but ``shared_state[PREDICT_API_EVENTS]`` populated: WARN and drop.
 
     The two ``use_offchain`` copies (on ``task_execution`` and
     ``task_submission_abci``) are independent env-overridable params —
     an operator can flip one but forget the other. If the ingress side
-    is on but this side is off, ``done_tasks`` will already carry
-    ``predict_api_event`` entries at consensus-replication cost, and
-    dropping them silently (as the pre-fix shape did) is invisible to
+    is on but this side is off, agent-local
+    ``shared_state[PREDICT_API_EVENTS]`` will already carry entries
+    from finalized tasks, and dropping them silently is invisible to
     alerting. The safety net here fires a WARNING so the misconfig
     surfaces in ops logs.
     """


### PR DESCRIPTION
## Summary

Stashes the per-task predict-api event in agent-local `shared_state[PREDICT_API_EVENTS]` keyed by `str(request_id)` instead of embedding it in the `done_task` dict. The consensus-replicated `done_task` now carries only its small fields (request_id, tool, task_result, is_offchain, etc); the ~30-60 KB `raw_content` payload no longer rides Tendermint replication.

## Why

Follow-up to [mech#482](https://github.com/valory-xyz/mech/pull/482) which reduced but did not bound the serialized `done_tasks`. A batch of 15-20 tasks each carrying a 30-60 KB `predict_api_event` still pushed one period's `done_tasks` past `MAX_READ_IN_BYTES = 1 MiB` and rejected the next `RegistrationPayload`. Reproduced on `single_mech_mm_predict_2359` earlier today: 3 crash-loop restarts in 6 minutes with individual done_tasks measured at 17 KB / 28 KB / 57 KB.

Moving the payload out of consensus caps the consensus payload size regardless of per-event size.

## Changes

- `task_execution._finalize_done_task`: writes the event to `shared_state[PREDICT_API_EVENTS][str(req_id)] = {"event": ..., "written_at": time.time()}` instead of `done_task["predict_api_event"] = ...`. On every write, runs a TTL sweep that drops entries older than `PREDICT_API_EVENT_TTL_SECONDS` (24h) and any malformed entries (non-dict, or non-numeric `written_at`). This bounds cache growth even for an agent whose settlements keep failing and never trigger the primary prune.
- `task_execution.ContractHandler.setup`: initialises `shared_state[PREDICT_API_EVENTS] = {}`.
- `task_submission_abci.PostTxSettlementBehaviour._extract_offchain_events`: iterates `done_tasks` and looks each event up in local `shared_state` by request_id. A miss on a task another agent executed logs DEBUG (normal, that agent posts it). A miss on a task **this** agent executed (identified by `task_executor_address == self.context.agent_address`) logs WARNING, since it's an ingress-side drop.
- `task_submission_abci.TaskPoolingBehaviour.handle_submitted_tasks`: after `remove_tasks_by_id(submitted_ids)`, drops the submitted request_ids from `shared_state[PREDICT_API_EVENTS]`. The prune is intentionally NOT inside `remove_tasks_by_id`, since that method is also called pre-settlement from `TransactionPreparationBehaviour.get_payload_content` on the simulation-skip path.
- Divergence-warning check (`use_offchain=False` on the egress side with ingress producing events) now watches `shared_state[PREDICT_API_EVENTS]` instead of scanning `done_tasks`.

## Intentional semantic change

Pre-PR, a deliver-tx simulation failure would still POST the event (the event rode consensus and `remove_tasks` only touched `shared_state[DONE_TASKS]`). Post-PR, a simulation-skipped task never gets a delivered event POSTed. This is the intended behaviour: no delivered event for a task that was never delivered, and `_sweep_pending_undelivered` still emits a request-only event later. Pinned by `test_pre_settlement_remove_tasks_preserves_predict_api_cache`.

## Multi-agent + durability tradeoff

Pre-PR every agent had every event in consensus (durable at TaskPoolingRound quorum, replayable from Tendermint blockchain) and every agent POST'd; predict-api dedups on `request_id`. Post-PR only the executing agent has the event locally, from `_finalize_done_task` completion through the entire settlement pipeline (randomness, select-keeper, collect-signature, finalize, validate, post-settlement). If that agent restarts anywhere in that window the row is lost, and there is no cross-agent redundancy on the POST — this is a materially longer and less-redundant window than the pre-PR one.

For Phase 1 dark rollout the subsystem is explicitly fail-soft; the kv_store replay buffer is a known follow-up that will close this window.

## Test plan

- [x] Unit tests pass locally (895 tests across `task_execution` + `task_submission_abci`).
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e darglint -e mypy` clean.
- [x] `tomte tox -e check-abci-docstrings -e check-abciapp-specs` OK.
- [x] `autonomy packages lock --check` OK.
- [ ] CI: full pipeline.
- [ ] Post-merge: canary on `single_mech_mm_predict_2359` (currently crash-looping on this exact edge case); confirm RegistrationPayload stays under 1 MiB across many settlement cycles and no `1048576` errors.